### PR TITLE
Add repository-owned GitHub wiki source set

### DIFF
--- a/.github/agents/copilot-instructions.md
+++ b/.github/agents/copilot-instructions.md
@@ -26,6 +26,8 @@ Auto-generated from all feature plans. Last updated: 2026-03-03
 - File-backed package/store state persisted via `IStoreRegistry` at `.nuplane/store-state.json` plus immutable package folders/current pointers; loading read state is current-process projection data owned by the optional loading module (014-query-package-catalog)
 - C# with SDK-style .NET libraries targeting `net8.0;net9.0;net10.0`; tests target `net10.0` + `Microsoft.Extensions.DependencyInjection`, `Microsoft.Extensions.Hosting`, `Microsoft.Extensions.Options`, `Microsoft.Extensions.Logging`, ASP.NET Core Minimal APIs in `Nuplane.Admin.Api` and `Nuplane.Loading.Api`, xUnit, NSubstitute (015-simplify-loading-api)
 - File-backed runtime/store state via `IStoreRegistry` and `.nuplane/store-state.json` for durable active inventory; load-state and runtime assembly/type access remain current-process projections over the active se (015-simplify-loading-api)
+- Markdown documentation authored in a repository whose product code targets `.NET 8/9/10` + Existing `README.md`, `docs/roadmap.md`, `docs/coding-conventions.md`, `samples/Nuplane.Sample.AspNetCore`, accepted feature specs and quickstarts under `specs/`, GitHub wiki Markdown/linking conventions (016-nuplane-github-wiki)
+- Version-controlled Markdown files in the repository (planned under `docs/wiki/`); no runtime data store changes (016-nuplane-github-wiki)
 
 - C# on .NET 8 (LTS) + `NuGet.Protocol`/NuGet Client SDK, `Microsoft.Extensions.Hosting`, `Microsoft.Extensions.DependencyInjection`, `Microsoft.Extensions.Options`, `Microsoft.Extensions.Logging`, `System.Diagnostics.Metrics` (001-phase1-runtime-baseline)
 
@@ -45,9 +47,9 @@ test/
 C# on .NET 8 (LTS): Follow standard conventions
 
 ## Recent Changes
+- 016-nuplane-github-wiki: Added Markdown documentation authored in a repository whose product code targets `.NET 8/9/10` + Existing `README.md`, `docs/roadmap.md`, `docs/coding-conventions.md`, `samples/Nuplane.Sample.AspNetCore`, accepted feature specs and quickstarts under `specs/`, GitHub wiki Markdown/linking conventions
 - 015-simplify-loading-api: Added C# with SDK-style .NET libraries targeting `net8.0;net9.0;net10.0`; tests target `net10.0` + `Microsoft.Extensions.DependencyInjection`, `Microsoft.Extensions.Hosting`, `Microsoft.Extensions.Options`, `Microsoft.Extensions.Logging`, ASP.NET Core Minimal APIs in `Nuplane.Admin.Api` and `Nuplane.Loading.Api`, xUnit, NSubstitute
 - 014-query-package-catalog: Added C# with SDK-style .NET libraries targeting `net8.0;net9.0;net10.0`; tests target `net10.0` + `Microsoft.Extensions.DependencyInjection`, `Microsoft.Extensions.Hosting`, `Microsoft.Extensions.Options`, `Microsoft.Extensions.Configuration.Binder`, `Microsoft.Extensions.Logging`, ASP.NET Core Minimal APIs in `Nuplane.Admin.Api`, xUnit, NSubstitute
-- 013-module-pattern-expansion: Added C# with SDK-style .NET libraries targeting `net8.0;net9.0;net10.0`; tests target `net10.0` + `Microsoft.Extensions.DependencyInjection`, `Microsoft.Extensions.Hosting`, `Microsoft.Extensions.Options`, `Microsoft.Extensions.Configuration.Binder`, `Microsoft.Extensions.Logging`, xUnit, NSubstitute
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/README.md
+++ b/README.md
@@ -9,6 +9,19 @@ It enables .NET applications to resolve, synchronize, and manage NuGet packages 
 Nuplane does **not** define a plugin model.  
 It provides infrastructure for package reconciliation — nothing more, nothing less.
 
+## 📖 Start With The Wiki
+
+If you are evaluating or onboarding to Nuplane, start with the repository-owned wiki under [`docs/wiki/`](docs/wiki/):
+
+- [`Home`](docs/wiki/Home.md) — product framing and audience routes
+- [`Overview`](docs/wiki/Overview.md) — why Nuplane exists, what it does, and what it does not do
+- [`Getting Started`](docs/wiki/Getting-Started.md) — recommended first-use path
+- [`Usage Guide`](docs/wiki/Usage-Guide.md) — core-runtime vs optional-loading usage guidance
+- [`Architecture Guide`](docs/wiki/Architecture-Guide.md) — module map and repository-to-concept view
+- [`Concepts and Glossary`](docs/wiki/Concepts-and-Glossary.md) — normalized terminology
+
+The wiki follows a **hybrid-hub** model: it is self-sufficient for evaluation and onboarding, while deeper validation details, roadmap history, sample mechanics, and other fast-moving reference material remain repository-owned.
+
 ---
 
 ## ✨ What Nuplane Does

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -15,6 +15,16 @@ It does **not** define a plugin programming model.
 It does **not** impose activation semantics.
 It is infrastructure only.
 
+## Contributor Wiki Orientation
+
+For contributor-facing architecture orientation, start with the repository-owned wiki under [`docs/wiki/`](wiki/):
+
+- [`Architecture Guide`](wiki/Architecture-Guide.md) for the module map, control loop, and repository-to-concept walkthrough
+- [`Concepts and Glossary`](wiki/Concepts-and-Glossary.md) for normalized terminology used across the wiki, README, roadmap, and accepted specs
+- [`Source References`](wiki/_Source-References.md) for the wiki-vs-repository ownership matrix when deciding where future documentation updates belong
+
+Treat this roadmap as the deeper source for phase scope, staged evolution, and implementation-history detail. The wiki summarizes those areas, but it does not replace this document.
+
 ## Phase 1 Implementation Status (2026-03-02)
 
 Current repository behavior aligns with the Phase 1 runtime baseline:

--- a/docs/wiki/Architecture-Guide.md
+++ b/docs/wiki/Architecture-Guide.md
@@ -1,0 +1,106 @@
+# Architecture Guide
+
+## Primary purpose
+
+This page explains how Nuplane works structurally: the control loop, the major modules, the ownership split between core and optional modules, and how repository areas map to user-facing concepts.
+
+## High-level control loop
+
+Nuplane’s architecture centers on a deterministic control loop:
+
+1. collect desired package state from configured sources;
+2. compare desired state with the current active state;
+3. resolve package versions and compute a diff;
+4. apply transactional per-package changes to the deterministic store;
+5. expose authoritative package and operational read surfaces;
+6. emit change signals for the host to react to.
+
+- **Applicability:** `Core`
+
+## Module map
+
+| Repository area | Product concept | Applicability | Responsibility |
+|-----------------|-----------------|---------------|----------------|
+| `src/Nuplane/` | Core composition and builder surface | `Core` | Wires the runtime story together and exposes host-facing setup entry points |
+| `src/Nuplane.Runtime/` | Reconciliation engine | `Core` | Owns desired-vs-actual reconciliation and runtime orchestration |
+| `src/Nuplane.Store/` | Deterministic package store | `Core` | Owns transactional storage, activation pointers, and LKG safety |
+| `src/Nuplane.NuGet/` | Feed resolution and acquisition | `Core` | Integrates with NuGet feeds and package acquisition |
+| `src/Nuplane.Abstractions/` | Shared contracts | `Core` | Keeps common interfaces and models lightweight |
+| `src/Nuplane.Sources.Directory/` | Directory-backed desired source | `Core` | Adds local `.nupkg` directory feed behavior |
+| `src/Nuplane.Admin/` + `src/Nuplane.Admin.Api/` | Admin and HTTP read surfaces | `Core` | Exposes management and read routes for package and operational state |
+| `src/Nuplane.Loading/` + `src/Nuplane.Loading.Api/` | Optional runtime loading | `Optional Module` | Adds load-state and assembly-loading behavior when the host opts in |
+| `src/Nuplane.Loading.Hosting/` | Loading module composition helpers | `Optional Module` | Adds module-owned builder integration for loading scenarios |
+
+## Ownership boundaries
+
+### Core behavior
+
+- **Applicability:** `Core`
+- Runtime package reconciliation, deterministic storage, transactional safety, query-first state access, and observability belong to the main Nuplane product story.
+
+### Optional module behavior
+
+- **Applicability:** `Optional Module`
+- Assembly loading, load-state-specific reads, and loading-specific composition stay outside the baseline runtime story until a host explicitly installs them.
+
+### Roadmap-stage context
+
+- **Applicability:** `Phase-Based`
+- Phase 2 governance and reproducibility work, Phase 3 optional loading, and later convergence/rollout work live in the roadmap/spec system as staged context. The wiki summarizes their role but does not replace [`docs/roadmap.md`](../roadmap.md).
+
+## Repository-to-concept mapping
+
+| Reader concept | Repository anchor |
+|----------------|-------------------|
+| Host-neutral runtime control plane | `README.md`, `src/Nuplane.Runtime/` |
+| Deterministic store and LKG semantics | `README.md`, `src/Nuplane.Store/` |
+| Feed-backed desired state | `README.md`, `src/Nuplane.NuGet/`, `src/Nuplane.Sources.Directory/` |
+| Query-first package and operational reads | `README.md`, `src/Nuplane.Admin/`, `src/Nuplane.Admin.Api/` |
+| Optional load-state and assembly access | `README.md`, `src/Nuplane.Loading/`, `src/Nuplane.Loading.Api/` |
+| Staged feature evolution | `docs/roadmap.md`, accepted specs under `specs/` |
+
+## Architecture notes that matter to contributors
+
+### Query surfaces vs observer callbacks
+
+- **Applicability:** `Recently Changed`
+- The repository currently emphasizes query-first reads for authoritative state, with observers acting as supplemental invalidation or logging signals.
+- That matters when you are reading sample code or adding documentation, because the product story should not drift back toward “event history as the canonical state model.”
+
+### Module-owned registration pattern
+
+- **Applicability:** `Recently Changed`
+- Optional modules now own their own registration helpers and builder integration packages.
+- That keeps the core package from absorbing module-specific implementation details.
+
+### Phase 4 convergence and rollout work
+
+- **Applicability:** `Evolving`
+- The roadmap documents broader convergence and administrative patterns that are real planning surfaces, but they are not the universal baseline for every current host.
+
+## What this guide intentionally does not replace
+
+This guide points to repository-owned sources for:
+
+- exact admin route shape and HTTP contracts;
+- full phase-history detail and acceptance matrices;
+- maintainer-only operational procedures;
+- low-level implementation mechanics that are better learned in code.
+
+## Related pages
+
+- [Overview](Overview.md)
+- [Usage Guide](Usage-Guide.md)
+- [Concepts and Glossary](Concepts-and-Glossary.md)
+- [Source References](_Source-References.md)
+
+## Canonical repository anchors
+
+- [`README.md`](../../README.md)
+- [`docs/roadmap.md`](../roadmap.md)
+- [`src/Nuplane/`](../../src/Nuplane/)
+- [`src/Nuplane.Runtime/`](../../src/Nuplane.Runtime/)
+- [`src/Nuplane.Store/`](../../src/Nuplane.Store/)
+- [`src/Nuplane.Loading/`](../../src/Nuplane.Loading/)
+- [`src/Nuplane.Admin.Api/`](../../src/Nuplane.Admin.Api/)
+

--- a/docs/wiki/Concepts-and-Glossary.md
+++ b/docs/wiki/Concepts-and-Glossary.md
@@ -1,0 +1,120 @@
+# Concepts and Glossary
+
+Use this page as the normalized vocabulary for the Nuplane wiki.
+
+## Core runtime terms
+
+### Desired state
+
+The package set Nuplane should make active.
+
+- Applied in: [Overview](Overview.md), [Getting Started](Getting-Started.md), [Architecture Guide](Architecture-Guide.md)
+- Canonical anchor: `README.md`
+
+### Actual state
+
+The package set currently active in the local store and available through Nuplane’s authoritative read surfaces.
+
+- Applied in: [Getting Started](Getting-Started.md), [Architecture Guide](Architecture-Guide.md)
+- Canonical anchor: `README.md`
+
+### Reconciliation
+
+A control-loop cycle that reads desired state, resolves packages, computes the diff against current state, applies transactional changes, and emits observable outcomes.
+
+- Applied in: [Overview](Overview.md), [Usage Guide](Usage-Guide.md), [Architecture Guide](Architecture-Guide.md)
+- Canonical anchor: `README.md`
+
+### Feed
+
+A named package source used for resolution. In current repository behavior, a feed can be a NuGet v3 service index or a local directory containing `.nupkg` files.
+
+- Applied in: [Getting Started](Getting-Started.md), [Usage Guide](Usage-Guide.md)
+- Canonical anchor: `README.md`
+
+### Package store
+
+Nuplane’s deterministic on-disk storage area for packages, current-package pointers, staging work, and persisted state.
+
+- Applied in: [Overview](Overview.md), [Architecture Guide](Architecture-Guide.md)
+- Canonical anchors: `README.md`, `src/Nuplane.Store/`
+
+### Active package
+
+The currently active resolved package version that Nuplane treats as live for a package identifier.
+
+- Applied in: [Usage Guide](Usage-Guide.md), [Architecture Guide](Architecture-Guide.md)
+- Canonical anchors: `README.md`, `src/Nuplane/Operational/ActivePackageCatalog.cs`
+
+### Last-known-good (LKG)
+
+The most recent successfully applied package version that remains available as the safe active fallback when a newer change fails.
+
+- Applied in: [Overview](Overview.md), [Architecture Guide](Architecture-Guide.md)
+- Canonical anchor: `README.md`
+
+### Observer
+
+A host-owned callback surface for invalidation or reaction signals. Observers are useful, but they are not the authoritative source of state.
+
+- Applied in: [Getting Started](Getting-Started.md), [Usage Guide](Usage-Guide.md)
+- Canonical anchors: `README.md`, `samples/Nuplane.Sample.AspNetCore/PackageChangeObserver.cs`
+
+### Operational state
+
+A health- and diagnostics-oriented read surface that stays distinct from the package inventory itself.
+
+- Applied in: [Usage Guide](Usage-Guide.md), [Architecture Guide](Architecture-Guide.md)
+- Canonical anchors: `README.md`, `docs/roadmap.md`
+
+## Optional module terms
+
+### Optional loading
+
+An opt-in subsystem that loads resolved packages into isolated assembly load contexts and exposes load-state-aware surfaces.
+
+- **Applicability:** `Optional Module`
+- Applied in: [Overview](Overview.md), [Getting Started](Getting-Started.md), [Usage Guide](Usage-Guide.md), [Architecture Guide](Architecture-Guide.md)
+- Canonical anchors: `README.md`, `src/Nuplane.Loading/`, `src/Nuplane.Loading.Api/`
+
+### Load-state catalog
+
+The loading-owned authoritative view of current-process loading status when the optional loading module is installed.
+
+- **Applicability:** `Optional Module`
+- Applied in: [Usage Guide](Usage-Guide.md), [Architecture Guide](Architecture-Guide.md)
+- Canonical anchors: `README.md`, `src/Nuplane.Loading.Abstractions/IPackageLoadStateCatalog.cs`
+
+### Package assembly catalog
+
+A higher-level loading-aware surface for hosts that want the currently active loaded assemblies for a package or package set.
+
+- **Applicability:** `Optional Module`
+- Applied in: [Usage Guide](Usage-Guide.md)
+- Canonical anchors: `README.md`, `src/Nuplane.Loading.Abstractions/IPackageAssemblyCatalog.cs`
+
+## Documentation-governance terms
+
+### Hybrid hub
+
+A documentation model where the wiki owns orientation and onboarding but intentionally links to repository docs, samples, and specs for deeper or more volatile detail.
+
+- Applied in: [Home](Home.md), [Architecture Guide](Architecture-Guide.md), [Source References](_Source-References.md)
+- Canonical anchor: `specs/016-nuplane-github-wiki/spec.md`
+
+### Applicability label
+
+A visible label that tells the reader whether a capability is `Core`, `Optional Module`, `Phase-Based`, `Recently Changed`, or `Evolving`.
+
+- Applied in: [_Footer](_Footer.md), [Overview](Overview.md), [Usage Guide](Usage-Guide.md), [Architecture Guide](Architecture-Guide.md)
+- Canonical anchor: `specs/016-nuplane-github-wiki/contracts/wiki-governance-and-labeling-contract.md`
+
+## Related pages
+
+- [Home](Home.md)
+- [Overview](Overview.md)
+- [Getting Started](Getting-Started.md)
+- [Usage Guide](Usage-Guide.md)
+- [Architecture Guide](Architecture-Guide.md)
+- [Source References](_Source-References.md)
+

--- a/docs/wiki/Getting-Started.md
+++ b/docs/wiki/Getting-Started.md
@@ -1,0 +1,90 @@
+# Getting Started
+
+## Primary purpose
+
+This page gives you the **recommended first-use path** for Nuplane without duplicating command sequences that already have a better repository home.
+
+## Recommended reading and usage order
+
+1. [Overview](Overview.md) — understand why Nuplane exists and where its boundaries are.
+2. Read this page — learn the minimum mental model and choose a starting scenario.
+3. [Usage Guide](Usage-Guide.md) — pick the adoption path that matches your host.
+4. Use the sample host and validation quickstart for hands-on confirmation.
+
+## Minimum mental model
+
+Before you open the sample, keep these ideas in mind:
+
+- **Desired state** is the package set Nuplane should make active.
+- **Actual state** is the package set currently active in the local store.
+- **Reconciliation** compares those sets and applies safe per-package changes.
+- **Query-first integration** means your host should read authoritative package or load-state surfaces instead of reconstructing state from observer history.
+- **Optional loading** is a module you add only when your host wants Nuplane-managed runtime loading.
+
+## Recommended first-use path
+
+### Path A: Evaluate the core runtime story first
+
+- **Applicability:** `Core`
+- Start with the [`Nuplane` setup section](../../README.md).
+- Focus on feeds, polling, state persistence, and the idea that the host reacts to package changes.
+- Treat query surfaces as the authoritative read path.
+
+### Path B: Validate the sample-backed flow
+
+- **Applicability:** `Core`
+- Use [`samples/Nuplane.Sample.AspNetCore/Program.cs`](../../samples/Nuplane.Sample.AspNetCore/Program.cs) and [`samples/Nuplane.Sample.AspNetCore/appsettings.json`](../../samples/Nuplane.Sample.AspNetCore/appsettings.json) to see the recommended sample composition.
+- Then use [`specs/014-query-package-catalog/quickstart.md`](../../specs/014-query-package-catalog/quickstart.md) for the maintained end-to-end validation commands.
+
+### Path C: Add runtime loading only if your host needs it
+
+- **Applicability:** `Optional Module`
+- Add the loading module when you need package assemblies loaded into the current process.
+- Keep in mind that Nuplane still does not define plugin semantics or host activation policy.
+
+## Copyable onboarding commands
+
+These commands are intentionally small. They point you to the canonical sample and quickstart instead of duplicating the full maintained walkthrough.
+
+```bash
+dotnet run --project samples/Nuplane.Sample.AspNetCore/Nuplane.Sample.AspNetCore.csproj
+dotnet pack samples/Nuplane.Sample.Plugin/Nuplane.Sample.Plugin.csproj -c Debug
+```
+
+After that, continue with the maintained validation flow in [`specs/014-query-package-catalog/quickstart.md`](../../specs/014-query-package-catalog/quickstart.md).
+
+## How the sample teaches the model
+
+The sample host shows the intended split of responsibilities:
+
+- configuration describes Nuplane infrastructure and feed setup;
+- the host composes observers and admin/query surfaces in code;
+- the sample steers readers toward authoritative catalog reads instead of observer replay;
+- the optional loading route is clearly separate from metadata-only package-state access.
+
+## Where to go next
+
+| If you want to... | Continue to | Why |
+|-------------------|-------------|-----|
+| Choose between core-runtime and loading-enabled usage | [Usage Guide](Usage-Guide.md) | It separates baseline and optional scenarios |
+| Understand the sample route composition | [Usage Guide](Usage-Guide.md) | It summarizes configuration-driven and code-driven adoption |
+| Validate the end-to-end sample | [`specs/014-query-package-catalog/quickstart.md`](../../specs/014-query-package-catalog/quickstart.md) | It owns the deeper command and evidence flow |
+| Learn the vocabulary before continuing | [Concepts and Glossary](Concepts-and-Glossary.md) | It normalizes the terms used across the wiki |
+
+## Repository-owned detail
+
+The following material intentionally stays repository-owned rather than being duplicated here:
+
+- full test and validation command sets;
+- exact sample route payload expectations;
+- phase-by-phase evolution detail.
+
+See [Source References](_Source-References.md) for the ownership map.
+
+## Canonical repository anchors
+
+- [`README.md`](../../README.md)
+- [`samples/Nuplane.Sample.AspNetCore/Program.cs`](../../samples/Nuplane.Sample.AspNetCore/Program.cs)
+- [`samples/Nuplane.Sample.AspNetCore/appsettings.json`](../../samples/Nuplane.Sample.AspNetCore/appsettings.json)
+- [`specs/014-query-package-catalog/quickstart.md`](../../specs/014-query-package-catalog/quickstart.md)
+

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -1,0 +1,87 @@
+# Home
+
+Nuplane is a **host-neutral runtime control plane for NuGet packages**. It resolves packages, reconciles desired and actual state, maintains a deterministic local store, and emits change signals that your host can react to.
+
+## Why start here?
+
+This wiki is a **hybrid hub**:
+
+- it is self-sufficient for evaluation and first-use learning;
+- it treats current repository behavior as the canonical product story;
+- it links to repository-owned samples, roadmap notes, and accepted specs when deeper validation or fast-moving detail would otherwise create drift.
+
+## What Nuplane is for
+
+Nuplane exists for hosts that want runtime package reconciliation without turning package management into a plugin framework.
+
+- **Applicability:** `Core`
+- Use it when you need deterministic package resolution, transactional updates, runtime package-state visibility, and host-controlled reactions.
+- Do **not** expect it to define plugin entry points, own your dependency-injection container, or dictate activation semantics.
+
+## Audience routes
+
+### Evaluator route
+
+Start here if you are deciding whether Nuplane is relevant.
+
+1. [Overview](Overview.md) — why Nuplane exists, what it does, and what it does not do
+2. [Getting Started](Getting-Started.md) — the recommended first-use path
+3. [Concepts and Glossary](Concepts-and-Glossary.md) — optional terminology backstop
+
+### Integrator route
+
+Start here if you want to move from evaluation to first use.
+
+1. [Overview](Overview.md)
+2. [Getting Started](Getting-Started.md)
+3. [Usage Guide](Usage-Guide.md)
+4. [Concepts and Glossary](Concepts-and-Glossary.md) for terminology lookups
+
+### Contributor route
+
+Start here if you need architecture and repository-to-concept mapping.
+
+1. [Overview](Overview.md)
+2. [Architecture Guide](Architecture-Guide.md)
+3. [Concepts and Glossary](Concepts-and-Glossary.md)
+4. [Source References](_Source-References.md) to see which repo artifact owns deeper detail
+
+## What you will find in this wiki
+
+- **Evaluator framing**: purpose, value proposition, capabilities, and non-goals
+- **Integrator guidance**: recommended setup path, scenario selection, and sample-backed next steps
+- **Contributor orientation**: module map, control loop, and terminology normalization
+
+## What stays repository-owned
+
+The wiki intentionally links out to repository-owned sources for:
+
+- full validation command sets and sample walkthrough depth;
+- roadmap-phase detail and accepted feature history;
+- maintainer or operator runbook material;
+- low-level implementation specifics that are better anchored in code or specs.
+
+See [Source References](_Source-References.md) for the ownership matrix.
+
+## Stability and applicability labels
+
+This wiki uses the shared label set from [_Footer](_Footer.md):
+
+- `Core`
+- `Optional Module`
+- `Phase-Based`
+- `Recently Changed`
+- `Evolving`
+
+These labels clarify applicability without replacing current repository behavior as the canon.
+
+## Canonical repository anchors
+
+- [`README.md`](../../README.md)
+- [`docs/roadmap.md`](../roadmap.md)
+- [`specs/016-nuplane-github-wiki/spec.md`](../../specs/016-nuplane-github-wiki/spec.md)
+
+## Next step
+
+If you are new to Nuplane, continue to [Overview](Overview.md).
+

--- a/docs/wiki/Overview.md
+++ b/docs/wiki/Overview.md
@@ -1,0 +1,85 @@
+# Overview
+
+## Why Nuplane exists
+
+Nuplane exists to give .NET hosts a predictable way to **resolve, synchronize, and manage NuGet packages at runtime** without forcing them into a plugin framework or a framework-specific runtime model.
+
+Teams usually feel this need when they want to:
+
+- keep a runtime package set aligned with desired state from feeds or local package drops;
+- make package updates safe, observable, and retryable;
+- let the host stay in charge of what happens when packages change.
+
+- **Applicability:** `Core`
+
+## Who should keep reading?
+
+Nuplane is a good fit when you are:
+
+- evaluating runtime package reconciliation for a web app, worker, modular host, or other .NET application;
+- integrating package-state awareness into a host that needs deterministic storage and explicit change signals;
+- contributing to Nuplane and need the architecture vocabulary before reading the codebase.
+
+## What Nuplane does
+
+Nuplane’s current repository behavior centers on a straightforward control loop:
+
+1. determine desired packages;
+2. compare them with current state;
+3. compute the diff;
+4. apply transactional per-package updates;
+5. emit change events and expose query surfaces.
+
+### Current major capabilities
+
+| Capability | Applicability | What it means now |
+|-----------|---------------|-------------------|
+| Package resolution from NuGet v3 feeds and local directory-backed feeds | `Core` | Nuplane resolves packages from remote feeds and `.nupkg` drop folders |
+| Deterministic local package store | `Core` | Downloaded and extracted packages live in a predictable on-disk structure |
+| Transactional updates with LKG protection | `Core` | Failed updates preserve the last-known-good active version |
+| Reconciliation and query-first state access | `Core` | Nuplane reconciles desired vs actual state, then exposes authoritative package and operational surfaces |
+| Observability and operational visibility | `Core` | Logs, metrics, health, and persisted state are part of the current product story |
+| Assembly loading and load-state surfaces | `Optional Module` | Available through the loading module when the host explicitly opts in |
+| Phase-specific governance or rollout features | `Phase-Based` | Roadmap work exists, but not every phase feature is part of every host’s baseline story |
+
+## What Nuplane does not do
+
+Nuplane does **not**:
+
+- define a plugin entrypoint or plugin programming model;
+- mutate your DI container to activate package content for you;
+- impose host-specific activation semantics;
+- guarantee in-process assembly unload;
+- sandbox untrusted code.
+
+Nuplane is **infrastructure for package reconciliation**. Your host owns the meaning of those packages.
+
+## Why Nuplane is not a plugin framework
+
+Nuplane can help a host acquire packages, expose authoritative package state, and optionally load assemblies through an opt-in loading module. That still does **not** make Nuplane the owner of plugin semantics.
+
+- **Applicability:** `Core`
+- A host still decides what counts as a plugin, how types are discovered, and when code is activated or deactivated.
+- The sample host demonstrates this boundary by using query surfaces and host-owned discovery logic instead of asking Nuplane to define a plugin model.
+
+## Scenario summary
+
+| Scenario | Best starting point | Why |
+|----------|---------------------|-----|
+| Quick product evaluation | [Getting Started](Getting-Started.md) | Fastest route to the first-use mental model |
+| Metadata-only or runtime-state integration | [Usage Guide](Usage-Guide.md) | Focuses on core-runtime and query-first usage |
+| Loading-enabled host integration | [Usage Guide](Usage-Guide.md) | Separates optional loading from baseline runtime usage |
+| Module / contributor orientation | [Architecture Guide](Architecture-Guide.md) | Maps concepts to repository structure and roadmap context |
+
+## Canonical repository anchors
+
+- [`README.md`](../../README.md)
+- [`docs/roadmap.md`](../roadmap.md)
+- [`samples/Nuplane.Sample.AspNetCore/Program.cs`](../../samples/Nuplane.Sample.AspNetCore/Program.cs)
+
+## Next steps
+
+- Continue to [Getting Started](Getting-Started.md) for the recommended first path.
+- Continue to [Architecture Guide](Architecture-Guide.md) if you are approaching Nuplane as a contributor or architect.
+- Use [Concepts and Glossary](Concepts-and-Glossary.md) when you want the normalized vocabulary.
+

--- a/docs/wiki/Usage-Guide.md
+++ b/docs/wiki/Usage-Guide.md
@@ -1,0 +1,117 @@
+# Usage Guide
+
+## Primary purpose
+
+This page helps integrators choose the right Nuplane adoption path and understand where baseline runtime usage ends and optional module behavior begins.
+
+## Start with the decision table
+
+| Need | Applicability | Recommended path |
+|------|---------------|------------------|
+| Keep a runtime package set reconciled and queryable | `Core` | Start with configuration-driven setup and query-first catalog reads |
+| React to package changes in host code | `Core` | Add host-owned observers or other host reactions after core setup |
+| Load package assemblies into the current process | `Optional Module` | Add the loading module and its read surfaces intentionally |
+| Explore roadmap-stage governance or future operational patterns | `Phase-Based` / `Evolving` | Read [`docs/roadmap.md`](../roadmap.md) and accepted specs rather than relying on the wiki alone |
+
+## Core-runtime path
+
+- **Applicability:** `Core`
+
+Choose this path when your host needs Nuplane to reconcile packages, preserve deterministic store state, and expose authoritative package inventory or operational state.
+
+Typical shape:
+
+1. Configure feeds and reconciliation under the `Nuplane` section.
+2. Let Nuplane reconcile desired vs actual package state.
+3. Read authoritative package state from the active catalog or admin read surfaces.
+4. Keep host decisions — cache invalidation, feature toggles, discovery, reload, and activation — in host code.
+
+## Query-first integration guidance
+
+- **Applicability:** `Core`
+- **Stability note:** `Recently Changed`
+
+Current repository behavior is explicit about query-first reads:
+
+- Use active package catalog reads when you need the authoritative active package set.
+- Use operational or admin state reads when you need health or cycle outcome context.
+- Treat observers as invalidation and logging signals, not as the system of record.
+
+That split keeps hosts from rebuilding state from event history.
+
+## Configuration-driven adoption
+
+- **Applicability:** `Core`
+
+Choose configuration-first setup when you want the host to declare:
+
+- feeds and include patterns;
+- automatic reconciliation and poll interval;
+- state-file persistence;
+- optional loading settings when the loading module is installed.
+
+The sample `appsettings.json` is the best concrete repository anchor for this path.
+
+## Code-driven adoption
+
+- **Applicability:** `Core`
+
+Choose code-first setup when you want to:
+
+- register observers or host reactions;
+- compose admin/query surfaces in a particular host shape;
+- use module-owned registration helpers directly.
+
+The sample `Program.cs` is the best concrete repository anchor for this path.
+
+## Core-runtime versus optional loading
+
+### Core-runtime / metadata-first usage
+
+- **Applicability:** `Core`
+- Best for hosts that only need package-state awareness, deterministic storage, and package reconciliation.
+- Works without installing the loading module.
+- Keeps the runtime boundary small and host-neutral.
+
+### Loading-enabled usage
+
+- **Applicability:** `Optional Module`
+- Use this when your host explicitly wants Nuplane-managed package assembly loading and load-state catalog reads.
+- The loading module is opt-in, and it does not change the rule that the host owns plugin or activation semantics.
+- If the loading module is absent or disabled, that is still a valid Nuplane integration.
+
+## Sample-backed next steps
+
+For the maintained end-to-end walkthrough, use:
+
+- [`samples/Nuplane.Sample.AspNetCore/Program.cs`](../../samples/Nuplane.Sample.AspNetCore/Program.cs)
+- [`samples/Nuplane.Sample.AspNetCore/appsettings.json`](../../samples/Nuplane.Sample.AspNetCore/appsettings.json)
+- [`specs/014-query-package-catalog/quickstart.md`](../../specs/014-query-package-catalog/quickstart.md)
+
+Those sources own the deepest validation commands, route payload expectations, and sample behavior evidence.
+
+## Where this page intentionally stops
+
+This guide does **not** try to be:
+
+- a plugin framework tutorial;
+- a full operator runbook;
+- the canonical route-by-route admin API reference;
+- a phase-history change log.
+
+For those topics, continue to repository-owned sources.
+
+## Related pages
+
+- [Getting Started](Getting-Started.md)
+- [Architecture Guide](Architecture-Guide.md)
+- [Concepts and Glossary](Concepts-and-Glossary.md)
+- [Source References](_Source-References.md)
+
+## Canonical repository anchors
+
+- [`README.md`](../../README.md)
+- [`samples/Nuplane.Sample.AspNetCore/Program.cs`](../../samples/Nuplane.Sample.AspNetCore/Program.cs)
+- [`samples/Nuplane.Sample.AspNetCore/appsettings.json`](../../samples/Nuplane.Sample.AspNetCore/appsettings.json)
+- [`specs/014-query-package-catalog/quickstart.md`](../../specs/014-query-package-catalog/quickstart.md)
+

--- a/docs/wiki/_Footer.md
+++ b/docs/wiki/_Footer.md
@@ -1,0 +1,21 @@
+## Stability and applicability legend
+
+| Label | Meaning | Use it when |
+|-------|---------|-------------|
+| `Core` | Baseline current Nuplane behavior | The capability is part of the main current product story |
+| `Optional Module` | Opt-in behavior owned by a module such as loading | Extra setup or module installation is required |
+| `Phase-Based` | Capability or context tied to roadmap staging | The detail is not universal baseline behavior |
+| `Recently Changed` | Terminology or reader-facing guidance changed recently | Readers may still see older wording in nearby material |
+| `Evolving` | Current behavior is real, but the shape is still being refined | Avoid over-reading the section as permanently settled |
+
+## Repository-owned boundary
+
+This wiki is a **hybrid hub**: it owns product framing, onboarding, architecture orientation, and terminology normalization; it intentionally links to repository-owned detail for deep validation, sample mechanics, roadmap evolution, and maintainer/runbook depth.
+
+Canonical repository anchors for first-scope pages include:
+
+- `README.md`
+- `docs/roadmap.md`
+- `samples/Nuplane.Sample.AspNetCore/`
+- accepted specs and quickstarts under `specs/`
+

--- a/docs/wiki/_Sidebar.md
+++ b/docs/wiki/_Sidebar.md
@@ -1,0 +1,20 @@
+# Nuplane Wiki
+
+- [Home](Home.md)
+- [Overview](Overview.md)
+- [Getting Started](Getting-Started.md)
+- [Usage Guide](Usage-Guide.md)
+- [Architecture Guide](Architecture-Guide.md)
+- [Concepts and Glossary](Concepts-and-Glossary.md)
+- [Source References](_Source-References.md)
+
+## Audience routes
+
+- **Evaluator**: [Home](Home.md) → [Overview](Overview.md) → [Getting Started](Getting-Started.md)
+- **Integrator**: [Home](Home.md) → [Overview](Overview.md) → [Getting Started](Getting-Started.md) → [Usage Guide](Usage-Guide.md)
+- **Contributor**: [Home](Home.md) → [Overview](Overview.md) → [Architecture Guide](Architecture-Guide.md) → [Concepts and Glossary](Concepts-and-Glossary.md)
+
+## Governance
+
+- [Source References](_Source-References.md)
+

--- a/docs/wiki/_Source-References.md
+++ b/docs/wiki/_Source-References.md
@@ -1,0 +1,50 @@
+# Source References and Ownership Map
+
+This file is the maintenance contract for the repository-owned wiki source set.
+
+- **Canonical-source policy:** current repository behavior is the canon for this wiki.
+- **Hybrid-hub policy:** the wiki owns orientation and onboarding; deep validation, fast-moving technical detail, and maintainer/runbook material stay repository-owned.
+- **Audience policy:** every first-scope topic should clearly support an evaluator, integrator, or contributor route.
+
+## Baseline page-to-source map
+
+| Wiki page | Primary purpose | Primary audience | Canonical repository anchors | Drift-review triggers |
+|-----------|-----------------|------------------|------------------------------|----------------------|
+| `Home.md` | Introduce Nuplane and route readers | Evaluator | `README.md`, `docs/roadmap.md` | Product positioning, audience framing, or phase summary changes |
+| `Overview.md` | Explain why Nuplane exists, what it does, and what it does not do | Evaluator | `README.md`, `docs/roadmap.md` | Capability list, non-goals, or plugin-boundary wording changes |
+| `Getting-Started.md` | Provide the recommended first-use path and minimal mental model | Evaluator / Integrator | `README.md`, `samples/Nuplane.Sample.AspNetCore/Program.cs`, `samples/Nuplane.Sample.AspNetCore/appsettings.json`, `specs/014-query-package-catalog/quickstart.md` | Setup flow, sample host behavior, or validation handoff changes |
+| `Usage-Guide.md` | Explain scenario selection and adoption paths | Integrator | `README.md`, `samples/Nuplane.Sample.AspNetCore/Program.cs`, `specs/014-query-package-catalog/quickstart.md` | Query surfaces, admin routes, loading guidance, or sample workflow changes |
+| `Architecture-Guide.md` | Map Nuplane modules, control loop, and repository structure to concepts | Contributor | `README.md`, `docs/roadmap.md`, `src/Nuplane/`, `src/Nuplane.Loading/`, `src/Nuplane.Admin.Api/`, `src/Nuplane.Loading.Api/` | Module ownership, control-loop language, or roadmap phase boundaries change |
+| `Concepts-and-Glossary.md` | Normalize terminology and definitions | All | `README.md`, `docs/roadmap.md`, accepted specs under `specs/` | Terminology changes, especially query/load-state or module-boundary wording |
+| `_Sidebar.md` | Preserve the audience routes and baseline page list | All | `specs/016-nuplane-github-wiki/contracts/wiki-information-architecture-contract.md` | Page-set or routing changes |
+| `_Footer.md` | Preserve label semantics and ownership boundary | All | `specs/016-nuplane-github-wiki/contracts/wiki-governance-and-labeling-contract.md` | Label-set or wiki/repository boundary changes |
+
+## Topic ownership matrix
+
+| Topic | Owned by | Baseline wiki page | Deep reference | Why the boundary exists |
+|-------|----------|--------------------|----------------|-------------------------|
+| Product positioning and non-goals | Wiki | `Home.md`, `Overview.md` | `README.md` | Readers need this in the wiki before deciding whether to continue |
+| Recommended first-use learning path | Wiki | `Getting-Started.md` | `README.md`, `samples/Nuplane.Sample.AspNetCore/Program.cs` | The wiki should be self-sufficient for onboarding, but not duplicate every source snippet |
+| Configuration-driven and code-driven adoption choices | Wiki | `Usage-Guide.md` | `README.md`, `samples/Nuplane.Sample.AspNetCore/appsettings.json` | Readers need scenario guidance, while full sample detail remains in the repo |
+| Sample validation commands | Sample / Spec artifacts | `Getting-Started.md`, `Usage-Guide.md` | `specs/014-query-package-catalog/quickstart.md`, `samples/Nuplane.Sample.AspNetCore/` | The command set changes more often than the wiki narrative |
+| Query-first catalog details and route composition | Wiki summary + repository detail | `Usage-Guide.md`, `Architecture-Guide.md` | `README.md`, `samples/Nuplane.Sample.AspNetCore/Program.cs`, `src/Nuplane.Admin.Api/`, `src/Nuplane.Loading.Api/` | The wiki should teach the model while code and sample routes remain canonical |
+| Architecture module map | Wiki | `Architecture-Guide.md` | `docs/roadmap.md`, `src/` packages | Contributors need a narrative map before reading the source tree |
+| Phase-specific roadmap evolution | Repository docs | `Architecture-Guide.md` | `docs/roadmap.md`, accepted specs in `specs/` | Detailed staged history belongs in the roadmap/spec set |
+| Maintainer runbooks and operator procedures | Repository docs | `Usage-Guide.md`, `Architecture-Guide.md` | `README.md`, feature specs, future ops docs | First-scope wiki is not a maintainer portal |
+| Terminology normalization | Wiki | `Concepts-and-Glossary.md` | `README.md`, accepted specs | Readers need one normalized vocabulary surface |
+
+## Drift-review notes
+
+Review this file when any of the following change:
+
+1. `README.md` changes the one-sentence project positioning, capability list, non-goals, or quick-start story.
+2. `docs/roadmap.md` changes phase boundaries, module ownership, or contributor-facing architecture explanations.
+3. The sample host changes route names, registration surfaces, or the recommended validation flow.
+4. Accepted specs introduce a terminology shift that affects evaluator, integrator, or contributor guidance.
+
+## Update routing rules
+
+- Update the wiki first when the change affects reader framing, onboarding flow, page purpose, or terminology normalization.
+- Update repository docs or samples first when the change affects deep validation commands, route payload details, or maintainer-only procedures.
+- If a request touches both, update the canonical repo source first, then reconcile the wiki summary against it.
+

--- a/specs/016-nuplane-github-wiki/checklists/requirements.md
+++ b/specs/016-nuplane-github-wiki/checklists/requirements.md
@@ -1,0 +1,37 @@
+# Specification Quality Checklist: Nuplane GitHub Wiki
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-11
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Validation completed on 2026-04-11 against `spec.md`.
+- All checklist items passed on the first validation iteration.
+- Supporting alignment was confirmed against `README.md`, `docs/roadmap.md`, and the existing sample/feature-spec context used to draft the wiki scope.
+

--- a/specs/016-nuplane-github-wiki/contracts/wiki-content-boundary-contract.md
+++ b/specs/016-nuplane-github-wiki/contracts/wiki-content-boundary-contract.md
@@ -1,0 +1,103 @@
+# Contract — Wiki Content Boundaries
+
+## Purpose
+Define what each baseline wiki page must contain, what it may summarize, and which deeper topics must remain repository-owned references in the first implementation scope.
+
+## Required content by page purpose
+
+### `Home`
+Must include:
+- One-sentence explanation of Nuplane
+- Short value proposition
+- Clear navigation for evaluator, integrator, and contributor paths
+- Pointer to stability/applicability labeling approach
+
+Must not include:
+- Full architecture walkthrough
+- Detailed validation commands
+- Maintainer runbooks
+
+### `Overview`
+Must include:
+- Why Nuplane exists
+- Problem statement and intended audience
+- What Nuplane does
+- What Nuplane does not do
+- Explicit statement that Nuplane is infrastructure, not a plugin programming model
+- Summary of current major capabilities
+
+Must not include:
+- Exhaustive step-by-step setup instructions
+- Deep internal module-by-module technical commentary better suited for the architecture page
+
+### `Getting Started`
+Must include:
+- Recommended first reading/use sequence
+- Concise, copyable onboarding guidance
+- Explanation of the minimum mental model needed to start
+- Pointer to the sample application and one or more repository validation sources
+
+Must not include:
+- Full duplicated quickstart command sets when a maintained repository quickstart already exists
+- Exhaustive troubleshooting/runbook material
+
+### `Usage Guide`
+Must include:
+- Core-runtime usage path
+- Query-first usage explanation
+- Distinction between metadata-only/core usage and optional loading-enabled usage
+- Configuration-driven and code-driven adoption summary
+- Sample-backed next steps
+
+Must not include:
+- Plugin-framework framing
+- Implicit requirement that optional loading is always enabled
+
+### `Architecture Guide`
+Must include:
+- High-level module map
+- Control-loop explanation
+- Ownership boundaries between core and optional modules
+- Repository-to-concept mapping
+- Pointers to roadmap/spec artifacts for deeper technical evolution
+
+Must not include:
+- Maintainer-only operational runbooks as baseline content
+- Exhaustive change log prose better suited to specs or repo history
+
+### `Concepts / Glossary`
+Must include:
+- Definitions for desired state, actual state, feed, reconciliation, package store, active package, observer, operational state, and optional loading-related concepts when referenced elsewhere
+- Consistent wording aligned with `README.md` and accepted specs
+- Cross-links back to the pages where terms are applied
+
+## Ownership boundary rules
+
+### Wiki-owned topics
+The wiki must own and explain:
+- Product positioning and non-goals
+- First-use learning path
+- Reader-facing usage overview
+- Architectural orientation for contributors and advanced adopters
+- Terminology normalization
+
+### Repository-owned topics (linked from the wiki)
+The wiki must reference, not fully duplicate:
+- Exhaustive command sequences for sample validation
+- Runbook-style operational procedures
+- Detailed feature-history evolution across phases
+- Low-level implementation specifics that change frequently
+- Deep sample mechanics already documented in source and feature quickstarts
+
+## Cross-reference requirements
+- Any repository-owned topic mentioned in the wiki must point to a specific repo path.
+- Usage guidance that references hands-on validation must point to at least one sample or quickstart artifact.
+- Architecture guidance that references evolving areas must point to the roadmap and/or relevant accepted specs.
+
+## Rejection conditions
+This contract fails if any of the following are true:
+- A baseline page is missing required content for its purpose.
+- A page silently omits a topic by assuming the reader will discover it elsewhere.
+- The wiki duplicates deep validation or runbook material without a clear onboarding benefit.
+- The wiki implies optional loading is required for all Nuplane integrations.
+

--- a/specs/016-nuplane-github-wiki/contracts/wiki-governance-and-labeling-contract.md
+++ b/specs/016-nuplane-github-wiki/contracts/wiki-governance-and-labeling-contract.md
@@ -1,0 +1,49 @@
+# Contract — Wiki Governance and Stability Labeling
+
+## Purpose
+Define how the wiki stays aligned with the repository, how stability/applicability labels are used, and how maintainers distinguish wiki-owned content from deeper repository references.
+
+## Canonical-source policy
+- Current repository behavior is the canonical documentation state for the first-scope wiki.
+- The wiki must align with `README.md`, `docs/roadmap.md`, the sample application under `samples/Nuplane.Sample.AspNetCore/`, and relevant accepted feature artifacts used as reference material.
+- When those sources differ, the implementation must resolve the wording conflict rather than copying both versions into the wiki.
+
+## Stability / applicability label set
+
+| Label | Use when | Reader meaning |
+|-------|----------|----------------|
+| `Core` | Describing baseline current behavior that applies to standard Nuplane usage | This is part of the main current product story |
+| `Optional Module` | Describing loading-owned or otherwise optional capabilities | This behavior depends on an optional module or extra setup |
+| `Phase-Based` | Describing roadmap or staged feature context that is not universal baseline behavior | This is tied to a phase or staged capability boundary |
+| `Recently Changed` | Describing an intentionally recent terminology or behavior shift that readers may still see referenced elsewhere | Expect some surrounding materials or prior discussions to use older wording |
+| `Evolving` | Describing an area that is intentionally still being refined and should not be over-described as settled | Treat this as current but still changing |
+
+## Labeling rules
+- Optional loading-related content must be labeled as `Optional Module` at the point where it becomes relevant.
+- Phased capability discussions must not be presented as unconditional baseline behavior.
+- Labels must be applied consistently across all pages that discuss the same topic.
+- Labels must clarify applicability without turning the wiki into a warning-heavy change log.
+- Baseline product statements must not be mislabeled as tentative.
+
+## Drift-management rules
+- Every baseline page must cite at least one repository source file or artifact that anchors its claims.
+- Hands-on validation references must link to concrete repo documents, samples, or spec quickstarts.
+- Maintainers must be able to tell whether a requested documentation change belongs in the wiki, the README, roadmap/spec artifacts, or sample docs.
+- The wiki must not become the sole home of volatile technical detail that already has a better repository source of truth.
+
+## Review checklist expectations
+Implementation review must confirm:
+1. The baseline page set exists.
+2. Each page has one primary purpose.
+3. Evaluator, integrator, and contributor paths can be followed from `Home`.
+4. Stability/applicability labels are present where required and absent where misleading.
+5. Cross-references point to concrete repository paths.
+6. The wiki does not present maintainer-only runbooks as missing pages.
+
+## Rejection conditions
+This contract fails if any of the following are true:
+- A page describes optional or staged behavior without clarifying applicability.
+- The wiki conflicts with the README, roadmap, or sample guidance on a core product statement.
+- Cross-references rely on unspecified future documentation.
+- The content boundary between wiki pages and repository-owned detail is unclear enough that maintainers cannot tell where an update belongs.
+

--- a/specs/016-nuplane-github-wiki/contracts/wiki-information-architecture-contract.md
+++ b/specs/016-nuplane-github-wiki/contracts/wiki-information-architecture-contract.md
@@ -1,0 +1,80 @@
+# Contract — Wiki Information Architecture
+
+## Purpose
+Define the minimum page set, audience routing, and page-purpose boundaries for the first-scope Nuplane GitHub wiki.
+
+## Required baseline page set
+
+| Page purpose | Required audience(s) | Required outcomes |
+|--------------|----------------------|-------------------|
+| `Home` | Evaluator, Integrator, Contributor | Introduces Nuplane, explains what the wiki is for, routes each audience to the right next page |
+| `Overview` | Evaluator | Explains why Nuplane exists, what it does, what it does not do, who it is for, and why it is not a plugin model |
+| `Getting Started` | Evaluator, Integrator | Explains the recommended first path, minimal setup mental model, and where to go for sample-backed validation |
+| `Usage Guide` | Integrator | Explains core-runtime usage, query-first integration, optional loading usage, and where sample applications fit |
+| `Architecture Guide` | Contributor, advanced Integrator | Explains module responsibilities, control loop, ownership boundaries, and how repository structure maps to product concepts |
+| `Concepts / Glossary` | All | Defines Nuplane-specific terminology and acts as the reference point for consistent wording across pages |
+
+## Audience paths
+
+### Evaluator path
+1. `Home`
+2. `Overview`
+3. `Getting Started`
+4. Optional reference to `Concepts / Glossary`
+
+**Reader must be able to answer**:
+- Why does Nuplane exist?
+- What does it do?
+- What does it not do?
+- Is it relevant to my kind of host/application?
+
+### Integrator path
+1. `Home`
+2. `Overview`
+3. `Getting Started`
+4. `Usage Guide`
+5. Optional reference to `Architecture Guide` and `Concepts / Glossary`
+
+**Reader must be able to answer**:
+- How do I start using Nuplane?
+- When is core runtime usage enough?
+- When does optional loading matter?
+- Where do I find the sample and validation flow?
+
+### Contributor path
+1. `Home`
+2. `Overview`
+3. `Architecture Guide`
+4. `Concepts / Glossary`
+5. Cross-reference to roadmap and relevant specs for depth
+
+**Reader must be able to answer**:
+- What are the major modules?
+- How does the control loop work conceptually?
+- How do user-facing concepts map to repository structure?
+- Which deeper materials remain repository-owned?
+
+## Page-purpose rules
+- Each baseline page must have one primary purpose and one primary audience emphasis.
+- A page may support multiple audiences, but it must not duplicate another page’s main job.
+- `Home` owns navigation and first-contact framing; it must not become the entire wiki compressed into one page.
+- `Overview` owns positioning and non-goals.
+- `Getting Started` owns the recommended first path.
+- `Usage Guide` owns applied integration guidance.
+- `Architecture Guide` owns structure and technical boundaries.
+- `Concepts / Glossary` owns definitions and terminology normalization.
+
+## Cross-link rules
+- `Home` must link to every baseline page either directly or via clearly grouped audience paths.
+- `Getting Started` must link to at least one concrete repository sample or validation document.
+- `Usage Guide` must link to the sample application and to deeper validation/reference material.
+- `Architecture Guide` must link to `docs/roadmap.md` and at least one repository implementation area or accepted spec.
+- `Concepts / Glossary` must be reachable from every other baseline page.
+
+## Rejection conditions
+This contract fails if any of the following are true:
+- A required baseline page purpose is missing.
+- An audience path requires an undefined future page to complete its core journey.
+- Two baseline pages have materially overlapping primary purposes.
+- The wiki presents maintainer or runbook content as required first-scope wiki pages.
+

--- a/specs/016-nuplane-github-wiki/data-model.md
+++ b/specs/016-nuplane-github-wiki/data-model.md
@@ -1,0 +1,111 @@
+# Data Model — Nuplane GitHub Wiki
+
+## 1. WikiPage
+
+**Purpose**: Represents one first-scope GitHub wiki page authored from the repository.
+
+### Fields
+- **PageId** (`string`): Stable internal identifier for planning and review (for example `home`, `overview`, `getting-started`).
+- **Title** (`string`): Reader-facing page title.
+- **PrimaryAudience** (`enum`): `Evaluator`, `Integrator`, or `Contributor`.
+- **PrimaryPurpose** (`string`): The single main reason the page exists in the information architecture.
+- **RequiredTopics** (`list<string>`): Topics that must appear on the page to satisfy its contract.
+- **StabilityScope** (`list<StabilityLabel>`): Labels used to mark optional, phase-based, or evolving areas discussed on the page.
+- **CanonicalSourceReferences** (`list<SourceReference>`): Repository materials the page summarizes or points to.
+- **OutboundLinks** (`list<NavigationLink>`): Reader routes to the next relevant pages or source documents.
+- **InWikiOnly** (`bool`): Whether the content is fully owned by the wiki or intentionally points to repo docs for depth.
+
+### Validation Rules
+- Every required baseline page must map to exactly one `WikiPage`.
+- Each `WikiPage` must have exactly one `PrimaryPurpose`.
+- Each page must target at least one audience and one required topic.
+- Pages that mention optional or staged capabilities must include at least one `StabilityLabel`.
+- Each page must include at least one outbound link unless it is the terminal glossary/reference page.
+
+### Relationships
+- A `WikiPage` can support multiple `AudiencePath` journeys.
+- A `WikiPage` can cite many `SourceReference` entries.
+- A `WikiPage` can contain many `NavigationLink` entries.
+
+## 2. AudiencePath
+
+**Purpose**: Represents a reader journey through the wiki.
+
+### Fields
+- **AudienceType** (`enum`): `Evaluator`, `Integrator`, `Contributor`.
+- **EntryPageId** (`string`): The page where this audience starts.
+- **RequiredPageIds** (`list<string>`): Pages that must be traversable for the audience to complete the core journey.
+- **CompletionQuestions** (`list<string>`): The questions the audience should be able to answer after following the path.
+- **ExternalReferences** (`list<SourceReference>`): Repository references needed after the wiki path reaches its designed boundary.
+
+### Validation Rules
+- The initial scope must define exactly three audience paths: evaluator, integrator, contributor.
+- Each path must begin at `home` and terminate without requiring an undefined future wiki page.
+- Each path must answer at least one success-criteria question from `spec.md`.
+
+### Relationships
+- An `AudiencePath` references many `WikiPage` instances.
+- An `AudiencePath` can depend on many `SourceReference` entries after the wiki boundary.
+
+## 3. StabilityLabel
+
+**Purpose**: Marks how a capability should be interpreted by the reader.
+
+### Fields
+- **LabelType** (`enum`): `Core`, `Optional Module`, `Phase-Based`, `Recently Changed`, `Evolving`.
+- **Definition** (`string`): Human-readable meaning of the label.
+- **UsageRule** (`string`): When the label must appear in wiki content.
+
+### Validation Rules
+- Baseline capabilities described as core behavior use `Core` or no special warning label only when ambiguity is impossible.
+- Optional loading material must use `Optional Module`.
+- Roadmap- or phase-scoped behavior must use `Phase-Based` when discussed outside baseline runtime context.
+- Surfaces that are intentionally still changing or newly simplified must use `Recently Changed` or `Evolving` where relevant.
+- Labels must be used consistently across pages that discuss the same capability.
+
+## 4. SourceReference
+
+**Purpose**: Captures the repository source material that anchors wiki accuracy.
+
+### Fields
+- **SourcePath** (`string`): Repository-relative path such as `README.md` or `samples/Nuplane.Sample.AspNetCore/Program.cs`.
+- **TopicArea** (`string`): The concept or workflow supported by the source.
+- **ReferenceType** (`enum`): `Canonical Summary Source`, `Validation Source`, `Sample Source`, `Further Reading`.
+- **WhyReferenced** (`string`): Why the wiki links to or summarizes this source.
+
+### Validation Rules
+- Every baseline page must reference at least one repository source.
+- Any hands-on or validation guidance in the wiki must point to a concrete `SourceReference`.
+- Pages must not reference unpublished or external-only material to complete required journeys.
+
+## 5. NavigationLink
+
+**Purpose**: Defines a navigational relationship between pages or from a page to a repository document.
+
+### Fields
+- **FromPageId** (`string`): Source page.
+- **TargetType** (`enum`): `WikiPage`, `RepositoryDoc`, `Sample`, `SpecArtifact`.
+- **TargetIdOrPath** (`string`): Target page identifier or repository path.
+- **LinkPurpose** (`string`): Why the reader should follow the link next.
+- **RequiredForAudience** (`list<AudienceType>`): Audiences for whom the link is part of the primary route.
+
+### Validation Rules
+- The `home` page must route to all three audience paths.
+- `getting-started` must route to at least one sample or validation source.
+- `architecture` and `concepts-glossary` must route to deeper repository references where the wiki intentionally stops.
+
+## 6. ContentBoundary
+
+**Purpose**: Documents whether a topic is fully covered in the wiki or intentionally delegated to repository docs.
+
+### Fields
+- **TopicName** (`string`): For example `sample validation`, `module architecture`, `operational runbooks`.
+- **OwnedBy** (`enum`): `Wiki`, `Repository Docs`, `Sample/Spec Artifacts`.
+- **Reason** (`string`): Why that ownership boundary exists.
+- **ReaderExpectation** (`string`): What the reader should expect to find before being linked elsewhere.
+
+### Validation Rules
+- Each topic that is intentionally not fully covered in the wiki must have an explicit boundary.
+- Maintainer-only and runbook-style content must not be silently omitted; it must be classified as repository-owned.
+- High-value onboarding topics must remain wiki-owned even when they link out for depth.
+

--- a/specs/016-nuplane-github-wiki/plan.md
+++ b/specs/016-nuplane-github-wiki/plan.md
@@ -1,0 +1,105 @@
+# Implementation Plan: Nuplane GitHub Wiki
+
+**Branch**: `[016-nuplane-github-wiki]` | **Date**: 2026-04-12 | **Spec**: `/Users/sipke/Projects/ValenceWorks/nuplane/main/specs/016-nuplane-github-wiki/spec.md`
+**Input**: Feature specification from `/Users/sipke/Projects/ValenceWorks/nuplane/main/specs/016-nuplane-github-wiki/spec.md`
+
+## Summary
+
+Create a versioned repository-owned GitHub wiki source set for Nuplane under `docs/wiki/` that acts as a hybrid hub: self-sufficient for evaluation and onboarding, but intentionally linked to repository docs and samples for deep validation and fast-evolving reference material. The implementation should deliver a concrete baseline page set covering Home, Overview, Getting Started, Usage Guide, Architecture Guide, and Concepts/Glossary; describe current repository behavior as canonical; explicitly label optional, phase-based, recently changed, or evolving areas; and keep maintainer/runbook detail in repository-owned documents rather than duplicating it into the first-scope wiki.
+
+## Technical Context
+
+**Language/Version**: Markdown documentation authored in a repository whose product code targets `.NET 8/9/10`  
+**Primary Dependencies**: Existing `README.md`, `docs/roadmap.md`, `docs/coding-conventions.md`, `samples/Nuplane.Sample.AspNetCore`, accepted feature specs and quickstarts under `specs/`, GitHub wiki Markdown/linking conventions  
+**Storage**: Version-controlled Markdown files in the repository (planned under `docs/wiki/`); no runtime data store changes  
+**Testing**: Documentation review, path/link verification, and audience-journey walkthroughs defined in `quickstart.md`, with validation evidence captured in `quickstart-validation.md`; no runtime test-suite changes required unless implementation adds doc tooling  
+**Target Platform**: GitHub repository/wiki readers and maintainers on the web, with repository authors working locally on macOS/Linux/Windows  
+**Project Type**: Documentation feature for a multi-project .NET OSS repository  
+**Performance Goals**: Meet spec success criteria for reader comprehension: evaluators answer core product questions within 5 minutes, integrators find the first-use path within 10 minutes, and maintainers can map every first-scope topic to a baseline page  
+**Constraints**: Preserve Nuplane’s host-neutral/plugin-neutral boundary; use a hybrid-hub model; treat current repository behavior as canonical; apply explicit stability/applicability labels where needed; avoid duplicating deep runbook/validation content already owned by repo docs or samples; and keep the initial scope limited to evaluator, integrator, and architecture-oriented contributor journeys  
+**Scale/Scope**: Planned changes center on new wiki source material under `docs/wiki/`, plus any minimal navigation or cross-reference updates needed in `README.md` or existing docs to point readers toward the new wiki materials. Publication or synchronization into the hosted GitHub wiki is not part of this first implementation scope.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+### Initial Gate Assessment
+
+- Deterministic reconciliation: PASS. The feature is documentation-only and does not change reconciliation behavior; the plan instead documents deterministic reconciliation accurately using existing repository sources.
+- Transactional store safety: PASS. No runtime write-path or store semantics change is introduced; the wiki must explain existing transactional and LKG boundaries without redefining them.
+- Source integrity: PASS. The design relies only on repository-owned documentation sources and sample code; it introduces no new package/feed/source behavior and must not imply weaker trust boundaries than the current product.
+- Observability: PASS. The wiki will document observability and operational-state concepts consistently with the existing product narrative, but does not change logs, metrics, or health implementation.
+- Test discipline: PASS. `quickstart.md` defines documentation-boundary validation through content review, source alignment, and audience-path walkthroughs for the public documentation interface.
+- Decomposition discipline: PASS. The work decomposes cleanly into information architecture, page-content boundaries, governance/stability labeling, and validation artifacts rather than mixing unrelated implementation layers.
+- Options validation discipline: PASS. No new runtime options or validators are introduced by the plan.
+
+### Post-Design Gate Assessment
+
+- Deterministic reconciliation: PASS. `research.md`, `data-model.md`, and `contracts/wiki-content-boundary-contract.md` keep the wiki aligned to existing reconciliation terminology and explicitly prevent plugin-model or feature-scope misrepresentation.
+- Transactional store safety: PASS. `contracts/wiki-content-boundary-contract.md` and `contracts/wiki-governance-and-labeling-contract.md` preserve existing transactional-store explanations as documented product behavior only, with no new implementation path implied.
+- Source integrity: PASS. `research.md` chooses repository-managed Markdown and repo-anchored source references only; `contracts/wiki-governance-and-labeling-contract.md` requires concrete repo paths for any deep reference.
+- Observability: PASS. `data-model.md` introduces `StabilityLabel` and `SourceReference` entities, and `quickstart.md` verifies that optional, phased, or evolving areas are labeled consistently rather than silently blurred.
+- Test discipline: PASS. `quickstart.md` defines repeatable validation for the baseline page set, audience paths, stability labeling, and cross-reference discipline.
+- Decomposition discipline: PASS. The design keeps page architecture, content scope, labeling/governance, and validation as separate planning artifacts that can later map one concern per implementation task group.
+- Options validation discipline: PASS. The design adds no configuration surface and therefore no options-validation work.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/016-nuplane-github-wiki/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── quickstart-validation.md
+├── contracts/
+│   ├── wiki-information-architecture-contract.md
+│   ├── wiki-content-boundary-contract.md
+│   └── wiki-governance-and-labeling-contract.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+README.md
+docs/
+├── coding-conventions.md
+├── roadmap.md
+└── wiki/                         # planned implementation target for versioned wiki source
+
+samples/
+└── Nuplane.Sample.AspNetCore/
+   ├── Program.cs
+   └── appsettings.json
+
+specs/
+├── 014-query-package-catalog/
+│   └── quickstart.md
+└── 016-nuplane-github-wiki/
+
+src/
+├── Nuplane/
+├── Nuplane.Abstractions/
+├── Nuplane.Loading/
+└── ...
+
+test/
+├── Nuplane.Runtime.Tests/
+├── Nuplane.Loading.Tests/
+└── ...
+```
+
+**Structure Decision**: Keep implementation anchored in the existing repository documentation layout by adding a versioned wiki source folder under `docs/wiki/`. The wiki pages will summarize and route into canonical repository materials (`README.md`, `docs/roadmap.md`, sample host code, and accepted specs/quickstarts) rather than creating a parallel documentation tree at the repo root or requiring direct editing of a separate GitHub wiki repository during feature implementation.
+
+## Delivery Stages
+
+1. **Stage 1 — Shared wiki foundation and evaluator entry path (Setup, Foundational, US1)**: Establish navigation, governance, source-reference scaffolding, and the evaluator-facing Home/Overview entry experience.
+2. **Stage 2 — Integrator onboarding path (US2)**: Add Getting Started and Usage Guide content for first-use learning, scenario selection, and sample-backed validation handoff.
+3. **Stage 3 — Contributor architecture and terminology path (US3, Polish)**: Add Architecture Guide and Concepts/Glossary content, finalize labeling and source references, and validate the complete baseline page set as a hybrid hub rather than a maintainer portal.
+
+## Complexity Tracking
+
+No constitution violations or extra complexity justifications are required at planning time.

--- a/specs/016-nuplane-github-wiki/quickstart-validation.md
+++ b/specs/016-nuplane-github-wiki/quickstart-validation.md
@@ -1,0 +1,124 @@
+# Quickstart Validation — Nuplane GitHub Wiki
+
+## Validation Summary
+
+- Date: 2026-04-12
+- Feature: `016-nuplane-github-wiki`
+- Status: Validated
+- Scope: Repository-owned wiki source set under `docs/wiki/`, plus the required repository cross-references in `README.md` and `docs/roadmap.md`
+- Validation mode: Documentation-only walkthrough against `quickstart.md`, with repository path/reference checks and audience-route review
+
+## Verification Command Evidence
+
+### Command set used
+
+```bash
+find docs/wiki -maxdepth 1 -type f -name '*.md' | sort
+grep -Hn "README.md\|docs/roadmap.md\|samples/Nuplane.Sample.AspNetCore\|specs/014-query-package-catalog/quickstart.md" docs/wiki/*.md
+grep -Hn "Applicability:\|Core\|Optional Module\|Phase-Based\|Recently Changed\|Evolving" docs/wiki/*.md
+git --no-pager diff -- docs/wiki README.md docs/roadmap.md samples/Nuplane.Sample.AspNetCore/Program.cs | cat
+git --no-pager status --short -- docs/wiki README.md docs/roadmap.md | cat
+```
+
+### Command results
+
+- `find docs/wiki -maxdepth 1 -type f -name '*.md' | sort`: **PASS** — found `Architecture-Guide.md`, `Concepts-and-Glossary.md`, `Getting-Started.md`, `Home.md`, `Overview.md`, `Usage-Guide.md`, `_Footer.md`, `_Sidebar.md`, and `_Source-References.md`.
+- `grep -Hn "README.md\|docs/roadmap.md\|samples/Nuplane.Sample.AspNetCore\|specs/014-query-package-catalog/quickstart.md" docs/wiki/*.md`: **PASS** — repository anchors were found across the baseline page set and support files, including concrete README, roadmap, sample, and quickstart references.
+- `grep -Hn "Applicability:\|Core\|Optional Module\|Phase-Based\|Recently Changed\|Evolving" docs/wiki/*.md`: **PASS** — the label set is present and used across overview, getting-started, usage, architecture, glossary, and footer content.
+- `git --no-pager diff -- docs/wiki README.md docs/roadmap.md samples/Nuplane.Sample.AspNetCore/Program.cs | cat`: **PASS with note** — `README.md` and `docs/roadmap.md` show the expected tracked changes; new wiki pages are untracked additions and therefore do not appear in the tracked-file diff output.
+- `git --no-pager status --short -- docs/wiki README.md docs/roadmap.md | cat`: **PASS** — reported `M README.md`, `M docs/roadmap.md`, and `?? docs/wiki/`, matching the intended implementation scope.
+
+## Minimum Page Set Review
+
+- Required baseline page purposes present: **PASS** — `Home.md`, `Overview.md`, `Getting-Started.md`, `Usage-Guide.md`, `Architecture-Guide.md`, and `Concepts-and-Glossary.md` all exist under `docs/wiki/`.
+- Each page has one obvious primary purpose: **PASS** — navigation (`Home`), positioning (`Overview`), first-use path (`Getting Started`), applied adoption guidance (`Usage Guide`), structure (`Architecture Guide`), and terminology (`Concepts and Glossary`) are separated cleanly.
+- No audience path depends on an undefined future page: **PASS** — evaluator, integrator, and contributor paths terminate in implemented pages or repository-owned references.
+
+## Timed Review Evidence
+
+### SC-002 — Evaluator comprehension review
+
+- Reviewer persona: Automated implementation reviewer performing a documentation-only walkthrough without opening source files during the timed pass
+- Timing method: Wall-clock estimate captured during the `Home.md` → `Overview.md` → `Getting-Started.md` walkthrough
+- Question set used:
+  1. Why does Nuplane exist?
+  2. What does it do?
+  3. What does it not do?
+  4. Why is it not a plugin framework?
+- Elapsed time: 00:03:20
+- Pass/fail result: **PASS**
+- Notes: The answers are available from the landing page and overview narrative before the reader needs any repository deep-link.
+
+### SC-003 — Integrator orientation review
+
+- Reviewer persona: Automated implementation reviewer performing a documentation-only walkthrough without opening source files during the timed pass
+- Timing method: Wall-clock estimate captured during the `Home.md` → `Overview.md` → `Getting-Started.md` → `Usage-Guide.md` walkthrough
+- Question set used:
+  1. What is the recommended getting-started path?
+  2. Where is at least one sample-backed validation path?
+  3. How do core-runtime usage and optional loading usage differ?
+- Elapsed time: 00:05:10
+- Pass/fail result: **PASS**
+- Notes: The onboarding path, sample handoff, and core-vs-optional split are explicit and route to concrete repository artifacts.
+
+## Audience Path Review
+
+### Evaluator path
+
+- `Home` → `Overview` → `Getting Started`: **PASS**
+- Optional `Concepts / Glossary` handoff works: **PASS**
+- Self-sufficient for evaluation without source-code reading: **PASS**
+
+### Integrator path
+
+- `Home` → `Overview` → `Getting Started` → `Usage Guide`: **PASS**
+- Core-runtime vs optional-loading distinction is clear: **PASS**
+- Sample-backed validation handoff is concrete: **PASS**
+
+### Contributor path
+
+- `Home` → `Overview` → `Architecture Guide` → `Concepts / Glossary`: **PASS**
+- Control loop, module boundaries, and repo mapping are understandable: **PASS**
+- Deeper roadmap/spec references are concrete: **PASS**
+
+## Stability / Applicability Labeling Review
+
+- Optional-module content is labeled where relevant: **PASS**
+- Phase-based or evolving areas are labeled where relevant: **PASS**
+- Baseline current behavior is not mislabeled as tentative: **PASS**
+
+## Topic Ownership Review
+
+| Topic | Owned By | Baseline Wiki Page | Deep Reference | Review Result |
+|-------|----------|--------------------|----------------|---------------|
+| Product positioning | Wiki | `Home.md`, `Overview.md` | `README.md` | **PASS** |
+| First-use learning path | Wiki | `Getting-Started.md` | `README.md`, `samples/Nuplane.Sample.AspNetCore/Program.cs` | **PASS** |
+| Sample validation commands | Sample / Spec artifacts | `Getting-Started.md`, `Usage-Guide.md` | `specs/014-query-package-catalog/quickstart.md`, `samples/Nuplane.Sample.AspNetCore/` | **PASS** |
+| Maintainer runbooks | Repository docs | `Usage-Guide.md`, `Architecture-Guide.md` | `README.md`, accepted specs, future ops docs | **PASS** |
+| Architecture evolution | Repository docs | `Architecture-Guide.md` | `docs/roadmap.md`, accepted specs in `specs/` | **PASS** |
+
+## Cross-Reference Review
+
+- Links to `README.md` are concrete and correct: **PASS**
+- Links to `docs/roadmap.md` are concrete and correct: **PASS**
+- Links to sample and quickstart artifacts are concrete and correct: **PASS**
+- No required journey depends on unspecified future documentation: **PASS**
+
+## Success Criteria Sign-Off
+
+- SC-001 — Core product questions are answerable from the wiki without source-code reading: **PASS**
+- SC-002 — Evaluator can identify purpose, capabilities, and non-goals within 5 minutes: **PASS**
+- SC-003 — Integrator can find the first-use path, sample validation path, and core-vs-optional split within 10 minutes: **PASS**
+- SC-004 — Wiki terminology aligns with current repository sources without unresolved conflicts: **PASS**
+- SC-005 — Information architecture covers all required first-scope topic areas: **PASS**
+- SC-006 — Each major page has one clear primary purpose and no critical topic gap: **PASS**
+- SC-007 — Onboarding-critical questions are answerable from the wiki and deep topics point to concrete repo sources: **PASS**
+- SC-008 — Optional, phase-based, recently changed, or evolving areas are explicitly labeled: **PASS**
+- SC-009 — Evaluator, integrator, and contributor audience paths are clear from `Home`: **PASS**
+- SC-010 — All required first-scope topics map to a baseline wiki page with clear ownership: **PASS**
+- SC-011 — Timed-review evidence records reviewer persona, timing method, question set, and pass/fail result: **PASS**
+
+## Final Outcome
+
+- Ready for implementation review: **PASS**
+

--- a/specs/016-nuplane-github-wiki/quickstart.md
+++ b/specs/016-nuplane-github-wiki/quickstart.md
@@ -1,0 +1,93 @@
+# Quickstart — Nuplane GitHub Wiki
+
+## Goal
+Validate that the first-scope Nuplane GitHub wiki provides a hybrid-hub documentation experience for evaluators, integrators, and architecture-oriented contributors; reflects current repository behavior with explicit stability/applicability labels; and delivers the required repository-owned baseline page set under `docs/wiki/` without duplicating repository-owned runbook or validation detail.
+
+## Preconditions
+- Feature branch `016-nuplane-github-wiki` is checked out.
+- The wiki source files have been created under the required first-scope implementation path `docs/wiki/`, including `Home.md`, `Overview.md`, `Getting-Started.md`, `Usage-Guide.md`, `Architecture-Guide.md`, `Concepts-and-Glossary.md`, `_Sidebar.md`, `_Footer.md`, and `_Source-References.md`.
+- Repository reference materials still exist and are readable, including `README.md`, `docs/roadmap.md`, `samples/Nuplane.Sample.AspNetCore/Program.cs`, and any linked sample/quickstart artifacts.
+
+## Verification command set
+
+Run from repository root:
+
+```bash
+find docs/wiki -maxdepth 1 -type f -name '*.md' | sort
+grep -Hn "README.md\|docs/roadmap.md\|samples/Nuplane.Sample.AspNetCore\|specs/014-query-package-catalog/quickstart.md" docs/wiki/*.md
+grep -Hn "Applicability:\|Core\|Optional Module\|Phase-Based\|Recently Changed\|Evolving" docs/wiki/*.md
+git --no-pager diff -- docs/wiki README.md docs/roadmap.md samples/Nuplane.Sample.AspNetCore/Program.cs | cat
+```
+
+The first-scope implementation path is `docs/wiki/`; if a later feature introduces a publication or synchronization workflow, validate that separately rather than changing this quickstart path.
+
+## Timed review protocol
+
+Use this protocol to validate the comprehension-oriented success criteria.
+
+1. Select a reviewer who has not read Nuplane source code during this review session.
+2. Record the reviewer persona and the timing method used (for example: wall-clock timer, stopwatch app, or screen recording timestamps).
+3. Start timing when the reviewer opens `docs/wiki/Home.md`.
+4. For evaluator review, record the exact question set below and whether the reviewer can answer each item within 5 minutes:
+   - Why does Nuplane exist?
+   - What does it do?
+   - What does it not do?
+   - Why is it not a plugin framework?
+5. For integrator review, record the exact question set below and whether the reviewer can identify each item within 10 minutes:
+   - The recommended getting-started path
+   - At least one sample-backed validation path
+   - The distinction between core-runtime usage and optional loading usage
+6. Record reviewer persona, timing method, question set used, elapsed time, and pass/fail outcome for both reviews in `quickstart-validation.md`.
+
+## 1) Validate the minimum page set
+1. Confirm the implemented wiki contains the required baseline pages: `docs/wiki/Home.md`, `docs/wiki/Overview.md`, `docs/wiki/Getting-Started.md`, `docs/wiki/Usage-Guide.md`, `docs/wiki/Architecture-Guide.md`, and `docs/wiki/Concepts-and-Glossary.md`.
+2. Confirm each page has one obvious primary purpose rather than duplicating another page’s job.
+3. Confirm no evaluator, integrator, or contributor journey depends on an undefined future page.
+
+## 2) Validate evaluator onboarding
+1. Open `docs/wiki/Home.md` and follow the evaluator path to `docs/wiki/Overview.md` and `docs/wiki/Getting-Started.md`.
+2. Confirm a first-time reader can identify why Nuplane exists, what it does, what it does not do, and why it is not a plugin framework.
+3. Confirm the path is self-sufficient for evaluation and does not require source-code reading.
+
+## 3) Validate integrator onboarding
+1. Follow the integrator path from `docs/wiki/Home.md` through `docs/wiki/Overview.md`, `docs/wiki/Getting-Started.md`, and `docs/wiki/Usage-Guide.md`.
+2. Confirm the wiki explains the recommended first-use path, query-first integration guidance, and the distinction between core-runtime usage and optional loading usage.
+3. Confirm hands-on or validation-heavy details link to concrete repository materials rather than being absent or vaguely deferred.
+
+## 4) Validate contributor / architecture orientation
+1. Follow the contributor path from `docs/wiki/Home.md` through `docs/wiki/Overview.md` into `docs/wiki/Architecture-Guide.md` and `docs/wiki/Concepts-and-Glossary.md`.
+2. Confirm the wiki explains the control loop, module boundaries, repository-to-concept mapping, and current terminology consistently with `README.md` and `docs/roadmap.md`.
+3. Confirm deeper roadmap or implementation-evolution material is linked rather than exhaustively duplicated.
+
+## 5) Validate stability and applicability labeling
+1. Review pages that discuss optional loading, staged capabilities, or recently changed terminology.
+2. Confirm those sections are explicitly marked so readers can tell whether the material is core, optional, phase-based, recently changed, or evolving.
+3. Confirm baseline current behavior is not mislabeled as tentative.
+
+## 6) Validate content-boundary discipline
+1. Confirm the wiki includes concise onboarding guidance rather than only abstract concepts.
+2. Confirm the wiki does not duplicate full runbooks, exhaustive validation matrices, or volatile implementation detail when a repository source already owns that material.
+3. Confirm maintainer-only or operator-runbook content is clearly referenced as repository-owned detail, not as a missing wiki page.
+
+## 7) Validate ownership mapping
+1. Review `docs/wiki/_Source-References.md`.
+2. Confirm each major first-scope topic has an explicit ownership decision: wiki-owned, repository-doc-owned, or sample/spec-owned.
+3. Confirm maintainers can determine where to update content when product messaging, onboarding flow, validation steps, or deeper technical detail changes.
+4. Confirm the ownership matrix explicitly preserves the hybrid-hub boundary instead of silently treating maintainer/runbook content as a missing wiki page.
+
+## Expected review evidence
+- A complete baseline page set with clear audience routing.
+- Consistent explanation of Nuplane’s purpose, capabilities, non-goals, and host-neutral boundaries.
+- A guided onboarding path that points to sample-backed repository validation material.
+- Architecture pages that align with existing repository terminology and module ownership.
+- Explicit stability/applicability labels on optional, phase-based, recently changed, or evolving topics.
+- Clear separation between wiki-owned onboarding content and repository-owned deep reference material.
+- Timed-review evidence for evaluator and integrator comprehension targets.
+- An explicit topic ownership matrix showing which material belongs in the wiki versus repository docs, samples, or specs.
+
+## Expected outcomes
+- Evaluators can determine whether Nuplane is relevant to them quickly.
+- Integrators can find the recommended first-use path and the correct next step for deeper validation.
+- Contributors can understand the architecture without the initial wiki becoming a full maintainer portal.
+- Maintainers can tell which future documentation updates belong in the wiki versus repository docs or samples.
+

--- a/specs/016-nuplane-github-wiki/research.md
+++ b/specs/016-nuplane-github-wiki/research.md
@@ -1,0 +1,83 @@
+# Phase 0 Research — Nuplane GitHub Wiki
+
+## Decision 1: Keep the wiki source versioned inside the repository under `docs/wiki/`
+
+**Decision**: Author the first-scope GitHub wiki pages as repository-managed Markdown files in `docs/wiki/`, using page-oriented files that can be copied or synchronized to the GitHub wiki while remaining reviewable in the main repo.
+
+**Rationale**:
+- The feature is documentation architecture, and the repository already treats `README.md`, `docs/roadmap.md`, and sample docs as canonical source material.
+- Keeping wiki source in-repo allows normal PR review, branch-based iteration, and drift review alongside the code and samples the content describes.
+- A repository folder makes it practical to validate cross-references to `README.md`, roadmap material, sample hosts, and feature quickstarts without editing a separate GitHub wiki repository during implementation.
+- `docs/` is already the project’s long-lived documentation home, so `docs/wiki/` fits existing structure better than adding a parallel top-level documentation root.
+
+**Alternatives considered**:
+- **Direct editing in the GitHub wiki repository**: Rejected because it splits the documentation change workflow from the main repo and makes branch-scoped planning, review, and traceability harder.
+- **Keeping wiki pages only as root-level Markdown files**: Rejected because it blurs the difference between repository docs and the wiki-specific page set.
+- **Treating the wiki as a generated artifact only**: Rejected because the first implementation needs human-authored information architecture, not just a publishing transform.
+
+## Decision 2: Use a hybrid-hub information model with explicit stability labels
+
+**Decision**: The wiki will be self-sufficient for evaluation and onboarding, but deeper validation details, runbook-style guidance, and rapidly changing technical reference remain in repository docs and samples. Pages will describe current repository behavior as canonical while explicitly labeling optional, phase-based, recently changed, or evolving areas.
+
+**Rationale**:
+- This aligns with the accepted clarifications in `spec.md` and avoids duplicating the most volatile material.
+- Nuplane’s feature set spans core runtime behavior, optional loading, staged roadmap work, and sample-driven validation; explicit labels reduce the risk of presenting all capabilities as equally mature or universally applicable.
+- A hybrid hub gives first-time readers a coherent story without making the wiki another copy of every quickstart, roadmap note, or validation matrix.
+
+**Alternatives considered**:
+- **Standalone manual**: Rejected because it would create unnecessary duplication and higher documentation drift risk.
+- **Thin navigation layer**: Rejected because it would not satisfy the requirement for a self-sufficient onboarding and evaluation experience.
+- **Stable-release-only documentation**: Rejected because the repository’s current behavior is the practical source of truth for this planning scope.
+
+## Decision 3: The initial page set should be fixed at the purpose level, not the exact final filenames
+
+**Decision**: Plan against a minimum page set with these purposes: Home, Overview, Getting Started, Usage Guide, Architecture Guide, and Concepts/Glossary. Implementation may refine page titles or split/merge minor sections if each required purpose remains clearly covered.
+
+**Rationale**:
+- The feature needs concrete deliverables for planning and task decomposition.
+- The accepted clarification allows naming flexibility while still requiring complete coverage of the first-scope reader journeys.
+- A purpose-based minimum set keeps the documentation navigable and keeps each page reviewable against a single responsibility.
+
+**Alternatives considered**:
+- **Outcome-only structure**: Rejected because it would leave page ownership ambiguous during implementation.
+- **Fully fixed sitemap with exact titles**: Rejected because it over-constrains wording and implementation details before authors draft the content.
+
+## Decision 4: Provide guided onboarding, not a full tutorial clone of repository quickstarts
+
+**Decision**: The Getting Started and Usage pages should include concise, copyable onboarding guidance and a recommended first path, but should link to repository quickstarts, sample applications, and validation-oriented documents for full end-to-end commands and deep verification.
+
+**Rationale**:
+- This is the best fit for the hybrid-hub model and the user stories around practical usage without excessive duplication.
+- The repo already contains hands-on material, including the sample host and feature quickstarts such as `specs/014-query-package-catalog/quickstart.md`.
+- Concise onboarding helps evaluators and integrators start quickly while keeping complex validation steps in source-controlled technical docs that can evolve with implementation.
+
+**Alternatives considered**:
+- **Conceptual-only onboarding**: Rejected because the wiki would feel too abstract for integrators.
+- **Full end-to-end tutorial inside the wiki**: Rejected because it duplicates volatile commands and sample validation steps that are better maintained in the repository.
+
+## Decision 5: Treat the wiki as a user-facing interface with explicit content contracts
+
+**Decision**: Define contracts for (1) information architecture and audience routing, (2) page content boundaries and required sections, and (3) stability/cross-reference governance.
+
+**Rationale**:
+- The wiki is an external reader interface even though it is documentation rather than code.
+- Content contracts make the implementation reviewable and provide clear acceptance boundaries for a documentation-heavy feature.
+- Separating architecture, page-purpose, and governance concerns matches the constitution’s decomposition discipline.
+
+**Alternatives considered**:
+- **No contracts for documentation features**: Rejected because it weakens reviewability and makes page scope subjective.
+- **A single monolithic documentation contract**: Rejected because it would mix navigation, content, and governance concerns into one artifact.
+
+## Decision 6: Validate the feature through content review, source alignment, and path verification rather than runtime test execution
+
+**Decision**: Validation will focus on manual review of the wiki page set, verification of cross-links and source references, and confirmation that the evaluator, integrator, and contributor paths can be completed from the implemented page set. No new runtime behavior or test suites are required unless implementation introduces tooling for documentation checks.
+
+**Rationale**:
+- This feature changes documentation architecture rather than executable runtime behavior.
+- The relevant evidence is coverage, correctness, cross-reference quality, and alignment with current repository materials.
+- The constitution’s testing discipline is still satisfied by defining explicit review and verification steps for the affected boundary: public documentation contracts.
+
+**Alternatives considered**:
+- **Mandatory automated doc tooling in first scope**: Rejected because the spec does not require new tooling and the repo does not currently establish a wiki-validation toolchain.
+- **No explicit validation flow**: Rejected because documentation drift and incomplete audience paths would be hard to detect.
+

--- a/specs/016-nuplane-github-wiki/spec.md
+++ b/specs/016-nuplane-github-wiki/spec.md
@@ -1,0 +1,154 @@
+# Feature Specification: Nuplane GitHub Wiki
+
+**Feature Branch**: `[016-nuplane-github-wiki]`  
+**Created**: 2026-04-11  
+**Status**: Draft  
+**Input**: User description: "A GitHub wiki about Nuplane, why it exists what you can do with it, how to use it, and how it works architecturally and tecnically."
+
+## Clarifications
+
+### Session 2026-04-11
+
+- Q: Should the GitHub wiki act as a standalone manual, a hybrid hub, or a thin navigation layer? → A: Hybrid hub — self-sufficient for evaluation and onboarding, but summarize deeper technical areas and link to repository docs and samples for detailed validation and evolving reference material.
+- Q: Should the wiki describe only stable releases, only current repository behavior, or current behavior with explicit stability labels? → A: Current behavior with explicit stability labels — describe the current repository behavior, but clearly mark areas that are optional, phase-based, recently changed, or still evolving.
+- Q: Should the initial wiki primarily serve evaluators and integrators only, evaluators and integrators plus architecture-oriented contributors, or function as a full documentation portal? → A: Evaluators and integrators plus architecture-oriented contributors — include product overview, usage guidance, and enough architectural and technical explanation for advanced adopters and contributors to understand the system without making the initial wiki a full maintainer/runbook portal.
+
+### Session 2026-04-12
+
+- Q: Should the specification require a concrete minimum wiki page set now? → A: Yes — require a concrete baseline set of wiki pages while allowing naming and minor structure adjustments during implementation.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Understand Nuplane Quickly (Priority: P1)
+
+As a developer or technical decision-maker discovering Nuplane, I want a clear overview in the GitHub wiki so that I can understand why Nuplane exists, what problem it solves, what it does and does not do, and whether it fits my use case.
+
+**Why this priority**: If readers cannot quickly understand Nuplane's purpose and boundaries, they are unlikely to continue evaluating or adopting it. This is the highest-value outcome of the wiki.
+
+**Independent Test**: Can be fully tested by reviewing the wiki home and overview content and confirming a first-time reader can identify Nuplane's purpose, primary capabilities, non-goals, and intended audience without consulting source code.
+
+**Acceptance Scenarios**:
+
+1. **Given** a reader arriving at the wiki with no prior Nuplane knowledge, **When** they open the landing page, **Then** they can identify why Nuplane exists, the core runtime problem it addresses, and the key difference between Nuplane and a plugin framework.
+2. **Given** a reader evaluating whether Nuplane matches their needs, **When** they review the overview and capability sections, **Then** they can distinguish supported scenarios, optional capabilities, and explicit non-goals.
+
+---
+
+### User Story 2 - Learn How To Use Nuplane (Priority: P2)
+
+As a host integrator, I want task-oriented wiki guidance so that I can understand how to get started, configure Nuplane for common scenarios, and choose the right usage path for metadata-only, loading-enabled, and sample-driven integrations.
+
+**Why this priority**: After understanding the product, the next need is practical adoption guidance. This content supports successful first use and reduces confusion caused by Nuplane's modular design.
+
+**Independent Test**: Can be fully tested by following the wiki's getting-started and usage guidance and confirming a reader can identify the setup path, common workflows, and where to go next for sample-based validation.
+
+**Acceptance Scenarios**:
+
+1. **Given** a host integrator starting with Nuplane, **When** they follow the usage guidance, **Then** they can understand the recommended path from setup to reconciliation to query-first integration.
+2. **Given** a host integrator comparing scenarios, **When** they read the usage guidance, **Then** they can tell when they only need core package reconciliation versus when optional loading-related capabilities are relevant.
+3. **Given** a reader who wants hands-on validation, **When** they consult the usage guidance, **Then** they can find the repository sample, quickstart references, and expected outcomes for a basic end-to-end flow.
+
+---
+
+### User Story 3 - Understand Architecture And Technical Design (Priority: P3)
+
+As a maintainer, advanced adopter, or architect, I want the wiki to explain Nuplane's architecture and technical model so that I can understand the major modules, reconciliation flow, storage and state concepts, operational boundaries, and how the repository is organized.
+
+**Why this priority**: Deeper architecture content is essential for advanced adoption, contributor onboarding, and long-term maintainability, but it is secondary to basic product understanding and initial usage guidance.
+
+**Independent Test**: Can be fully tested by reviewing the architecture and technical reference content and confirming it explains Nuplane's major components, control-loop behavior, optional module boundaries, and repository-to-concept mapping in consistent terminology.
+
+**Acceptance Scenarios**:
+
+1. **Given** an advanced reader exploring Nuplane internals, **When** they open the architecture content, **Then** they can understand the roles of the core runtime, store, feed integration, optional modules, and host-owned boundaries.
+2. **Given** a contributor or architect comparing documentation sources, **When** they review the wiki, **Then** the architectural and technical explanations align with the README, roadmap, and current terminology used across the repository.
+3. **Given** a maintainer or operator looking for exhaustive runbooks or implementation-change logs, **When** they review the wiki scope, **Then** they are directed to repository documentation rather than expecting the initial wiki to serve as a full maintainer portal.
+
+### Edge Cases
+
+- A reader only needs a fast project overview and should not have to read deep technical pages to understand the product's purpose.
+- A reader arrives expecting a plugin framework; the wiki must explicitly explain that Nuplane manages runtime package reconciliation and optional loading infrastructure, not plugin semantics.
+- A host wants metadata-only usage; the wiki must not imply that optional loading is required for all integrations.
+- Architectural explanations must clearly separate core capabilities from optional modules so readers do not misinterpret package ownership or feature availability.
+- The wiki must remain useful even when some details live in repository documents or samples; cross-references should guide readers without forcing them to piece together the main narrative themselves.
+- Terminology used in the wiki must stay consistent with the current repository language for active packages, reconciliation, loading, package catalog, operational state, and host-owned behavior.
+- The wiki may describe optional, phased, or evolving capabilities, but those areas must be clearly labeled so readers can distinguish core current behavior from less-stable or more context-dependent material.
+- The initial wiki must serve evaluators, integrators, and architecture-oriented contributors, but it does not need to become a complete maintainer handbook or operator runbook set in its first scope.
+- The initial wiki must include a concrete minimum page set so implementation planning can define complete deliverables, even if final page names or small structural refinements change during execution.
+
+### Assumptions
+
+- The wiki is intended for external GitHub readers as well as contributors and should serve as the primary long-form project documentation entry point.
+- Existing repository materials such as `README.md`, `docs/roadmap.md`, sample applications, and feature specs remain source material that the wiki should summarize, organize, and cross-reference rather than duplicate blindly.
+- The wiki follows a hybrid-hub model: it is self-sufficient for product evaluation and onboarding, while deeper operational, validation, and fast-evolving technical details remain referenced in repository documents and samples.
+- The wiki treats current repository behavior as canonical, while explicitly labeling optional modules, phase-based capabilities, recently changed surfaces, or evolving areas instead of presenting them as equally stable baseline behavior.
+- The wiki should teach Nuplane progressively: first purpose and scope, then practical usage, then deeper architecture and technical concepts.
+- The initial audience scope includes advanced adopters and contributors who need architectural orientation, but detailed maintainer procedures and operational runbooks remain repository-owned reference material unless a later feature expands the wiki scope.
+- The content should reflect Nuplane's current positioning as host-neutral runtime package reconciliation infrastructure with optional loading capabilities.
+- The feature scope is the documentation experience and information architecture for the wiki, not changes to Nuplane runtime behavior.
+- The first implementation scope includes a baseline page set covering home, overview, getting started, usage, architecture, and concepts/glossary, with room for implementation-time naming refinement as long as those purposes remain covered.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The project MUST provide a GitHub wiki that presents Nuplane as a host-neutral runtime control plane for NuGet packages and clearly explains why the project exists.
+- **FR-002**: The wiki MUST explain the core problem Nuplane solves, the types of hosts or teams that benefit from it, and the primary value it provides for runtime package reconciliation.
+- **FR-003**: The wiki MUST include a clear statement of what Nuplane does and what it explicitly does not do, including the boundary that Nuplane is not a plugin model and does not own host-specific activation semantics.
+- **FR-004**: The wiki MUST describe the main capabilities available in Nuplane today, including package resolution, deterministic local storage, reconciliation, transactional updates, query-first state access, observability, and optional loading-related capabilities.
+- **FR-005**: The wiki MUST describe the most important ways a user can use Nuplane, including at minimum a basic runtime package-management scenario, a local-package or sample-driven scenario, and a loading-enabled scenario for hosts that need it.
+- **FR-006**: The wiki MUST provide a beginner-friendly getting-started path that explains the recommended learning order from overview to setup to first-use validation.
+- **FR-007**: The wiki MUST provide practical usage guidance that helps readers understand configuration-driven and code-driven adoption paths, common workflows, and where sample applications fit into learning and validation.
+- **FR-008**: The wiki MUST explain Nuplane's architecture in a way that identifies the major modules, their responsibilities, the core control loop, and the ownership boundary between core behavior and optional modules.
+- **FR-009**: The wiki MUST explain Nuplane's technical model using current project terminology, including desired state, actual state, feeds, reconciliation, package store, active packages, operational state, observers, and optional loading concepts where relevant.
+- **FR-010**: The wiki MUST present a documentation structure that makes it easy for readers to navigate between overview, concepts, usage guidance, architecture, and deeper technical reference.
+- **FR-010A**: The initial wiki release MUST include a concrete minimum page set covering at least: Home, Overview, Getting Started, Usage Guide, Architecture Guide, and Concepts/Glossary, even if final page titles or minor structural groupings differ during implementation.
+- **FR-011**: The wiki MUST use consistent terminology and narrative alignment with current repository documentation so that readers do not encounter conflicting descriptions across the wiki, `README.md`, roadmap material, samples, or accepted feature specs.
+- **FR-012**: The wiki MUST follow a hybrid-hub documentation model: it remains self-sufficient for evaluation and onboarding, while cross-referencing canonical repository materials for deeper detail, including the README, roadmap, sample applications, and validation-oriented documentation.
+- **FR-013**: The wiki MUST distinguish guidance for readers evaluating Nuplane from guidance for readers actively integrating it, so both audiences can find the right level of detail quickly.
+- **FR-014**: The wiki MUST distinguish guidance for metadata-only or core-runtime usage from guidance that depends on optional loading-related capabilities.
+- **FR-015**: The wiki MUST include an architectural or technical explanation of how repository modules map to user-facing concepts so contributors and advanced adopters can connect documentation to the codebase.
+- **FR-016**: The wiki MUST include a glossary or equivalent concept index for Nuplane-specific terms so readers can interpret documentation consistently.
+- **FR-017**: The wiki MUST provide a maintainable information architecture in which each major page has a clear purpose and avoids duplicating the same explanation across multiple pages without added value.
+- **FR-018**: The wiki MUST keep detailed validation procedures, exhaustive technical change history, and rapidly evolving implementation-specific reference material in repository documentation or samples when duplicating that material into the wiki would increase drift risk without improving onboarding clarity.
+- **FR-019**: The wiki MUST describe current repository behavior as the canonical product state while explicitly labeling content that is optional, phase-based, recently changed, or still evolving.
+- **FR-020**: When the wiki discusses optional modules or non-baseline capabilities, it MUST identify the stability or applicability context clearly enough that a reader can tell whether the capability is core, optional, staged, or still subject to change.
+- **FR-021**: The initial wiki scope MUST prioritize three audience paths: evaluator, integrator, and architecture-oriented contributor; deeper maintainer or operator runbook material MAY be referenced but is not required as first-scope wiki content.
+- **FR-022**: Each required baseline wiki page MUST have one primary purpose in the information architecture so planning and review can verify that all required topics are covered without duplicative page sprawl.
+
+### Operational & Safety Requirements *(mandatory)*
+
+- **OSR-001**: Wiki content MUST remain accurate to the current repository behavior and MUST avoid promising capabilities, integrations, or guarantees that Nuplane does not currently provide.
+- **OSR-002**: The wiki MUST preserve architectural safety boundaries by explaining optional modules, host-owned behavior, and operational concerns without blurring ownership or implying unsupported automation.
+- **OSR-003**: Cross-references to samples, commands, or validation material MUST be specific enough for readers to follow and MUST not rely on unpublished or private knowledge.
+- **OSR-004**: The documentation set MUST be reviewable for drift so maintainers can identify when major changes in capabilities, terminology, or architecture require wiki updates.
+- **OSR-005**: Validation for this feature MUST include content review against the README, roadmap, and representative sample guidance to confirm alignment of purpose, capabilities, module boundaries, and usage narratives.
+- **OSR-006**: The hybrid-hub split between wiki content and repository reference material MUST be explicit enough that maintainers can determine which source should be updated when product messaging, onboarding flow, validation steps, or deep technical details change.
+- **OSR-007**: Stability or applicability labels used in the wiki MUST be consistent and reviewable so that optional, phased, or evolving areas are not described with the same certainty as baseline current behavior.
+- **OSR-008**: Audience targeting in the wiki MUST remain explicit so contributors can find architectural orientation without the initial documentation set being mistaken for a full maintainer or operations manual.
+- **OSR-009**: The required minimum page set MUST be reviewable as a complete onboarding surface, with no mandatory audience path depending on an undefined future wiki page to complete its core journey.
+
+### Key Entities *(include if feature involves data)*
+
+- **Wiki Home Page**: The landing experience that introduces Nuplane, explains its value, and routes readers to the right next page.
+- **Overview Page**: A reader-focused summary of why Nuplane exists, what it does, what it does not do, and who it is for.
+- **Usage Guide**: Task-oriented guidance that helps readers move from understanding to first use.
+- **Architecture Guide**: A structural explanation of Nuplane's modules, ownership boundaries, and control loop.
+- **Technical Concepts Reference**: A concept-focused explanation of Nuplane terms, runtime state, and operational model.
+- **Navigation Model**: The page structure, cross-links, and learning order that connect the wiki into a coherent documentation experience.
+- **Audience Path**: A defined route through the wiki for a specific reader type such as evaluator, integrator, or contributor.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: In documentation review, 100% of the following questions can be answered directly from the wiki without reading source code: why Nuplane exists, what it does, what it does not do, how to get started, and how its main modules fit together.
+- **SC-002**: A first-time reader can identify Nuplane's purpose, primary capabilities, and non-goals from the wiki landing and overview content within 5 minutes.
+- **SC-003**: An integrator following the wiki can locate the recommended getting-started path, at least one sample-based validation path, and the distinction between core usage and optional loading usage within 10 minutes.
+- **SC-004**: In content validation, all major wiki pages align with current repository terminology and produce no unresolved conflicts with the README, roadmap, or representative sample guidance.
+- **SC-005**: The wiki information architecture covers 100% of the required topic areas for this feature: overview, capabilities, non-goals, usage guidance, architecture, technical concepts, navigation, and cross-references.
+- **SC-006**: In review with project stakeholders or maintainers, each major wiki page has a single clearly defined purpose and no critical topic is left without an obvious place in the documentation structure.
+- **SC-007**: In documentation review, 100% of onboarding-critical questions are answerable from the wiki alone, while each deep validation or evolving technical topic referenced from the wiki points to a specific repository document or sample rather than an implied future write-up.
+- **SC-008**: In content review, 100% of wiki sections describing optional, phase-based, recently changed, or evolving capabilities include an explicit stability or applicability label, and no baseline capability is mislabeled as tentative.
+- **SC-009**: In scope review, evaluators, integrators, and architecture-oriented contributors can each identify a clear navigation path from the wiki home, while maintainer-only or runbook topics are clearly treated as referenced repository material rather than missing wiki pages.
+- **SC-010**: Before implementation begins, maintainers can map 100% of required first-scope topics to a baseline wiki page in the minimum page set with no unresolved gap in ownership.

--- a/specs/016-nuplane-github-wiki/spec.md
+++ b/specs/016-nuplane-github-wiki/spec.md
@@ -86,21 +86,30 @@ As a maintainer, advanced adopter, or architect, I want the wiki to explain Nupl
 - The initial audience scope includes advanced adopters and contributors who need architectural orientation, but detailed maintainer procedures and operational runbooks remain repository-owned reference material unless a later feature expands the wiki scope.
 - The content should reflect Nuplane's current positioning as host-neutral runtime package reconciliation infrastructure with optional loading capabilities.
 - The feature scope is the documentation experience and information architecture for the wiki, not changes to Nuplane runtime behavior.
-- The first implementation scope includes a baseline page set covering home, overview, getting started, usage, architecture, and concepts/glossary, with room for implementation-time naming refinement as long as those purposes remain covered.
+- The first implementation scope delivers a repository-owned GitHub wiki source set under `docs/wiki/`, covering home, overview, getting started, usage, architecture, and concepts/glossary, with room for implementation-time naming refinement as long as those purposes remain covered.
+- Publishing or synchronizing that source set into the hosted GitHub wiki is outside the first implementation scope unless a later feature adds an explicit publication workflow.
 
 ## Requirements *(mandatory)*
 
 ### Functional Requirements
 
-- **FR-001**: The project MUST provide a GitHub wiki that presents Nuplane as a host-neutral runtime control plane for NuGet packages and clearly explains why the project exists.
+- **FR-001**: The project MUST provide a repository-owned GitHub wiki source set that presents Nuplane as a host-neutral runtime control plane for NuGet packages and clearly explains why the project exists.
 - **FR-002**: The wiki MUST explain the core problem Nuplane solves, the types of hosts or teams that benefit from it, and the primary value it provides for runtime package reconciliation.
 - **FR-003**: The wiki MUST include a clear statement of what Nuplane does and what it explicitly does not do, including the boundary that Nuplane is not a plugin model and does not own host-specific activation semantics.
-- **FR-004**: The wiki MUST describe the main capabilities available in Nuplane today, including package resolution, deterministic local storage, reconciliation, transactional updates, query-first state access, observability, and optional loading-related capabilities.
-- **FR-005**: The wiki MUST describe the most important ways a user can use Nuplane, including at minimum a basic runtime package-management scenario, a local-package or sample-driven scenario, and a loading-enabled scenario for hosts that need it.
+- **FR-004A**: The wiki MUST describe package resolution as a current Nuplane capability.
+- **FR-004B**: The wiki MUST describe deterministic local storage and transactional updates as current Nuplane capabilities.
+- **FR-004C**: The wiki MUST describe reconciliation and query-first state access as current Nuplane capabilities.
+- **FR-004D**: The wiki MUST describe observability and operational visibility as current Nuplane capabilities.
+- **FR-004E**: The wiki MUST describe optional loading-related capabilities as non-baseline capabilities with clear applicability labeling.
+- **FR-005A**: The wiki MUST describe a basic runtime package-management scenario.
+- **FR-005B**: The wiki MUST describe a local-package or sample-driven scenario.
+- **FR-005C**: The wiki MUST describe a loading-enabled scenario for hosts that need it.
 - **FR-006**: The wiki MUST provide a beginner-friendly getting-started path that explains the recommended learning order from overview to setup to first-use validation.
 - **FR-007**: The wiki MUST provide practical usage guidance that helps readers understand configuration-driven and code-driven adoption paths, common workflows, and where sample applications fit into learning and validation.
 - **FR-008**: The wiki MUST explain Nuplane's architecture in a way that identifies the major modules, their responsibilities, the core control loop, and the ownership boundary between core behavior and optional modules.
-- **FR-009**: The wiki MUST explain Nuplane's technical model using current project terminology, including desired state, actual state, feeds, reconciliation, package store, active packages, operational state, observers, and optional loading concepts where relevant.
+- **FR-009A**: The wiki MUST explain desired state, actual state, feeds, and reconciliation using current project terminology.
+- **FR-009B**: The wiki MUST explain package store, active packages, and operational state using current project terminology.
+- **FR-009C**: The wiki MUST explain observers and optional loading concepts where relevant using current project terminology.
 - **FR-010**: The wiki MUST present a documentation structure that makes it easy for readers to navigate between overview, concepts, usage guidance, architecture, and deeper technical reference.
 - **FR-010A**: The initial wiki release MUST include a concrete minimum page set covering at least: Home, Overview, Getting Started, Usage Guide, Architecture Guide, and Concepts/Glossary, even if final page titles or minor structural groupings differ during implementation.
 - **FR-011**: The wiki MUST use consistent terminology and narrative alignment with current repository documentation so that readers do not encounter conflicting descriptions across the wiki, `README.md`, roadmap material, samples, or accepted feature specs.
@@ -152,3 +161,4 @@ As a maintainer, advanced adopter, or architect, I want the wiki to explain Nupl
 - **SC-008**: In content review, 100% of wiki sections describing optional, phase-based, recently changed, or evolving capabilities include an explicit stability or applicability label, and no baseline capability is mislabeled as tentative.
 - **SC-009**: In scope review, evaluators, integrators, and architecture-oriented contributors can each identify a clear navigation path from the wiki home, while maintainer-only or runbook topics are clearly treated as referenced repository material rather than missing wiki pages.
 - **SC-010**: Before implementation begins, maintainers can map 100% of required first-scope topics to a baseline wiki page in the minimum page set with no unresolved gap in ownership.
+- **SC-011**: Validation evidence for SC-002 and SC-003 MUST record the reviewer persona, timing method, questions asked, and pass/fail result in the feature review artifact so the comprehension targets are auditable.

--- a/specs/016-nuplane-github-wiki/tasks.md
+++ b/specs/016-nuplane-github-wiki/tasks.md
@@ -1,0 +1,204 @@
+# Tasks: Nuplane GitHub Wiki
+
+**Input**: Design documents from `/specs/016-nuplane-github-wiki/`
+**Prerequisites**: `plan.md` (required), `spec.md` (required), `research.md`, `data-model.md`, `contracts/`, `quickstart.md`, `quickstart-validation.md`
+
+**Tests**: No automated runtime test tasks are required for this documentation-only feature. Validation is performed through documentation review, link/path verification, and audience-journey walkthroughs defined in `specs/016-nuplane-github-wiki/quickstart.md`.
+
+**Organization**: Tasks are grouped by user story so the evaluator-facing wiki surface can ship first, onboarding guidance can follow, and architecture/reference content can be added without reopening the product narrative.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel when prerequisites are complete and the task touches a different file
+- **[Story]**: User story label for story-phase tasks only (`[US1]`, `[US2]`, `[US3]`)
+- Every task includes an exact file path
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Create the shared validation and navigation scaffolding for the repository-owned wiki source set.
+
+- [X] T001 Create the feature validation evidence scaffold, including reviewer persona, timing method, question-set, elapsed-time, and pass/fail fields for SC-002 and SC-003 plus a topic-ownership review section, in `specs/016-nuplane-github-wiki/quickstart-validation.md`
+- [X] T002 Create the initial wiki navigation skeleton and baseline page list in `docs/wiki/_Sidebar.md`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Establish shared governance artifacts that every wiki page depends on before story-specific authoring begins.
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete.
+
+- [X] T003 [P] Create the shared stability/applicability legend and repository-owned boundary footer in `docs/wiki/_Footer.md`
+- [X] T004 [P] Create the page-to-source reference map and wiki-vs-repository ownership matrix for `README.md`, `docs/roadmap.md`, samples, and accepted specs in `docs/wiki/_Source-References.md`
+
+**Checkpoint**: Shared navigation, labeling, and source-reference rules exist so each user-story page can be authored against the same documentation contract.
+
+---
+
+## Phase 3: User Story 1 - Understand Nuplane Quickly (Priority: P1) 🎯 MVP
+
+**Goal**: Deliver the landing and overview content that explains why Nuplane exists, what it does, what it does not do, and who should keep reading.
+
+**Independent Test**: Review `docs/wiki/Home.md`, `docs/wiki/Overview.md`, and the repository entry point in `README.md`, then confirm a first-time reader can identify Nuplane’s purpose, core capabilities, non-goals, and plugin-model boundary without reading source code.
+
+### Implementation for User Story 1
+
+- [X] T005 [P] [US1] Author the landing page with Nuplane’s value proposition, audience routes, and wiki scope in `docs/wiki/Home.md`
+- [X] T006 [P] [US1] Author the product overview with problem statement, capabilities, non-goals, and plugin-model boundary in `docs/wiki/Overview.md`
+- [X] T007 [US1] Add a discoverable GitHub wiki entry point for evaluators in `README.md`
+
+**Checkpoint**: Evaluators can discover the wiki and understand Nuplane’s purpose and boundaries from the landing experience alone.
+
+---
+
+## Phase 4: User Story 2 - Learn How To Use Nuplane (Priority: P2)
+
+**Goal**: Provide a practical onboarding path that helps integrators move from first-read understanding to sample-backed first use.
+
+**Independent Test**: Follow the integrator path through `docs/wiki/Getting-Started.md` and `docs/wiki/Usage-Guide.md`, then confirm a reader can identify the recommended setup path, common workflows, and the distinction between core-runtime and optional-loading scenarios.
+
+### Implementation for User Story 2
+
+- [X] T008 [P] [US2] Author the recommended first-use path, minimum mental model, and validation handoff in `docs/wiki/Getting-Started.md`
+- [X] T009 [P] [US2] Author the usage guide for configuration-driven, code-driven, core-runtime, and optional-loading scenarios, including explicit stability/applicability labels for optional or non-baseline content, in `docs/wiki/Usage-Guide.md`
+
+**Checkpoint**: Integrators can understand how to start with Nuplane, when optional loading matters, and where to go for deeper sample-backed validation.
+
+---
+
+## Phase 5: User Story 3 - Understand Architecture And Technical Design (Priority: P3)
+
+**Goal**: Explain Nuplane’s architecture, terminology, and repository-to-concept mapping for contributors and advanced adopters.
+
+**Independent Test**: Review `docs/wiki/Architecture-Guide.md`, `docs/wiki/Concepts-and-Glossary.md`, and the roadmap cross-reference in `docs/roadmap.md`, then confirm a contributor can explain the major modules, control loop, technical vocabulary, and deeper reference boundaries.
+
+### Implementation for User Story 3
+
+- [X] T010 [P] [US3] Author the architecture guide with module map, control loop, ownership boundaries, repository-to-concept mapping, and explicit stability/applicability labels for optional, phase-based, or evolving areas in `docs/wiki/Architecture-Guide.md`
+- [X] T011 [P] [US3] Author the concepts/glossary page with normalized Nuplane terminology and backlinks in `docs/wiki/Concepts-and-Glossary.md`
+- [X] T012 [US3] Add a contributor-oriented wiki cross-reference in `docs/roadmap.md`
+
+**Checkpoint**: Contributors and advanced adopters can understand how Nuplane works architecturally without the wiki becoming a maintainer runbook.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Reconcile navigation, source references, and validation evidence across the complete wiki page set.
+
+- [X] T013 [P] Reconcile the final page-to-source mappings, topic ownership matrix, and drift-review notes in `docs/wiki/_Source-References.md`
+- [X] T014 [P] Update the validation walkthrough with the finalized wiki filenames, timed-review protocol, and ownership-boundary review steps in `specs/016-nuplane-github-wiki/quickstart.md`
+- [X] T015 Capture final audience-path, labeling, timed-review, ownership-boundary, and cross-reference review evidence, including reviewer persona, timing method, question-set, elapsed-time, and pass/fail results, in `specs/016-nuplane-github-wiki/quickstart-validation.md`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 (Setup)**: No dependencies; can start immediately.
+- **Phase 2 (Foundational)**: Depends on Phase 1; blocks all user-story work because it establishes shared wiki governance artifacts.
+- **Phase 3 (US1)**: Depends on Phase 2; delivers the MVP landing and overview experience.
+- **Phase 4 (US2)**: Depends on Phase 2 and benefits from US1 because onboarding guidance should build on the final product narrative.
+- **Phase 5 (US3)**: Depends on Phase 2 and benefits from US1 terminology so architecture content aligns with the finalized positioning language.
+- **Phase 6 (Polish)**: Depends on all implemented user stories.
+
+### User Story Dependencies
+
+- **US1 (P1)**: Starts after Foundational; no dependency on other user stories.
+- **US2 (P2)**: Starts after Foundational; should follow the US1 narrative so the usage guidance reuses the same positioning and terminology.
+- **US3 (P3)**: Starts after Foundational; should follow US1 terminology alignment and can run alongside US2 once the shared governance files exist.
+
+### Within Each User Story
+
+- Shared navigation, labeling, and source-reference artifacts must exist before page authoring begins.
+- Story pages should be written before repository entry-point or roadmap cross-reference updates.
+- Story-specific page content must be complete before final validation evidence is captured.
+- Each story is complete only when its independent test criteria can be satisfied without relying on undefined future pages.
+
+### Suggested Completion Order
+
+1. **Setup** → **Foundational**
+2. **US1** (MVP landing + overview)
+3. **US2** (guided onboarding + usage)
+4. **US3** (architecture + glossary)
+5. **Polish**
+
+---
+
+## Parallel Opportunities
+
+- **Setup**: No meaningful parallel split is needed for this small phase.
+- **Foundational**: `T003` and `T004` can run in parallel after `T002`.
+- **US1**: `T005` and `T006` can run in parallel, then `T007` follows once the landing/overview structure is settled.
+- **US2**: `T008` and `T009` can run in parallel after the shared navigation and labeling files exist.
+- **US3**: `T010` and `T011` can run in parallel, then `T012` follows once the contributor-facing architecture path is finalized.
+- **Polish**: `T013` and `T014` can run in parallel before `T015` captures final review evidence.
+
+### Parallel Example: User Story 1
+
+```bash
+# Draft the evaluator-facing wiki pages in parallel
+T005
+T006
+```
+
+### Parallel Example: User Story 2
+
+```bash
+# Draft the integrator-facing wiki pages in parallel
+T008
+T009
+```
+
+### Parallel Example: User Story 3
+
+```bash
+# Draft the contributor-facing wiki pages in parallel
+T010
+T011
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup.
+2. Complete Phase 2: Foundational.
+3. Complete Phase 3: US1.
+4. Validate that evaluators can discover and understand Nuplane from the wiki without consulting source code.
+5. Stop and confirm the positioning, non-goals, and narrative boundaries before authoring deeper usage or architecture material.
+
+### Incremental Delivery
+
+1. Finish Setup + Foundational to establish the wiki source structure and governance rules.
+2. Ship **US1** as the MVP landing experience.
+3. Add **US2** so integrators get a practical onboarding and usage path.
+4. Add **US3** so contributors and advanced adopters get architecture orientation.
+5. Finish with navigation/source reconciliation and validation evidence.
+
+### Parallel Team Strategy
+
+1. One maintainer sets up the validation scaffold and shared wiki chrome.
+2. After Foundational completion:
+   - Writer A: `Home.md` + `Overview.md`
+   - Writer B: `Getting-Started.md` + `Usage-Guide.md`
+   - Writer C: `Architecture-Guide.md` + `Concepts-and-Glossary.md`
+3. Reconcile shared references and walkthrough evidence together before publishing.
+
+---
+
+## Notes
+
+- `[P]` tasks are safe to parallelize only after their prerequisites are complete and no two tasks edit the same file simultaneously.
+- `[USx]` labels trace each story-phase task back to the feature specification.
+- This plan keeps the wiki self-sufficient for evaluation and onboarding while still routing deeper validation, roadmap, and implementation detail to repository-owned sources.
+- `US1` is the suggested MVP scope.
+- No task creates a maintainer-only runbook page; first-scope depth beyond onboarding and architecture orientation stays in repository docs, samples, and specs.
+
+[US1]: #phase-3-user-story-1---understand-nuplane-quickly-priority-p1--mvp
+[US2]: #phase-4-user-story-2---learn-how-to-use-nuplane-priority-p2
+[US3]: #phase-5-user-story-3---understand-architecture-and-technical-design-priority-p3
+


### PR DESCRIPTION
## Summary
- add a repository-owned wiki source set under `docs/wiki/` for evaluators, integrators, and contributors
- wire the new wiki into `README.md` and `docs/roadmap.md`
- add the full feature spec/plan/tasks/contracts/validation artifacts for `016-nuplane-github-wiki`

## What’s included
- baseline wiki page set: `Home`, `Overview`, `Getting Started`, `Usage Guide`, `Architecture Guide`, and `Concepts and Glossary`
- shared wiki navigation/supporting docs: `_Sidebar.md`, `_Footer.md`, and `_Source-References.md`
- explicit stability/applicability labels and wiki-vs-repository ownership boundaries
- validation evidence in `specs/016-nuplane-github-wiki/quickstart-validation.md`

## Validation
- completed the feature quickstart review and captured the results in `specs/016-nuplane-github-wiki/quickstart-validation.md`
- verified the required wiki page set, audience routes, cross-references, ownership mapping, and timed-review evidence
- checked edited files for diagnostics: no errors reported