### PR TITLE
Fix remote package download base URI handling

### DIFF
--- a/src/Nuplane/Feeds/NuGetRemotePackageAcquirer.cs
+++ b/src/Nuplane/Feeds/NuGetRemotePackageAcquirer.cs
@@ -136,12 +136,20 @@ public sealed class NuGetRemotePackageAcquirer(IOptions<FeedResolutionOptions> o
             var id = idProperty.GetString();
             if (!string.IsNullOrWhiteSpace(id))
             {
-                return new(id, UriKind.Absolute);
+                return EnsureTrailingSlash(new(id, UriKind.Absolute));
             }
         }
 
         throw new InvalidOperationException(
             $"NuGet service index '{serviceIndex}' does not expose a PackageBaseAddress resource.");
+    }
+
+    private static Uri EnsureTrailingSlash(Uri uri)
+    {
+        var value = uri.AbsoluteUri;
+        return value.EndsWith("/", StringComparison.Ordinal)
+            ? uri
+            : new Uri(value + "/", UriKind.Absolute);
     }
 
     private string ResolveInstallRoot() =>

--- a/test/Nuplane.Runtime.Tests/Reconciliation/RemoteFeedDownloadContractTests.cs
+++ b/test/Nuplane.Runtime.Tests/Reconciliation/RemoteFeedDownloadContractTests.cs
@@ -57,6 +57,35 @@ public sealed class RemoteFeedDownloadContractTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task Resolve_RemoteFeed_DownloadsPackageWhenPackageBaseAddressOmitsTrailingSlash()
+    {
+        var packageBytes = NupkgTestBuilder.Create("MyPlugin", "1.0.0").Build();
+        await using var server = new TestNuGetFeedServer(
+            "MyPlugin",
+            "1.0.0",
+            packageBytes,
+            omitPackageBaseTrailingSlash: true);
+
+        var options = new FeedResolutionOptions { PackageInstallRoot = Path.Combine(_tempDir, "installed") };
+        options.Feeds.Add(new("remote-feed", server.ServiceIndexUri));
+        var policy = new FeedResolutionPolicy(new OptionsWrapper<FeedResolutionOptions>(options));
+        var resolver = new MultiFeedPackageResolver(
+            new OptionsWrapper<FeedResolutionOptions>(options), policy,
+            new NuGetRemotePackageAcquirer(new OptionsWrapper<FeedResolutionOptions>(options)),
+            StubVersionEnumerator("1.0.0"),
+            StubVersionRangeEvaluator(),
+            NullLogger<MultiFeedPackageResolver>.Instance);
+
+        var result = await resolver.ResolveAsync(
+            new("MyPlugin", "1.0.0", "remote-feed", PackageUpdatePolicy.Exact, "remote-source"),
+            CancellationToken.None);
+
+        Assert.Equal("remote-feed", result.FeedName);
+        Assert.True(File.Exists(Path.Combine(result.InstallPath, "MyPlugin.nuspec")));
+        Assert.Equal(1, server.PackageDownloads);
+    }
+
+    [Fact]
     public async Task Resolve_RemoteFeed_ReusesExtractedInstallPathOnSubsequentResolve()
     {
         var packageBytes = NupkgTestBuilder.Create("MyPlugin", "1.0.0").Build();
@@ -103,4 +132,3 @@ public sealed class RemoteFeedDownloadContractTests : IAsyncLifetime
         return evaluator;
     }
 }
-

--- a/test/Nuplane.Runtime.Tests/TestSupport/TestNuGetFeedServer.cs
+++ b/test/Nuplane.Runtime.Tests/TestSupport/TestNuGetFeedServer.cs
@@ -12,15 +12,17 @@ internal sealed class TestNuGetFeedServer : IAsyncDisposable
     private readonly string _packageId;
     private readonly string _version;
     private readonly string _baseAddress;
+    private readonly bool _omitPackageBaseTrailingSlash;
 
     public int PackageDownloads { get; private set; }
     public Uri ServiceIndexUri => new(new(_baseAddress), "v3/index.json");
 
-    public TestNuGetFeedServer(string packageId, string version, byte[] packageBytes)
+    public TestNuGetFeedServer(string packageId, string version, byte[] packageBytes, bool omitPackageBaseTrailingSlash = false)
     {
         _packageId = packageId ?? throw new ArgumentNullException(nameof(packageId));
         _version = version ?? throw new ArgumentNullException(nameof(version));
         _packageBytes = packageBytes ?? throw new ArgumentNullException(nameof(packageBytes));
+        _omitPackageBaseTrailingSlash = omitPackageBaseTrailingSlash;
 
         var prefix = $"http://127.0.0.1:{GetFreePort()}/";
         _baseAddress = prefix;
@@ -76,6 +78,9 @@ internal sealed class TestNuGetFeedServer : IAsyncDisposable
         var lowerPackageId = _packageId.ToLowerInvariant();
         var lowerVersion = _version.ToLowerInvariant();
         var lowerNupkgName = $"{lowerPackageId}.{lowerVersion}.nupkg";
+        var packageBaseAddress = _omitPackageBaseTrailingSlash
+            ? $"{_baseAddress}flatcontainer"
+            : $"{_baseAddress}flatcontainer/";
 
         if (requestPath.Equals("/v3/index.json", StringComparison.OrdinalIgnoreCase))
         {
@@ -84,7 +89,7 @@ internal sealed class TestNuGetFeedServer : IAsyncDisposable
                   "version": "3.0.0",
                   "resources": [
                     {
-                      "@id": "{{_baseAddress}}flatcontainer/",
+                      "@id": "{{packageBaseAddress}}",
                       "@type": "PackageBaseAddress/3.0.0"
                     }
                   ]
@@ -142,4 +147,3 @@ internal sealed class TestNuGetFeedServer : IAsyncDisposable
         }
     }
 }
-


### PR DESCRIPTION
## Summary
- normalize NuGet PackageBaseAddress resources to include a trailing slash before composing flat-container package URLs
- add a regression case for feeds that return PackageBaseAddress without a trailing slash

## Test Plan
- dotnet test test/Nuplane.Runtime.Tests/Nuplane.Runtime.Tests.csproj