### PR TITLE
Add host-integrated package loading

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,8 @@ Run focused tests first for the area changed, then run the full solution when pr
 ## Active Technologies
 - C# with SDK-style .NET libraries targeting `net8.0;net9.0;net10.0`; tests target `net10.0` + Microsoft.Extensions.DependencyInjection/Options/Logging/Hosting, NuGet.Protocol and NuGet.Versioning already used by feed version resolution, System.Runtime.Loader, xUnit, NSubstitute (017-dependency-closure-loading)
 - File-backed Nuplane store state and package install directories under configured state/package roots; no database (017-dependency-closure-loading)
+- C# with SDK-style .NET libraries targeting `net8.0;net9.0;net10.0`; tests target `net10.0` + Microsoft.Extensions.DependencyInjection, Microsoft.Extensions.Options, Microsoft.Extensions.Logging, System.Runtime.Loader, NuGet.Versioning/NuGet.Protocol via existing runtime resolution surfaces, xUnit, NSubstitute (018-host-integrated-loading)
+- Existing file-backed Nuplane package store and active package state; no database changes (018-host-integrated-loading)
 
 ## Recent Changes
 - 017-dependency-closure-loading: Added C# with SDK-style .NET libraries targeting `net8.0;net9.0;net10.0`; tests target `net10.0` + Microsoft.Extensions.DependencyInjection/Options/Logging/Hosting, NuGet.Protocol and NuGet.Versioning already used by feed version resolution, System.Runtime.Loader, xUnit, NSubstitute

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,10 +76,10 @@ Run focused tests first for the area changed, then run the full solution when pr
 - Prefer small, reviewable changes that match existing project patterns.
 
 ## Active Technologies
-- C# with SDK-style .NET libraries targeting `net8.0;net9.0;net10.0`; tests target `net10.0` + Microsoft.Extensions.DependencyInjection/Options/Logging/Hosting, NuGet.Protocol and NuGet.Versioning already used by feed version resolution, System.Runtime.Loader, xUnit, NSubstitute (017-dependency-closure-loading)
-- File-backed Nuplane store state and package install directories under configured state/package roots; no database (017-dependency-closure-loading)
-- C# with SDK-style .NET libraries targeting `net8.0;net9.0;net10.0`; tests target `net10.0` + Microsoft.Extensions.DependencyInjection, Microsoft.Extensions.Options, Microsoft.Extensions.Logging, System.Runtime.Loader, NuGet.Versioning/NuGet.Protocol via existing runtime resolution surfaces, xUnit, NSubstitute (018-host-integrated-loading)
-- Existing file-backed Nuplane package store and active package state; no database changes (018-host-integrated-loading)
+- C# with SDK-style .NET libraries targeting `net8.0;net9.0;net10.0`; tests target `net10.0`.
+- Microsoft.Extensions.DependencyInjection/Options/Logging/Hosting, NuGet.Protocol, NuGet.Versioning, System.Runtime.Loader, xUnit, and NSubstitute.
+- File-backed Nuplane store state and package install directories under configured state/package roots; no database.
 
 ## Recent Changes
 - 017-dependency-closure-loading: Added C# with SDK-style .NET libraries targeting `net8.0;net9.0;net10.0`; tests target `net10.0` + Microsoft.Extensions.DependencyInjection/Options/Logging/Hosting, NuGet.Protocol and NuGet.Versioning already used by feed version resolution, System.Runtime.Loader, xUnit, NSubstitute
+- 018-host-integrated-loading: Added host-integrated package loading using non-collectible assembly load contexts and framework-visible resolution catalog metadata.

--- a/README.md
+++ b/README.md
@@ -139,8 +139,14 @@ Nuplane emits events such as package-change completion or package-loading comple
 
 ### Optional loading
 
-An opt-in subsystem that loads resolved packages into isolated assembly load contexts.
-Nuplane can manage shared contract assemblies, deactivation timeout, and unload coordination, but your host still decides what to do with loaded types.
+An opt-in subsystem that loads resolved packages into assembly load contexts.
+Nuplane supports two package load modes:
+
+- `Collectible` is the default mode for isolated or scan-only plugin scenarios where package assemblies should remain unloadable when references drain.
+- `HostIntegrated` is for packages that contribute application-lifetime framework types such as DI registrations, endpoints, hosted services, options, validators, or database migrations.
+
+Shared assemblies remain a separate policy: they solve contract/type identity by resolving selected abstractions from the host/default context, but they do not by themselves make package assemblies framework-integrated or resolvable by name.
+Nuplane can manage shared contract assemblies, deactivation timeout, unload coordination for collectible packages, and host-integrated assembly-name resolution, but your host still decides what loaded types mean.
 
 ### Module registration
 
@@ -207,6 +213,13 @@ builder.Services.AddNuplane(nuplaneConfiguration, nuplane =>
     },
     "Loading": {
       "Enabled": true,
+      "DefaultLoadMode": "Collectible",
+      "PackageLoadModes": [
+        {
+          "PackageId": "Elsa.Persistence.EFCore.PostgreSql",
+          "LoadMode": "HostIntegrated"
+        }
+      ],
       "SharedAssemblies": [
         {
           "Name": "Nuplane.Abstractions",
@@ -271,6 +284,8 @@ Nuplane has two configuration layers:
   - `Enabled`
   - `DeactivationTimeout`
   - `ActiveStoreRoot`
+  - `DefaultLoadMode`
+  - `PackageLoadModes`
   - `SharedAssemblies`
 
 For unrestricted feeds, prefer one of these explicit forms:

--- a/docs/wiki/Concepts-and-Glossary.md
+++ b/docs/wiki/Concepts-and-Glossary.md
@@ -93,6 +93,23 @@ A higher-level loading-aware surface for hosts that want the currently active lo
 - Applied in: [Usage Guide](Usage-Guide.md)
 - Canonical anchors: `README.md`, `src/Nuplane.Loading.Abstractions/IPackageAssemblyCatalog.cs`
 
+### Package load mode
+
+The loading setting that controls package assembly lifetime and framework integration behavior.
+`Collectible` keeps the existing unloadable/isolation-oriented behavior, while `HostIntegrated` makes active package assemblies safe for application-lifetime framework integration and by-name resolution.
+
+- **Applicability:** `Optional Module`
+- Applied in: [Usage Guide](Usage-Guide.md)
+- Canonical anchors: `README.md`, `src/Nuplane.Loading.Abstractions/PackageLoadMode.cs`
+
+### Host-integrated assembly
+
+An active package assembly loaded in `HostIntegrated` mode so framework code can safely hold references to it and resolve it by assembly name without host-owned resolver plumbing.
+
+- **Applicability:** `Optional Module`
+- Applied in: [Usage Guide](Usage-Guide.md)
+- Canonical anchors: `README.md`, `src/Nuplane.Loading/HostIntegratedAssemblyResolver.cs`
+
 ## Documentation-governance terms
 
 ### Hybrid hub
@@ -117,4 +134,3 @@ A visible label that tells the reader whether a capability is `Core`, `Optional 
 - [Usage Guide](Usage-Guide.md)
 - [Architecture Guide](Architecture-Guide.md)
 - [Source References](_Source-References.md)
-

--- a/docs/wiki/Usage-Guide.md
+++ b/docs/wiki/Usage-Guide.md
@@ -104,6 +104,13 @@ The sample `Program.cs` is the best concrete repository anchor for this path.
 - The loading module is opt-in, and it does not change the rule that the host owns plugin or activation semantics.
 - If the loading module is absent or disabled, that is still a valid Nuplane integration.
 
+#### Choosing a package load mode
+
+- Use `Collectible` for isolated plugin discovery, scan-only packages, and scenarios where unloadability matters. It is the default to preserve existing loading behavior.
+- Use `HostIntegrated` for packages that contribute application-lifetime framework types such as DI registrations, endpoints, hosted services, options, validators, or database migrations. Host-integrated package assemblies may remain loaded for the process lifetime.
+- Configure shared assemblies separately from load mode. Shared assemblies preserve contract/type identity; load mode controls package lifetime and whether active package assemblies are made visible to framework by-name resolution.
+- Prefer explicit default and package-specific load mode configuration over auto-detection.
+
 ## Sample-backed next steps
 
 For the maintained end-to-end walkthrough, use:
@@ -138,4 +145,3 @@ For those topics, continue to repository-owned sources.
 - [`samples/Nuplane.Sample.AspNetCore/Program.cs`](../../samples/Nuplane.Sample.AspNetCore/Program.cs)
 - [`samples/Nuplane.Sample.AspNetCore/appsettings.json`](../../samples/Nuplane.Sample.AspNetCore/appsettings.json)
 - [`specs/014-query-package-catalog/quickstart.md`](../../specs/014-query-package-catalog/quickstart.md)
-

--- a/specs/018-host-integrated-loading/checklists/requirements.md
+++ b/specs/018-host-integrated-loading/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Host-Integrated Package Loading
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-09
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Validation passed after clarification. Former open questions are resolved in the spec's Clarifications section.

--- a/specs/018-host-integrated-loading/contracts/host-integrated-loading-contract.md
+++ b/specs/018-host-integrated-loading/contracts/host-integrated-loading-contract.md
@@ -1,0 +1,52 @@
+# Contract: Host-Integrated Package Loading
+
+## Scope
+
+This contract defines the expected behavior for package load mode configuration, package assembly catalog metadata, and Nuplane-owned assembly-name resolution for host-integrated packages.
+
+## Configuration Contract
+
+1. Loading configuration MUST support a default package load mode.
+2. The default load mode MUST accept `Collectible` and `HostIntegrated`.
+3. The default load mode MUST remain `Collectible` when not explicitly configured.
+4. Loading configuration MUST support package-specific load mode overrides when package-level configuration is available.
+5. Package-specific overrides MUST take precedence over the default load mode.
+6. Invalid load mode values MUST fail options validation before loading begins.
+7. Duplicate package overrides for the same package ID MUST fail options validation.
+8. Shared assembly policy MUST remain configured separately from load mode.
+
+## Loading Contract
+
+1. `Collectible` mode MUST preserve existing collectible package load behavior.
+2. `HostIntegrated` mode MUST load package assemblies so returned assemblies are safe for non-collectible host/framework code.
+3. Host-integrated loading MUST keep dependency graph resolution consistent with the resolved package graph.
+4. Host-integrated activation MUST fail before visibility publication when active host-integrated packages expose different versions of the same assembly simple name.
+5. Failed host-integrated activation MUST preserve last-known-good package and assembly resolution visibility.
+6. Host applications MUST NOT be required to register custom assembly load context or assembly resolving handlers for intended host-integrated packages.
+
+## Catalog Contract
+
+1. The existing package assembly catalog MUST remain the canonical host-facing package assembly discovery surface.
+2. Catalog results MUST include the effective load mode for each active package entry.
+3. Catalog results MUST indicate whether each entry is safe for framework integration.
+4. Host-integrated package entries MUST be marked framework-integration safe.
+5. Collectible package entries MUST not be marked framework-integration safe.
+6. Existing package-grouped deterministic ordering MUST be preserved.
+
+## Assembly Resolution Contract
+
+1. Nuplane MUST maintain active resolution entries for host-integrated package assemblies.
+2. Framework by-name assembly resolution MUST succeed when the requested identity uniquely matches an active host-integrated package assembly.
+3. Resolution by full name MUST honor the requested version and identity.
+4. Resolution by simple name MUST fail deterministically when multiple active host-integrated versions could match.
+5. Resolution failures MUST emit structured diagnostics for not found, ambiguity, conflict, and inactive package state.
+6. Replacement visibility MUST switch to a new generation only after package activation and visibility setup complete successfully.
+7. If replacement activation or visibility setup fails, the previous last-known-good resolution generation MUST remain active.
+
+## Observability Contract
+
+1. Loading logs MUST include selected load mode, package identity, package version, graph key, and selection reason.
+2. Host-integrated resolution logs MUST include requested assembly identity, outcome, selected package identity, and selected assembly path when successful.
+3. Conflict logs MUST include conflicting package identities and assembly versions.
+4. Metrics or operational state MUST expose host-integrated load success/failure and resolution failure counts where the loading module already reports loading health.
+5. Diagnostics MUST not log secrets, credentials, or full exception stack traces at Information level.

--- a/specs/018-host-integrated-loading/data-model.md
+++ b/specs/018-host-integrated-loading/data-model.md
@@ -1,0 +1,126 @@
+# Data Model: Host-Integrated Package Loading
+
+## PackageLoadMode
+
+Represents the configured package assembly lifetime and framework integration behavior.
+
+**Fields**:
+- `Collectible`: Existing unloadable/isolation-oriented mode for isolated or scan-only package scenarios.
+- `HostIntegrated`: Application-lifetime framework integration mode for packages whose assemblies must be safe for host/framework code and visible to by-name assembly resolution.
+
+**Validation rules**:
+- Values must be one of the supported modes.
+- Missing values use the configured default mode.
+- Existing default remains `Collectible` unless explicitly changed.
+
+## LoadingOptions
+
+Represents module-level package loading configuration.
+
+**Fields**:
+- `Enabled`: Existing loading enablement flag.
+- `DeactivationTimeout`: Existing collectible-context deactivation timeout.
+- `ActiveStoreRoot`: Existing active store root validation boundary.
+- `SharedAssemblies`: Existing shared assembly policy entries.
+- `DefaultLoadMode`: New default mode for autoloaded packages.
+- `Packages`: Optional package-specific load mode overrides keyed by package identity.
+
+**Validation rules**:
+- `DefaultLoadMode` must be supported.
+- Package override identifiers must be non-empty and unique case-insensitively.
+- Package override load modes must be supported.
+- Shared assembly validation remains independent from load mode validation.
+
+## PackageLoadModeOverride
+
+Represents load mode configuration for one package.
+
+**Fields**:
+- `PackageId`: Package identifier to match against resolved package identity.
+- `LoadMode`: Mode applied to that package when it is autoloaded.
+
+**Relationships**:
+- Belongs to `LoadingOptions`.
+- Overrides `LoadingOptions.DefaultLoadMode` for matching package identities.
+
+**Validation rules**:
+- `PackageId` must be non-empty.
+- At most one override may exist for a package ID using case-insensitive comparison.
+- `LoadMode` must be supported.
+
+## PackageLoadModeSelection
+
+Represents the resolved load mode decision for a package during a reconciliation cycle.
+
+**Fields**:
+- `PackageId`: Package identity.
+- `Version`: Resolved package version.
+- `LoadMode`: Effective mode after applying default and package-specific overrides.
+- `SelectionReason`: Whether the mode came from a default or package override.
+- `GraphKey`: Active package graph key when the package is loaded with its dependency graph.
+
+**Relationships**:
+- Consumed by `PackageLoader` when creating load contexts.
+- Recorded in load state and package assembly catalog metadata.
+
+**Validation rules**:
+- Selection is deterministic for the same package set and configuration.
+- Package override wins over default mode.
+
+## HostIntegratedAssemblyResolutionEntry
+
+Represents a framework-visible mapping from assembly identity to an active host-integrated package assembly.
+
+**Fields**:
+- `AssemblySimpleName`: Simple assembly name.
+- `AssemblyFullName`: Full assembly identity when available.
+- `Version`: Assembly version.
+- `AssemblyPath`: Durable path for the loaded assembly.
+- `PackageId`: Owning package identifier.
+- `PackageVersion`: Owning package version.
+- `GraphKey`: Owning graph key.
+- `Generation`: Active visibility generation.
+
+**Relationships**:
+- Created only for active host-integrated package assemblies.
+- Used by the Nuplane-owned assembly resolution bridge.
+- Referenced by diagnostics for success, conflict, ambiguity, and failure.
+
+**Validation rules**:
+- Active entries must not contain conflicting versions for the same simple name.
+- Replacement entries become visible only after successful activation and visibility setup.
+- Last-known-good entries remain active if replacement setup fails.
+
+## PackageAssemblies Metadata
+
+Represents catalog-visible metadata attached to active package assemblies.
+
+**Fields**:
+- `PackageId`: Existing package identifier.
+- `Version`: Existing active package version.
+- `Assemblies`: Existing loaded assembly instances.
+- `AssemblyReferences`: Existing durable assembly references.
+- `LoadMode`: Effective load mode for the package.
+- `FrameworkIntegrationSafe`: Whether returned assemblies are safe for non-collectible host/framework code.
+
+**Validation rules**:
+- `FrameworkIntegrationSafe` is true for host-integrated package assemblies.
+- `FrameworkIntegrationSafe` is false for collectible package assemblies.
+- Metadata must match the effective load mode recorded for the active load session.
+
+## ResolutionDiagnostic
+
+Represents the observable outcome of a host-integrated assembly resolution decision.
+
+**Fields**:
+- `CorrelationId`: Reconciliation or loading cycle correlation identifier when available.
+- `RequestedAssemblyName`: Assembly identity requested by framework code.
+- `Outcome`: Success, not found, conflict, ambiguity, or inactive.
+- `SelectedAssemblyPath`: Selected assembly path for successful resolution.
+- `CandidateAssemblies`: Candidate identities considered for ambiguous or conflicting requests.
+- `Message`: Actionable diagnostic text.
+
+**Validation rules**:
+- Failure diagnostics must identify the requested assembly name.
+- Conflict diagnostics must identify the conflicting packages and assembly versions.
+- Diagnostics must not include secrets or credentials.

--- a/specs/018-host-integrated-loading/plan.md
+++ b/specs/018-host-integrated-loading/plan.md
@@ -1,0 +1,136 @@
+# Implementation Plan: Host-Integrated Package Loading
+
+**Branch**: `018-host-integrated-loading` | **Date**: 2026-05-09 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/018-host-integrated-loading/spec.md`
+
+## Summary
+
+Add an explicit host-integrated package load mode to Nuplane's loading module while preserving the current collectible default. The technical approach extends loading options and validation with load mode selection, records effective mode metadata in load sessions/catalog results, adds host-integrated non-collectible loading with a Nuplane-owned assembly-name resolution bridge, rejects conflicting host-integrated assembly identities before visibility publication, and documents configuration plus lifecycle tradeoffs.
+
+## Technical Context
+
+**Language/Version**: C# with SDK-style .NET libraries targeting `net8.0;net9.0;net10.0`; tests target `net10.0`  
+**Primary Dependencies**: Microsoft.Extensions.DependencyInjection, Microsoft.Extensions.Options, Microsoft.Extensions.Logging, System.Runtime.Loader, NuGet.Versioning/NuGet.Protocol via existing runtime resolution surfaces, xUnit, NSubstitute  
+**Storage**: Existing file-backed Nuplane package store and active package state; no database changes  
+**Testing**: xUnit via `dotnet test`, focused first on `test/Nuplane.Loading.Tests/Nuplane.Loading.Tests.csproj`  
+**Target Platform**: .NET host applications supported by current Nuplane multi-targeted libraries  
+**Project Type**: Infrastructure/library modules with public abstractions, loading implementation, and documentation  
+**Performance Goals**: Host-integrated resolution lookup is deterministic and bounded by active host-integrated assembly entries; no package graph re-resolution during framework assembly resolution  
+**Constraints**: Preserve current collectible default; keep `Nuplane.Runtime` dependency-lean; do not add host-specific framework dependencies; public/protected APIs require XML documentation; options validation uses `IValidateOptions<T>` and `ValidateOnStart()`  
+**Scale/Scope**: Active package graph sizes remain bounded by existing reconciliation/loading behavior; resolution tables cover active host-integrated package assemblies only
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- Deterministic reconciliation: PASS — load mode selection is deterministic from package identity plus configuration; host-integrated conflict checks fail activation before visibility publication.
+- Transactional store safety: PASS — package store state remains staged/validated/published by existing flows; host-integrated visibility follows LKG fallback and switches only after successful activation.
+- Source integrity: PASS — source trust, package identity validation, and integrity checks remain before loading; no new package source or credential path is introduced.
+- Observability: PASS — plan requires structured diagnostics for selected load mode, assembly identity, graph key, resolution outcome, conflicts, and failures.
+- Test discipline: PASS — affected loading contracts, options validation, catalog metadata, resolution bridge, conflict handling, and LKG replacement require unit/boundary tests.
+- Decomposition discipline: PASS — design separates options/selection, loader mechanics, resolver visibility, catalog metadata, observability, docs, and tests into distinct artifacts for task generation.
+- Options validation discipline: PASS — new load mode configuration is validated through loading options validators and startup fail-fast registration.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/018-host-integrated-loading/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── host-integrated-loading-contract.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+src/
+├── Nuplane.Loading.Abstractions/
+│   ├── IPackageAssemblyCatalog.cs
+│   ├── PackageAssemblyReference.cs
+│   └── PackageLoadMode.cs
+├── Nuplane.Loading/
+│   ├── LoadingOptions.cs
+│   ├── LoadingOptionsValidator.cs
+│   ├── PackageLoader.cs
+│   ├── PackageGraphLoadContext.cs
+│   ├── PackageAssemblyLoadContext.cs
+│   ├── HostIntegratedAssemblyResolutionCatalog.cs
+│   ├── HostIntegratedAssemblyResolver.cs
+│   ├── PackageAssemblyCatalog.cs
+│   ├── PackageAssemblyProvider.cs
+│   └── Registration/LoadingRegistrationServices.cs
+├── Nuplane.Loading/Builder/
+│   ├── NuplaneLoadingBuilder.cs
+│   └── NuplaneBuilderLoadingExtensions.cs
+
+test/
+├── Nuplane.Loading.Tests/
+│   ├── LoadingOptionsValidatorTests.cs
+│   ├── PackageLoaderHostIntegratedTests.cs
+│   ├── HostIntegratedAssemblyResolverTests.cs
+│   ├── PackageAssemblyCatalogHostIntegratedTests.cs
+│   ├── PackageAutoLoadingObserverTests.cs
+│   └── LoadingRegistrationDeterminismTests.cs
+└── Nuplane.Loading.Tests.Fixtures/
+    └── host-integrated fixture assemblies as needed
+
+docs/
+├── wiki/Usage-Guide.md
+└── wiki/Concepts-and-Glossary.md
+
+README.md
+```
+
+**Structure Decision**: Implement the feature inside the existing loading module and loading abstractions because load mode, assembly catalog metadata, and assembly resolution visibility are owned by Nuplane loading. Documentation updates are limited to existing README/wiki loading guidance. No new host-specific framework package is added.
+
+## Complexity Tracking
+
+No constitution violations or complexity exceptions are required.
+
+## Phase 0: Research
+
+Research is complete in [research.md](./research.md). Key decisions:
+
+- Preserve `Collectible` as the default load mode.
+- Introduce explicit `PackageLoadMode` values for `Collectible` and `HostIntegrated`.
+- Extend the existing package assembly catalog with load mode and framework-safety metadata.
+- Reject host-integrated activation on conflicting assembly simple names with different versions.
+- Apply last-known-good fallback to replacement visibility.
+- Use a Nuplane-owned default-context resolving bridge for host-integrated by-name resolution.
+- Keep source trust and package graph resolution unchanged before load mode behavior.
+- Keep options validation in the loading options pipeline.
+
+## Phase 1: Design & Contracts
+
+Design artifacts are complete:
+
+- Data model: [data-model.md](./data-model.md)
+- Contract: [contracts/host-integrated-loading-contract.md](./contracts/host-integrated-loading-contract.md)
+- Quickstart validation: [quickstart.md](./quickstart.md)
+
+### Design Summary
+
+- Loading options gain a default load mode and package-specific overrides.
+- A load mode selector resolves the effective mode deterministically for each package.
+- Collectible package loading remains the existing path.
+- Host-integrated package loading uses non-collectible framework-safe assembly exposure and publishes resolution entries only after successful activation.
+- Host-integrated conflict detection rejects active graphs that would expose multiple versions for the same assembly simple name.
+- The package assembly catalog exposes effective load mode and framework-safety metadata in its returned package entries.
+- A module-owned resolver handles framework by-name resolution for active host-integrated entries so hosts do not write custom resolver code.
+- Replacement visibility uses last-known-good semantics if activation or visibility setup fails.
+
+## Post-Design Constitution Check
+
+- Deterministic reconciliation: PASS — data model defines deterministic mode selection and resolution entries; contract requires fail-fast conflict handling.
+- Transactional store safety: PASS — contract requires visibility publication only after successful activation and LKG visibility fallback on replacement failure.
+- Source integrity: PASS — design explicitly leaves source trust and package integrity checks unchanged before any load mode behavior.
+- Observability: PASS — contract specifies logs/diagnostics for load mode selection, resolution outcomes, conflicts, and failures.
+- Test discipline: PASS — quickstart and contract identify focused tests for options validation, loader behavior, resolver behavior, catalog metadata, conflict handling, and LKG fallback.
+- Decomposition discipline: PASS — planned artifacts map to discrete option, loader, resolver, catalog, registration, documentation, and test concerns.
+- Options validation discipline: PASS — options remain data-only and load mode validation stays in `IValidateOptions<LoadingOptions>` with existing `ValidateOnStart()` registration.

--- a/specs/018-host-integrated-loading/quickstart.md
+++ b/specs/018-host-integrated-loading/quickstart.md
@@ -1,0 +1,76 @@
+# Quickstart: Host-Integrated Package Loading
+
+## Purpose
+
+Use this quickstart to validate host-integrated loading behavior during implementation. It focuses on observable outcomes, not implementation internals.
+
+## Scenario 1: Default host-integrated loading
+
+1. Configure Nuplane loading as enabled.
+2. Set the loading default mode to `HostIntegrated`.
+3. Configure shared assemblies for host/plugin contracts separately from load mode.
+4. Add a package that contributes framework-discoverable types.
+5. Run reconciliation and wait for loading completion.
+6. Query the package assembly catalog.
+7. Verify the package entry reports `HostIntegrated` and framework-integration safe metadata.
+8. Verify host/framework code can discover and activate the contributed types without custom assembly resolving code.
+
+## Scenario 2: Package-specific override
+
+1. Configure the loading default mode as `Collectible`.
+2. Add a package-specific override setting one package to `HostIntegrated`.
+3. Add one isolated plugin package without an override.
+4. Run reconciliation and wait for loading completion.
+5. Verify the overridden package is host-integrated and framework-integration safe.
+6. Verify the isolated package remains collectible and is not marked framework-integration safe.
+
+## Scenario 3: Assembly-name resolution
+
+1. Load a host-integrated package that contains a known assembly identity.
+2. Request the assembly by full name from framework-style code.
+3. Verify the expected active package assembly is returned.
+4. Request the assembly by simple name when exactly one active host-integrated assembly matches.
+5. Verify the expected active package assembly is returned.
+6. Review logs or operational state to confirm resolution diagnostics include request identity, selected package, and selected path.
+
+## Scenario 4: Conflict handling
+
+1. Prepare two host-integrated package graphs that expose different versions of the same assembly simple name.
+2. Reconcile both packages into the desired active set.
+3. Verify activation fails deterministically before conflicting visibility is published.
+4. Verify diagnostics identify the assembly simple name, versions, and owning packages.
+5. Verify last-known-good active visibility remains unchanged when one exists.
+
+## Scenario 5: Replacement fallback
+
+1. Start with a successfully active host-integrated package version.
+2. Reconcile a replacement version that fails during activation or visibility setup.
+3. Verify the replacement is not made visible to assembly-name resolution.
+4. Verify the prior last-known-good assembly resolution entries remain active.
+5. Verify diagnostics identify the replacement failure stage.
+
+## Scenario 6: Invalid configuration
+
+1. Configure an unsupported default load mode value.
+2. Start the host.
+3. Verify options validation fails before package loading begins.
+4. Repeat with duplicate package-specific overrides for the same package ID.
+5. Verify validation reports duplicate override diagnostics.
+
+## Required validation commands
+
+Run focused tests first, then broader validation when practical:
+
+```bash
+dotnet test test/Nuplane.Loading.Tests/Nuplane.Loading.Tests.csproj
+dotnet test nuplane.sln
+```
+
+## Documentation validation
+
+Update the loading section in the README or wiki to explain:
+
+- When to choose `Collectible`.
+- When to choose `HostIntegrated`.
+- Why shared assemblies solve type identity but do not replace load mode.
+- Why host-integrated packages may remain loaded for the process lifetime.

--- a/specs/018-host-integrated-loading/research.md
+++ b/specs/018-host-integrated-loading/research.md
@@ -1,0 +1,67 @@
+# Research: Host-Integrated Package Loading
+
+## Decision: Keep collectible as the default load mode
+
+**Rationale**: Existing consumers currently expect loaded package assemblies to come from collectible package contexts. Preserving that default avoids silent lifetime and isolation changes, keeps backward compatibility, and requires hosts to opt into the broader visibility and longer lifetime of host-integrated loading.
+
+**Alternatives considered**:
+- Make host-integrated the default when loading is enabled: rejected because it changes current unloadability/isolation semantics.
+- Auto-detect framework-integrated packages: rejected because framework participation is ambiguous and could surprise hosts.
+
+## Decision: Add an explicit `PackageLoadMode` model with `Collectible` and `HostIntegrated`
+
+**Rationale**: Shared assembly policy, package lifetime, and resolution visibility are independent decisions. A dedicated load mode makes lifetime and resolution behavior explicit without overloading shared assembly configuration.
+
+**Alternatives considered**:
+- Reuse shared assembly policy to imply host integration: rejected because shared assemblies solve contract identity only.
+- Add boolean flags such as `UseDefaultContext`: rejected because load behavior is a closed set that should validate deterministically and leave room for future modes.
+
+## Decision: Extend the existing package assembly catalog with load-mode and framework-safety metadata
+
+**Rationale**: The current package assembly catalog is already the host-facing discovery surface for active loaded assemblies. Extending its returned models with load mode and framework-safety metadata keeps discovery cohesive while making host-integrated safety explicit.
+
+**Alternatives considered**:
+- Add a separate host-integrated catalog: rejected because consumers would need to choose between overlapping discovery surfaces.
+- Keep the catalog unchanged and add only a resolver service: rejected because callers also need to know whether returned assemblies are safe for framework integration.
+
+## Decision: Reject host-integrated activation on conflicting assembly simple names with different versions
+
+**Rationale**: Framework assembly resolution by simple name must not bind arbitrarily. Failing activation before the package graph becomes visible preserves deterministic reconciliation and avoids hidden runtime binding drift.
+
+**Alternatives considered**:
+- Defer conflict failure until resolution is requested: rejected because activation could appear healthy while later framework operations fail.
+- Prefer highest version: rejected because it can mask incompatibilities and violate package graph intent.
+- Prefer last-known-good version: rejected for initial activation conflicts because it can hide the new desired state failure.
+
+## Decision: Apply last-known-good fallback to host-integrated replacement visibility
+
+**Rationale**: Nuplane already preserves last-known-good state for failed updates. Host-integrated assembly visibility must follow the same safety rule: replacement mappings become visible only after successful activation and visibility setup; otherwise the previous visible mapping remains active.
+
+**Alternatives considered**:
+- Require process restart for every replacement: rejected because it blocks Nuplane's runtime update value for compatible host-integrated replacements.
+- Switch visibility immediately after package install: rejected because framework code could observe a package before load and conflict checks complete.
+- Block all replacement of host-integrated packages: rejected because it is too restrictive for package updates that remain deterministic and compatible.
+
+## Decision: Use a Nuplane-owned default-context resolving bridge for host-integrated visibility
+
+**Rationale**: Host applications should not register custom assembly resolving handlers. Nuplane can own the process-wide resolving hook behind the loading module and route requests only to active host-integrated assembly resolution entries. This keeps behavior centralized and observable while satisfying framework `Assembly.Load` by-name scenarios.
+
+**Alternatives considered**:
+- Require each host to subscribe to resolving events: rejected by feature goal.
+- Load all package assemblies directly into the default context: rejected as the first-choice design because it maximizes compatibility but removes more isolation than necessary and cannot be reversed for already-loaded identities.
+- Use only non-collectible package-specific contexts without a default-context resolving bridge: rejected because framework by-name resolution would remain unsolved.
+
+## Decision: Keep source trust and graph resolution unchanged before load mode behavior
+
+**Rationale**: Load mode changes assembly lifetime and visibility, not package trust. Existing source validation, package graph resolution, integrity checks, and transactional apply boundaries remain the gate before assemblies can be loaded or made visible.
+
+**Alternatives considered**:
+- Add separate trust configuration for host-integrated packages: deferred because the current feature does not introduce new package sources and should not duplicate source trust policy.
+
+## Decision: Options validation stays in the loading options pipeline
+
+**Rationale**: The constitution requires `IValidateOptions<T>` and startup fail-fast for runtime options. New load mode properties must be data-only on options and validated by the loading validator adapter already registered with `ValidateOnStart()`.
+
+**Alternatives considered**:
+- Add `IsValid()` to options: rejected by repository rules.
+- Validate only when first package loads: rejected because invalid load mode configuration should fail before runtime reconciliation work begins.

--- a/specs/018-host-integrated-loading/spec.md
+++ b/specs/018-host-integrated-loading/spec.md
@@ -1,0 +1,167 @@
+# Feature Specification: Host-Integrated Package Loading
+
+**Feature Branch**: `018-host-integrated-loading`  
+**Created**: 2026-05-09  
+**Status**: Draft  
+**Input**: User description: "Add a first-class host-integrated package load mode to Nuplane so packages that contribute DI registrations, EF Core providers or migrations, ASP.NET endpoints, CShells/Elsa shell features, hosted services, options, validators, or similar framework-integrated types can be loaded for application lifetime without host-specific AssemblyLoadContext or resolver plumbing. Distinguish shared assemblies/type identity from package load mode/lifetime and from assembly resolution visibility. Preserve existing collectible behavior for isolated or scan-only plugin scenarios. Allow default and per-package load mode configuration. Ensure host-integrated assemblies are safe for non-collectible framework code, framework Assembly.Load by name can resolve active host-integrated package assemblies when appropriate, package graph dependency resolution remains deterministic, version conflicts surface clear diagnostics, and docs explain collectible versus host-integrated modes."
+
+## Problem
+
+Nuplane can load package assemblies for dynamic runtime scenarios, but framework-integrated packages expose a different requirement than isolated plugin scanning. Packages that register services, provide database migrations, contribute web endpoints, expose shell features, or participate in host frameworks may later be resolved and used by framework code that lives outside the original package loading boundary.
+
+Shared assembly policy solves contract type identity by ensuring host/plugin abstractions match, but it does not by itself define package assembly lifetime or make package assemblies discoverable when framework code resolves an assembly by name. Hosts currently need custom assembly loading or resolution plumbing for these scenarios, which makes Nuplane harder to adopt and risks runtime failures when non-collectible framework code interacts with collectible plugin assemblies.
+
+## Goals
+
+- Provide an explicit host-integrated loading mode for packages intended to participate in application-lifetime framework behavior.
+- Keep shared assembly policy independent from package load mode so contract identity remains configurable without implying package lifetime.
+- Make active host-integrated package assemblies discoverable to host/framework code when resolving by assembly name.
+- Preserve existing collectible package loading for isolated, scan-only, or unloadable plugin scenarios.
+- Surface deterministic diagnostics for version conflicts, ambiguous assembly resolution, and failed assembly resolution.
+- Document when to use host-integrated loading, when to use collectible loading, and how shared assemblies relate to both modes.
+
+## Non-Goals
+
+- Automatically detecting every framework integration pattern and changing package load behavior without explicit host configuration.
+- Making host-integrated packages unloadable with the same guarantees as collectible packages.
+- Replacing source trust validation, package graph resolution, or existing reconciliation safety behavior.
+- Requiring host applications to register custom assembly load or assembly resolving handlers.
+- Silently changing existing consumers from collectible loading to host-integrated loading.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Load Framework-Integrated Packages (Priority: P1)
+
+As a host application owner, I want to mark runtime packages as host-integrated so services, migrations, endpoints, shell features, hosted services, options, and validators can be discovered and used by host frameworks for the application lifetime without custom assembly loading code.
+
+**Why this priority**: This is the primary value of the feature and removes the current adoption blocker for framework-integrated package scenarios.
+
+**Independent Test**: Configure one package as host-integrated, load it through Nuplane, and verify host/framework code can discover and activate its contributed types without any host-specific resolver logic.
+
+**Acceptance Scenarios**:
+
+1. **Given** a configured host-integrated package containing framework-contributed types, **When** Nuplane loads the package, **Then** the host receives assemblies that are safe for framework integration and can discover the contributed types.
+2. **Given** a host-integrated package containing a database migrations assembly, **When** framework code resolves that migrations assembly by name, **Then** the expected active package assembly is resolved without host custom code.
+3. **Given** a host-integrated package contributes shell features, **When** the host enumerates package assemblies, **Then** shell feature implementations are discoverable and activatable for the application lifetime.
+
+---
+
+### User Story 2 - Preserve Collectible Loading (Priority: P2)
+
+As a host application owner, I want existing collectible loading scenarios to keep working so isolated or scan-only plugin packages can still be unloaded or treated with stronger isolation where framework integration is not required.
+
+**Why this priority**: Backward compatibility prevents existing Nuplane consumers from being surprised by changed assembly lifetime or isolation behavior.
+
+**Independent Test**: Configure a package for collectible loading and verify Nuplane returns collectible package assemblies using the same observable behavior expected by existing consumers.
+
+**Acceptance Scenarios**:
+
+1. **Given** a package configured for collectible loading, **When** Nuplane loads the package, **Then** the package remains isolated from host-integrated assembly resolution behavior.
+2. **Given** an existing consumer relying on collectible package behavior, **When** the feature is enabled with default settings unchanged, **Then** the consumer observes no silent switch to host-integrated loading.
+
+---
+
+### User Story 3 - Configure Load Mode Predictably (Priority: P3)
+
+As an operations or platform maintainer, I want to set the default package load mode and override it for specific packages so mixed workloads can use host-integrated loading only where needed.
+
+**Why this priority**: Real hosts may combine framework-integrated packages with isolated plugins, so load behavior must be explicit and controllable.
+
+**Independent Test**: Configure a default load mode and a package-specific override, load multiple packages, and verify each package follows the intended mode.
+
+**Acceptance Scenarios**:
+
+1. **Given** a default package load mode is configured, **When** Nuplane autoloads packages without overrides, **Then** each package uses the configured default mode.
+2. **Given** a package-specific load mode override is configured, **When** Nuplane loads that package, **Then** the override takes precedence over the default mode.
+3. **Given** shared assemblies are configured, **When** packages use different load modes, **Then** shared assembly contract identity remains governed by shared assembly policy, not by load mode selection.
+
+---
+
+### User Story 4 - Diagnose Conflicts and Resolution Failures (Priority: P4)
+
+As an operator, I want clear diagnostics when assembly resolution is ambiguous, conflicting, or fails so package loading problems can be understood without inspecting host-specific assembly loader internals.
+
+**Why this priority**: Host-integrated packages increase assembly visibility, so deterministic conflict handling and diagnostics are required for safe operations.
+
+**Independent Test**: Load packages that create ambiguous assembly names or incompatible versions and verify Nuplane reports a deterministic failure with actionable diagnostics.
+
+**Acceptance Scenarios**:
+
+1. **Given** two active host-integrated packages expose conflicting versions of the same assembly identity, **When** framework code resolves that assembly by name, **Then** Nuplane applies deterministic conflict handling and emits a clear diagnostic outcome.
+2. **Given** framework code requests an assembly name that is not available from active host-integrated packages, **When** resolution fails, **Then** diagnostics identify the requested assembly and the relevant active package context.
+
+### Edge Cases
+
+- A package is configured as host-integrated while one of its dependencies has a conflicting assembly identity already active from another host-integrated package.
+- A package uses shared assemblies for contract identity but is still loaded in collectible mode.
+- A host-integrated package references a shared assembly supplied by the host/default context.
+- Framework code requests an assembly by simple name and multiple active package assemblies could match.
+- Framework code requests an assembly by full name with a version that does not match any active package assembly.
+- A package fails to load after package graph resolution succeeds but before all host-integrated assemblies are visible.
+- A reconciliation update replaces a previously active host-integrated package version while framework code may still hold references to the old assembly.
+- Configuration specifies an unsupported load mode value or conflicting default/per-package values.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Nuplane MUST expose an explicit package load mode concept with at least collectible and host-integrated modes.
+- **FR-002**: Nuplane MUST allow hosts to configure the default load mode used for autoloaded packages.
+- **FR-003**: Nuplane MUST allow hosts to override load mode for an individual package when package-level configuration is available.
+- **FR-004**: Nuplane MUST preserve shared assembly policy as an independent configuration area that controls contract/type identity without implying package load mode.
+- **FR-005**: Nuplane MUST expose assemblies for active host-integrated packages through the existing package assembly catalog with metadata that identifies load mode and framework-integration safety.
+- **FR-006**: Nuplane MUST ensure assemblies returned for host-integrated packages are not collectible assemblies returned to non-collectible host/framework code.
+- **FR-007**: Nuplane MUST make active host-integrated package assemblies resolvable by assembly name for framework code when the requested identity uniquely matches an active host-integrated assembly.
+- **FR-008**: Nuplane MUST keep package dependency graph resolution consistent with the active package graph for both direct packages and transitive dependencies.
+- **FR-009**: Nuplane MUST reject activation when active host-integrated packages would expose conflicting versions of the same assembly simple name, and MUST expose clear diagnostics for conflicts, ambiguities, and failed resolution.
+- **FR-010**: Nuplane MUST NOT require host applications to implement custom assembly load context or assembly resolving handlers for intended host-integrated packages.
+- **FR-011**: Nuplane MUST preserve existing collectible loading behavior for packages configured or defaulted to collectible mode.
+- **FR-012**: Nuplane MUST validate load mode configuration values at startup or configuration activation time and fail with actionable errors for invalid values.
+- **FR-013**: Nuplane MUST document the behavioral difference between collectible and host-integrated modes, including lifetime and isolation tradeoffs.
+- **FR-014**: Nuplane MUST document that shared assemblies solve type identity but do not replace load mode selection or assembly resolution visibility.
+- **FR-015**: Nuplane MUST log the selected load mode, active assembly identities, resolution decisions, conflicts, and failed resolution attempts without logging secrets or credentials.
+
+### Operational & Safety Requirements *(mandatory)*
+
+- **OSR-001**: Reconciliation/apply flows MUST remain idempotent when repeated with identical package requests and load mode configuration.
+- **OSR-002**: Update flows MUST preserve transactional behavior and last-known-good fallback semantics when a host-integrated package fails to load or become resolvable, including keeping the previous last-known-good assembly resolution visibility active when replacement activation or visibility setup fails.
+- **OSR-003**: Source trust validation, package integrity checks, and secret handling MUST remain unchanged and apply before packages become host-integrated or collectible.
+- **OSR-004**: Observability MUST include structured diagnostics for chosen load mode, package assembly identity, dependency graph identity, assembly resolution source, ambiguity, conflict, and failure.
+- **OSR-005**: Tests MUST cover host-integrated loading, collectible loading compatibility, shared assembly identity independence, assembly-name resolution, version conflicts, invalid configuration, and framework-style discovery scenarios.
+
+### Key Entities
+
+- **Package Load Mode**: The configured lifetime and framework integration behavior for package assemblies, such as collectible or host-integrated.
+- **Shared Assembly Policy**: The host-controlled list or rule set that determines which assemblies are shared for contract/type identity.
+- **Host-Integrated Package Assembly**: An active package assembly intended to be stable for framework use during the application lifetime and visible to assembly-name resolution.
+- **Package Assembly Catalog**: The existing discovery surface that exposes active package assemblies to consumers and includes metadata indicating load mode and whether assemblies are safe for framework integration.
+- **Assembly Resolution Entry**: A deterministic mapping from an assembly identity to the active host-integrated package assembly that can satisfy it; replacement updates the mapping only after successful activation and visibility setup, otherwise the last-known-good mapping remains active.
+- **Resolution Diagnostic**: A structured outcome that explains successful resolution, ambiguity, conflict, or failure.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A host can load a framework-integrated package and discover contributed framework types without adding host-specific assembly loading or resolving code.
+- **SC-002**: A framework request for an active host-integrated package assembly by simple or full name resolves to the expected assembly when the identity is unambiguous.
+- **SC-003**: A package containing database migrations can be loaded in host-integrated mode and its migrations assembly can be resolved by framework code by name.
+- **SC-004**: A shell-style host can discover and activate shell feature implementations from host-integrated Nuplane packages.
+- **SC-005**: Collectible mode remains available and covered by tests that verify existing collectible behavior is not silently changed.
+- **SC-006**: Shared assembly policy remains independent from load mode and tests prove contract type identity works across load modes.
+- **SC-007**: Host-integrated package assemblies returned to framework code are verified as non-collectible and do not trigger collectible-to-non-collectible reference failures.
+- **SC-008**: Ambiguous or conflicting assembly identities produce deterministic diagnostics that identify the requested assembly and the conflicting package assemblies.
+- **SC-009**: Invalid load mode configuration fails validation with a clear message before packages are activated under an unintended mode.
+- **SC-010**: User documentation includes guidance for choosing collectible versus host-integrated loading and explains how shared assemblies relate to both modes.
+
+## Assumptions
+
+- Existing consumers should keep the current default loading behavior unless they explicitly opt into host-integrated loading or configure it as their default.
+- Host-integrated packages may remain loaded for the process lifetime and should be documented as lower isolation than collectible packages.
+- Explicit configuration is preferred over automatic inference of framework-integrated package intent.
+- Package source trust and graph resolution happen before load mode behavior is applied.
+
+## Clarifications
+
+- **2026-05-09**: Host-integrated assembly conflicts fail activation when active host-integrated packages expose different versions of the same assembly simple name.
+- **2026-05-09**: Host-integrated package replacement follows last-known-good fallback; the previous resolution visibility remains active if replacement activation or visibility setup fails.
+- **2026-05-09**: Host-integrated assemblies are exposed through the existing package assembly catalog with load mode and framework-safety metadata.

--- a/specs/018-host-integrated-loading/tasks.md
+++ b/specs/018-host-integrated-loading/tasks.md
@@ -1,0 +1,265 @@
+# Tasks: Host-Integrated Package Loading
+
+**Input**: Design documents from `/specs/018-host-integrated-loading/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/host-integrated-loading-contract.md, quickstart.md
+
+**Tests**: Required by the specification and constitution for changed loading behavior, public contracts, options validation, catalog metadata, assembly resolution, conflict handling, and LKG fallback.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel with other tasks in the same phase when files do not overlap
+- **[Story]**: User story label for story phases only
+- All task descriptions include exact file paths
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Prepare shared fixtures and baseline contract tests used by later story phases.
+
+- [x] T001 [P] Add host-integrated fixture marker type in test/Nuplane.Loading.Tests.Fixtures/HostIntegratedFixtureTypes.cs
+- [x] T002 [P] Add second-version conflict fixture project in test/Nuplane.Loading.Tests.Fixtures.Conflict/Nuplane.Loading.Tests.Fixtures.Conflict.csproj
+- [x] T003 Add conflict fixture source type in test/Nuplane.Loading.Tests.Fixtures.Conflict/ConflictFixtureTypes.cs
+- [x] T004 Add conflict fixture project reference to test/Nuplane.Loading.Tests/Nuplane.Loading.Tests.csproj
+- [x] T005 [P] Add public loading contract tests for load mode API shape in test/Nuplane.Loading.Tests/LoadingOwnershipContractTests.cs
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Define shared models, validation, and internal load-mode selection required before any user story can be implemented.
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete.
+
+- [x] T006 Create public PackageLoadMode enum with XML documentation in src/Nuplane.Loading.Abstractions/PackageLoadMode.cs
+- [x] T007 Extend LoadingOptions with DefaultLoadMode and package override collection in src/Nuplane.Loading/LoadingOptions.cs
+- [x] T008 Add package override options model with XML documentation in src/Nuplane.Loading/PackageLoadModeOverrideOptions.cs
+- [x] T009 [P] Add load mode validation tests in test/Nuplane.Loading.Tests/LoadingOptionsValidatorTests.cs
+- [x] T010 Update LoadingOptionsValidator to validate supported modes and duplicate package overrides in src/Nuplane.Loading/LoadingOptionsValidator.cs
+- [x] T011 Add internal PackageLoadModeSelection record in src/Nuplane.Loading/PackageLoadModeSelection.cs
+- [x] T012 Add deterministic PackageLoadModeSelector in src/Nuplane.Loading/PackageLoadModeSelector.cs
+- [x] T013 [P] Add package load mode selector tests in test/Nuplane.Loading.Tests/PackageLoadModeSelectorTests.cs
+- [x] T014 Register PackageLoadModeSelector in src/Nuplane.Loading/Registration/LoadingRegistrationServices.cs
+- [x] T015 Extend PackageLoadSession with effective load mode metadata in src/Nuplane.Loading.Abstractions/PackageLoadSession.cs
+- [x] T016 Update IPackageLoader method contracts to accept effective load mode selections in src/Nuplane.Loading.Abstractions/IPackageLoader.cs
+- [x] T017 Update PackageAutoLoadingObserver to pass deterministic load mode selections to the loader in src/Nuplane.Loading/PackageAutoLoadingObserver.cs
+
+**Checkpoint**: Foundation ready - user story implementation can now begin.
+
+---
+
+## Phase 3: User Story 1 - Load Framework-Integrated Packages (Priority: P1) 🎯 MVP
+
+**Goal**: A host can mark packages as host-integrated and discover/use framework-integrated package assemblies without custom assembly resolver code.
+
+**Independent Test**: Configure one package as host-integrated, load it through Nuplane, query the catalog, and verify framework-style by-name resolution and type discovery work without host resolver setup.
+
+### Tests for User Story 1 ⚠️
+
+> **NOTE: Write these tests FIRST, ensure they FAIL before implementation.**
+
+- [x] T018 [P] [US1] Add host-integrated loader tests for non-collectible framework-safe assemblies in test/Nuplane.Loading.Tests/PackageLoaderHostIntegratedTests.cs
+- [x] T019 [P] [US1] Add host-integrated assembly resolver tests for simple-name and full-name success in test/Nuplane.Loading.Tests/HostIntegratedAssemblyResolverTests.cs
+- [x] T020 [P] [US1] Add package assembly catalog metadata tests for host-integrated entries in test/Nuplane.Loading.Tests/PackageAssemblyCatalogHostIntegratedTests.cs
+- [x] T021 [P] [US1] Add type finder discovery test for host-integrated catalog entries in test/Nuplane.Loading.Tests/PackageTypeFinderTests.cs
+
+### Implementation for User Story 1
+
+- [x] T022 [US1] Add non-collectible host-integrated graph load context in src/Nuplane.Loading/HostIntegratedPackageGraphLoadContext.cs
+- [x] T023 [US1] Add host-integrated assembly resolution entry model in src/Nuplane.Loading/HostIntegratedAssemblyResolutionEntry.cs
+- [x] T024 [US1] Add host-integrated assembly resolution catalog with generation publication in src/Nuplane.Loading/HostIntegratedAssemblyResolutionCatalog.cs
+- [x] T025 [US1] Add Nuplane-owned assembly resolving bridge in src/Nuplane.Loading/HostIntegratedAssemblyResolver.cs
+- [x] T026 [US1] Register host-integrated resolver services in src/Nuplane.Loading/Registration/LoadingRegistrationServices.cs
+- [x] T027 [US1] Update PackageLoader to create host-integrated contexts for HostIntegrated selections in src/Nuplane.Loading/PackageLoader.cs
+- [x] T028 [US1] Update PackageAssemblyProvider to return assemblies from host-integrated contexts in src/Nuplane.Loading/PackageAssemblyProvider.cs
+- [x] T029 [US1] Extend PackageAssemblies with load mode and framework-safety metadata in src/Nuplane.Loading.Abstractions/IPackageAssemblyCatalog.cs
+- [x] T030 [US1] Update PackageAssemblyCatalog to populate host-integrated metadata in src/Nuplane.Loading/PackageAssemblyCatalog.cs
+- [x] T031 [US1] Update package assembly catalog extensions to preserve new metadata in src/Nuplane.Loading.Abstractions/Extensions/PackageAssemblyCatalogExtensions.cs
+- [x] T032 [US1] Add host-integrated load and resolver logs in src/Nuplane.Loading/PackageLoader.cs
+
+**Checkpoint**: User Story 1 is functional and testable independently as the MVP.
+
+---
+
+## Phase 4: User Story 2 - Preserve Collectible Loading (Priority: P2)
+
+**Goal**: Existing collectible loading remains available and is not silently changed by host-integrated support.
+
+**Independent Test**: Load a package using default settings and verify existing collectible behavior, unloadability semantics, and catalog framework-safety metadata remain collectible-oriented.
+
+### Tests for User Story 2 ⚠️
+
+- [x] T033 [P] [US2] Add regression tests proving default load mode remains collectible in test/Nuplane.Loading.Tests/PackageLoaderTests.cs
+- [x] T034 [P] [US2] Add collectible catalog metadata tests in test/Nuplane.Loading.Tests/PackageAssemblyCatalogTests.cs
+- [x] T035 [P] [US2] Add unload coordinator regression tests for collectible sessions in test/Nuplane.Loading.Tests/PackageUnloadCoordinatorTests.cs
+
+### Implementation for User Story 2
+
+- [x] T036 [US2] Update PackageLoader collectible branch to preserve existing collectible context behavior in src/Nuplane.Loading/PackageLoader.cs
+- [x] T037 [US2] Update PackageAssemblyLoadContext documentation for collectible mode semantics in src/Nuplane.Loading/PackageAssemblyLoadContext.cs
+- [x] T038 [US2] Update PackageUnloadCoordinator to skip host-integrated contexts and preserve collectible unloading in src/Nuplane.Loading/PackageUnloadCoordinator.cs
+- [x] T039 [US2] Update LoadingCatalog to report load mode in load state snapshots in src/Nuplane.Loading/LoadingCatalog.cs
+- [x] T040 [US2] Update loading operational state projection for collectible versus host-integrated counts in src/Nuplane.Loading/LoadingOperationalStateContributor.cs
+
+**Checkpoint**: User Stories 1 and 2 both work, and existing collectible consumers remain compatible.
+
+---
+
+## Phase 5: User Story 3 - Configure Load Mode Predictably (Priority: P3)
+
+**Goal**: Hosts can set a default load mode and override load mode for individual packages while shared assembly policy remains independent.
+
+**Independent Test**: Configure default `Collectible`, override one package to `HostIntegrated`, load multiple packages, and verify each package follows the intended mode while shared assembly policy still controls contract identity only.
+
+### Tests for User Story 3 ⚠️
+
+- [x] T041 [P] [US3] Add builder API tests for default load mode and package override configuration in test/Nuplane.Loading.Tests/LoadingRegistrationDeterminismTests.cs
+- [x] T042 [P] [US3] Add auto-loading observer tests for default and per-package mode selection in test/Nuplane.Loading.Tests/PackageAutoLoadingObserverTests.cs
+- [x] T043 [P] [US3] Add shared assembly independence tests across load modes in test/Nuplane.Loading.Tests/SharedAssemblyPolicyMatcherTests.cs
+
+### Implementation for User Story 3
+
+- [x] T044 [US3] Add fluent builder method for default load mode in src/Nuplane.Loading/Builder/NuplaneLoadingBuilder.cs
+- [x] T045 [US3] Add fluent builder method for package load mode override in src/Nuplane.Loading/Builder/NuplaneLoadingBuilder.cs
+- [x] T046 [US3] Update configuration binding documentation comments for load mode options in src/Nuplane.Loading/LoadingOptions.cs
+- [x] T047 [US3] Update PackageAutoLoadingObserver diagnostics to include mode selection reason in src/Nuplane.Loading/PackageAutoLoadingObserver.cs
+- [x] T048 [US3] Update NuplaneBuilderLoadingExtensions XML documentation for configured load modes in src/Nuplane.Loading/Builder/NuplaneBuilderLoadingExtensions.cs
+
+**Checkpoint**: User Stories 1, 2, and 3 work independently with predictable configuration behavior.
+
+---
+
+## Phase 6: User Story 4 - Diagnose Conflicts and Resolution Failures (Priority: P4)
+
+**Goal**: Operators receive deterministic diagnostics for conflicting, ambiguous, inactive, and failed host-integrated assembly resolution.
+
+**Independent Test**: Load conflicting or ambiguous host-integrated package assemblies and verify activation/resolution fails deterministically with diagnostics identifying requested assembly names, candidate packages, versions, and failure stage.
+
+### Tests for User Story 4 ⚠️
+
+- [x] T049 [P] [US4] Add conflict activation tests for same simple name with different versions in test/Nuplane.Loading.Tests/PackageLoaderHostIntegratedConflictTests.cs
+- [x] T050 [P] [US4] Add resolver diagnostics tests for not-found, ambiguity, and inactive entries in test/Nuplane.Loading.Tests/HostIntegratedAssemblyResolverDiagnosticsTests.cs
+- [x] T051 [P] [US4] Add replacement LKG fallback tests in test/Nuplane.Loading.Tests/HostIntegratedAssemblyResolutionCatalogTests.cs
+- [x] T052 [P] [US4] Add loading observability tests for conflict and resolution diagnostics in test/Nuplane.Loading.Tests/LoadingCatalogObservabilityTests.cs
+
+### Implementation for User Story 4
+
+- [x] T053 [US4] Add conflict detection before host-integrated visibility publication in src/Nuplane.Loading/HostIntegratedAssemblyResolutionCatalog.cs
+- [x] T054 [US4] Add deterministic failure result details for host-integrated conflicts in src/Nuplane.Loading.Abstractions/PackageLoadResult.cs
+- [x] T055 [US4] Update PackageLoader to preserve LKG visibility when host-integrated replacement fails in src/Nuplane.Loading/PackageLoader.cs
+- [x] T056 [US4] Add resolver diagnostic outcome model in src/Nuplane.Loading/HostIntegratedAssemblyResolutionDiagnostic.cs
+- [x] T057 [US4] Update HostIntegratedAssemblyResolver to emit success and failure diagnostics in src/Nuplane.Loading/HostIntegratedAssemblyResolver.cs
+- [x] T058 [US4] Update LoadingFailureTracker to record host-integrated conflict and resolution failures in src/Nuplane.Loading/LoadingFailureTracker.cs
+- [x] T059 [US4] Update LoadingCatalog health degradation for host-integrated activation conflicts in src/Nuplane.Loading/LoadingCatalog.cs
+
+**Checkpoint**: All user stories are independently functional with deterministic diagnostics and fallback behavior.
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+**Purpose**: Documentation, final contract alignment, and validation.
+
+- [x] T060 [P] Update README loading guidance for Collectible versus HostIntegrated modes in README.md
+- [x] T061 [P] Update wiki usage guidance for host-integrated loading configuration in docs/wiki/Usage-Guide.md
+- [x] T062 [P] Update glossary with package load mode and host-integrated assembly terms in docs/wiki/Concepts-and-Glossary.md
+- [x] T063 [P] Update XML docs on public loading catalog models in src/Nuplane.Loading.Abstractions/IPackageAssemblyCatalog.cs
+- [x] T064 [P] Update XML docs on PackageAssemblyReference if metadata relationships change in src/Nuplane.Loading.Abstractions/PackageAssemblyReference.cs
+- [x] T065 Run focused loading tests with `dotnet test test/Nuplane.Loading.Tests/Nuplane.Loading.Tests.csproj`
+- [x] T066 Run full solution tests with `dotnet test nuplane.sln`
+- [x] T067 Validate quickstart scenarios against implemented behavior in specs/018-host-integrated-loading/quickstart.md
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1**: No dependencies; can start immediately.
+- **Phase 2**: Depends on Phase 1 fixture and baseline setup.
+- **Phase 3 (US1)**: Depends on Phase 2; delivers MVP host-integrated loading.
+- **Phase 4 (US2)**: Depends on Phase 2; can run after or parallel with US1 after shared loader interfaces stabilize.
+- **Phase 5 (US3)**: Depends on Phase 2; benefits from US1/US2 behavior for end-to-end verification.
+- **Phase 6 (US4)**: Depends on US1 host-integrated resolver/catalog infrastructure.
+- **Phase 7**: Depends on completed story behavior.
+
+### User Story Dependencies
+
+- **US1**: Requires foundational load mode models and selector.
+- **US2**: Requires foundational load mode models; validates backward compatibility independently.
+- **US3**: Requires foundational options models and selector; validates configuration path.
+- **US4**: Requires US1 host-integrated resolution catalog and resolver.
+
+### Suggested Story Order
+
+1. **US1** - MVP host-integrated loading and by-name resolution.
+2. **US2** - Backward compatibility for collectible behavior.
+3. **US3** - Configuration default and per-package overrides.
+4. **US4** - Conflict, ambiguity, and LKG diagnostics.
+
+---
+
+## Parallel Execution Examples
+
+### Phase 1
+
+- T001 can run in parallel with T002.
+- T005 can run in parallel with fixture setup once expected public API names are agreed.
+
+### Phase 2
+
+- T009 and T013 can be written in parallel after T006-T008 are sketched.
+- T011 and T012 can run in parallel because they create separate internal artifacts.
+
+### User Story 1
+
+- T018, T019, T020, and T021 can be written in parallel.
+- T022, T023, and T024 can be implemented in parallel after T018-T020 define expected behavior.
+- T028, T030, and T031 can run in parallel after T027 establishes loader session metadata.
+
+### User Story 2
+
+- T033, T034, and T035 can be written in parallel.
+- T037 and T040 can run in parallel with T036 because they touch separate files.
+
+### User Story 3
+
+- T041, T042, and T043 can be written in parallel.
+- T046 and T048 can run in parallel with builder implementation tasks.
+
+### User Story 4
+
+- T049, T050, T051, and T052 can be written in parallel.
+- T056 and T058 can run in parallel after diagnostic outcome fields are agreed.
+
+### Polish
+
+- T060, T061, T062, T063, and T064 can run in parallel.
+
+---
+
+## Implementation Strategy
+
+### MVP First (US1 Only)
+
+1. Complete Phase 1 setup.
+2. Complete Phase 2 foundations.
+3. Complete Phase 3 host-integrated loading and resolver behavior.
+4. Run `dotnet test test/Nuplane.Loading.Tests/Nuplane.Loading.Tests.csproj --filter "FullyQualifiedName~HostIntegrated|FullyQualifiedName~PackageAssemblyCatalogHostIntegrated|FullyQualifiedName~PackageTypeFinder"`.
+
+### Incremental Delivery
+
+1. Deliver US1 to prove framework-integrated packages can be loaded and resolved.
+2. Deliver US2 to lock backward compatibility for collectible mode.
+3. Deliver US3 to expose complete configuration ergonomics.
+4. Deliver US4 to harden operations with deterministic diagnostics and LKG fallback.
+5. Complete documentation and full validation.
+
+### Validation Gates
+
+- Every changed public/protected API has XML documentation.
+- Every options property has a validator and runtime consumer.
+- Host-integrated conflict behavior fails before visibility publication.
+- LKG visibility remains active after replacement activation or visibility setup failure.
+- `dotnet test test/Nuplane.Loading.Tests/Nuplane.Loading.Tests.csproj` passes before full solution validation.
+- `dotnet test nuplane.sln` passes or any unrelated failures are documented.

--- a/src/Nuplane.Loading.Abstractions/IPackageAssemblyCatalog.cs
+++ b/src/Nuplane.Loading.Abstractions/IPackageAssemblyCatalog.cs
@@ -52,11 +52,15 @@ public interface IPackageAssemblyCatalog
 /// <param name="Version">The active package version.</param>
 /// <param name="Assemblies">The loaded assemblies materialized for the package.</param>
 /// <param name="AssemblyReferences">The deterministic durable assembly references associated with the package.</param>
+/// <param name="LoadMode">The effective load mode used for the package.</param>
+/// <param name="FrameworkIntegrationSafe">Whether the loaded assemblies are safe for framework integration.</param>
 public sealed record PackageAssemblies(
     string PackageId,
     string Version,
     IReadOnlyList<Assembly> Assemblies,
-    IReadOnlyList<PackageAssemblyReference> AssemblyReferences);
+    IReadOnlyList<PackageAssemblyReference> AssemblyReferences,
+    PackageLoadMode LoadMode = PackageLoadMode.Collectible,
+    bool FrameworkIntegrationSafe = false);
 
 /// <summary>
 /// Legacy assembly catalog entry retained temporarily while the repo migrates to <see cref="PackageAssemblies"/>.
@@ -65,11 +69,15 @@ public sealed record PackageAssemblies(
 /// <param name="Version">The active package version.</param>
 /// <param name="Assemblies">The loaded assemblies materialized for the package.</param>
 /// <param name="ScanCandidates">The deterministic scan candidates associated with the package.</param>
+/// <param name="LoadMode">The effective load mode used for the package.</param>
+/// <param name="FrameworkIntegrationSafe">Whether the loaded assemblies are safe for framework integration.</param>
 internal sealed record PackageAssemblyCatalogEntry(
     string PackageId,
     string Version,
     IReadOnlyList<Assembly> Assemblies,
-    IReadOnlyList<AssemblyScanCandidate> ScanCandidates)
+    IReadOnlyList<AssemblyScanCandidate> ScanCandidates,
+    PackageLoadMode LoadMode = PackageLoadMode.Collectible,
+    bool FrameworkIntegrationSafe = false)
 {
     /// <summary>
     /// Converts this legacy assembly catalog entry to the canonical <see cref="PackageAssemblies"/> model.
@@ -79,7 +87,9 @@ internal sealed record PackageAssemblyCatalogEntry(
             PackageId,
             Version,
             Assemblies,
-            ScanCandidates.Select(static candidate => PackageAssemblyReference.FromCandidate(candidate)).ToArray());
+            ScanCandidates.Select(static candidate => PackageAssemblyReference.FromCandidate(candidate)).ToArray(),
+            LoadMode,
+            FrameworkIntegrationSafe);
 
     /// <summary>
     /// Creates a legacy assembly catalog entry from the canonical <see cref="PackageAssemblies"/> model.
@@ -89,5 +99,7 @@ internal sealed record PackageAssemblyCatalogEntry(
             package.PackageId,
             package.Version,
             package.Assemblies,
-            package.AssemblyReferences.Select(static reference => reference.ToCandidate()).ToArray());
+            package.AssemblyReferences.Select(static reference => reference.ToCandidate()).ToArray(),
+            package.LoadMode,
+            package.FrameworkIntegrationSafe);
 }

--- a/src/Nuplane.Loading.Abstractions/LoadingPackageDescriptor.cs
+++ b/src/Nuplane.Loading.Abstractions/LoadingPackageDescriptor.cs
@@ -11,6 +11,8 @@ namespace Nuplane.Loading;
 /// <param name="Diagnostics">Secret-safe loading diagnostics.</param>
 /// <param name="ScanCandidates">The deterministic assembly scan candidates for the package.</param>
 /// <param name="ContextKey">The current load-context key, when one exists.</param>
+/// <param name="LoadMode">The effective load mode used for the package.</param>
+/// <param name="FrameworkIntegrationSafe">Whether the loaded package assemblies are safe for framework integration.</param>
 internal sealed record LoadingPackageDescriptor(
     string PackageId,
     string Version,
@@ -19,5 +21,6 @@ internal sealed record LoadingPackageDescriptor(
     DateTimeOffset? LoadedAtUtc,
     IReadOnlyList<string> Diagnostics,
     IReadOnlyList<AssemblyScanCandidate> ScanCandidates,
-    string? ContextKey);
-
+    string? ContextKey,
+    PackageLoadMode LoadMode = PackageLoadMode.Collectible,
+    bool FrameworkIntegrationSafe = false);

--- a/src/Nuplane.Loading.Abstractions/PackageLoadMode.cs
+++ b/src/Nuplane.Loading.Abstractions/PackageLoadMode.cs
@@ -1,0 +1,17 @@
+namespace Nuplane.Loading;
+
+/// <summary>
+/// Defines how Nuplane loads package assemblies and exposes them to host/framework code.
+/// </summary>
+public enum PackageLoadMode
+{
+    /// <summary>
+    /// Loads package assemblies into collectible package contexts for isolated or scan-only scenarios.
+    /// </summary>
+    Collectible = 0,
+
+    /// <summary>
+    /// Loads package assemblies for application-lifetime framework integration and by-name assembly resolution.
+    /// </summary>
+    HostIntegrated = 1
+}

--- a/src/Nuplane.Loading.Abstractions/PackageLoadSession.cs
+++ b/src/Nuplane.Loading.Abstractions/PackageLoadSession.cs
@@ -11,6 +11,8 @@ namespace Nuplane.Loading;
 /// <param name="LoadedAt">The time at which the package was loaded.</param>
 /// <param name="IsLoaded">Whether the package was successfully loaded into an assembly context.</param>
 /// <param name="LastError">The error message from the last failed load attempt, if any.</param>
+/// <param name="LoadMode">The effective load mode used for the package.</param>
+/// <param name="FrameworkIntegrationSafe">Whether the loaded package assemblies are safe for framework integration.</param>
 internal sealed record PackageLoadSession(
     string PackageId,
     string Version,
@@ -18,4 +20,6 @@ internal sealed record PackageLoadSession(
     string ContextKey,
     DateTimeOffset LoadedAt,
     bool IsLoaded,
-    string? LastError);
+    string? LastError,
+    PackageLoadMode LoadMode = PackageLoadMode.Collectible,
+    bool FrameworkIntegrationSafe = false);

--- a/src/Nuplane.Loading.Abstractions/PackageLoadState.cs
+++ b/src/Nuplane.Loading.Abstractions/PackageLoadState.cs
@@ -11,6 +11,8 @@ namespace Nuplane.Loading;
 /// <param name="Diagnostics">Secret-safe load diagnostics.</param>
 /// <param name="AssemblyReferences">The deterministic assembly references associated with the package.</param>
 /// <param name="Discoverable">Whether this loaded package should be exposed by default discovery surfaces.</param>
+/// <param name="LoadMode">The effective load mode used for the package.</param>
+/// <param name="FrameworkIntegrationSafe">Whether the loaded package assemblies are safe for framework integration.</param>
 public sealed record PackageLoadState(
     string PackageId,
     string Version,
@@ -19,7 +21,9 @@ public sealed record PackageLoadState(
     DateTimeOffset? LoadedAtUtc,
     IReadOnlyList<string> Diagnostics,
     IReadOnlyList<PackageAssemblyReference> AssemblyReferences,
-    bool Discoverable = true)
+    bool Discoverable = true,
+    PackageLoadMode LoadMode = PackageLoadMode.Collectible,
+    bool FrameworkIntegrationSafe = false)
 {
     /// <summary>
     /// Creates a canonical package load-state record from the legacy loading descriptor model.
@@ -42,6 +46,9 @@ public sealed record PackageLoadState(
             descriptor.ActiveInstallPath,
             descriptor.LoadedAtUtc,
             descriptor.Diagnostics,
-            descriptor.ScanCandidates.Select(static candidate => PackageAssemblyReference.FromCandidate(candidate)).ToArray());
+            descriptor.ScanCandidates.Select(static candidate => PackageAssemblyReference.FromCandidate(candidate)).ToArray(),
+            Discoverable: true,
+            descriptor.LoadMode,
+            descriptor.FrameworkIntegrationSafe);
     }
 }

--- a/src/Nuplane.Loading/Builder/NuplaneLoadingBuilder.cs
+++ b/src/Nuplane.Loading/Builder/NuplaneLoadingBuilder.cs
@@ -52,6 +52,48 @@ public sealed class NuplaneLoadingBuilder
     }
 
     /// <summary>
+    /// Sets the default package load mode for autoloaded packages.
+    /// </summary>
+    /// <param name="loadMode">The default load mode to apply when no package-specific override exists.</param>
+    public NuplaneLoadingBuilder WithDefaultLoadMode(PackageLoadMode loadMode)
+    {
+        Services.Configure<LoadingOptions>(options =>
+        {
+            options.DefaultLoadMode = loadMode;
+        });
+
+        return this;
+    }
+
+    /// <summary>
+    /// Sets a package-specific load mode override.
+    /// </summary>
+    /// <param name="packageId">The package identifier to override.</param>
+    /// <param name="loadMode">The load mode to use for the package.</param>
+    public NuplaneLoadingBuilder PackageLoadMode(string packageId, PackageLoadMode loadMode)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(packageId);
+
+        Services.Configure<LoadingOptions>(options =>
+        {
+            var existing = options.PackageLoadModes.FirstOrDefault(candidate =>
+                string.Equals(candidate.PackageId, packageId, StringComparison.OrdinalIgnoreCase));
+            if (existing is not null)
+            {
+                options.PackageLoadModes.Remove(existing);
+            }
+
+            options.PackageLoadModes.Add(new()
+            {
+                PackageId = packageId,
+                LoadMode = loadMode
+            });
+        });
+
+        return this;
+    }
+
+    /// <summary>
     /// Enables assembly loading when it was previously disabled.
     /// Useful for code-based overrides on top of configuration.
     /// </summary>

--- a/src/Nuplane.Loading/Builder/NuplaneLoadingBuilder.cs
+++ b/src/Nuplane.Loading/Builder/NuplaneLoadingBuilder.cs
@@ -73,6 +73,7 @@ public sealed class NuplaneLoadingBuilder
     public NuplaneLoadingBuilder PackageLoadMode(string packageId, PackageLoadMode loadMode)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(packageId);
+        packageId = packageId.Trim();
 
         Services.Configure<LoadingOptions>(options =>
         {

--- a/src/Nuplane.Loading/HostIntegratedAssemblyResolutionCandidate.cs
+++ b/src/Nuplane.Loading/HostIntegratedAssemblyResolutionCandidate.cs
@@ -1,0 +1,11 @@
+namespace Nuplane.Loading;
+
+/// <summary>
+/// Describes a host-integrated assembly identity before its assembly is loaded.
+/// </summary>
+internal sealed record HostIntegratedAssemblyResolutionCandidate(
+    string AssemblySimpleName,
+    Version? Version,
+    string PackageId,
+    string PackageVersion,
+    string GraphKey);

--- a/src/Nuplane.Loading/HostIntegratedAssemblyResolutionCatalog.cs
+++ b/src/Nuplane.Loading/HostIntegratedAssemblyResolutionCatalog.cs
@@ -65,9 +65,13 @@ internal sealed class HostIntegratedAssemblyResolutionCatalog
 
         lock (gate)
         {
+            var replacementPackageKeys = additions
+                .Select(static entry => BuildPackageKey(entry.PackageId, entry.PackageVersion))
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
             var nextGeneration = generation + 1;
             var retained = entries
-                .Where(entry => !string.Equals(entry.GraphKey, graphKey, StringComparison.OrdinalIgnoreCase))
+                .Where(entry => !string.Equals(entry.GraphKey, graphKey, StringComparison.OrdinalIgnoreCase)
+                    && !replacementPackageKeys.Contains(BuildPackageKey(entry.PackageId, entry.PackageVersion)))
                 .Concat(additions.Select(entry => entry with { Generation = nextGeneration }))
                 .ToArray();
 
@@ -95,8 +99,12 @@ internal sealed class HostIntegratedAssemblyResolutionCatalog
 
         lock (gate)
         {
+            var replacementPackageKeys = candidates
+                .Select(static candidate => BuildPackageKey(candidate.PackageId, candidate.PackageVersion))
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
             var proposedEntries = entries
-                .Where(entry => !string.Equals(entry.GraphKey, graphKey, StringComparison.OrdinalIgnoreCase))
+                .Where(entry => !string.Equals(entry.GraphKey, graphKey, StringComparison.OrdinalIgnoreCase)
+                    && !replacementPackageKeys.Contains(BuildPackageKey(entry.PackageId, entry.PackageVersion)))
                 .Select(static entry => new ConflictCandidate(
                     entry.AssemblySimpleName,
                     entry.Version,
@@ -229,7 +237,10 @@ internal sealed class HostIntegratedAssemblyResolutionCatalog
         string.Equals(requested.Name, definition.Name, StringComparison.OrdinalIgnoreCase)
         && Equals(requested.Version, definition.Version)
         && string.Equals(NormalizeCultureName(requested.CultureName), NormalizeCultureName(definition.CultureName), StringComparison.OrdinalIgnoreCase)
-        && requested.GetPublicKeyToken().AsSpan().SequenceEqual(definition.GetPublicKeyToken());
+        && PublicKeyTokensMatch(requested.GetPublicKeyToken(), definition.GetPublicKeyToken());
+
+    private static bool PublicKeyTokensMatch(byte[]? requested, byte[]? definition) =>
+        (requested ?? []).AsSpan().SequenceEqual(definition ?? []);
 
     private static string NormalizeCultureName(string? cultureName) =>
         string.IsNullOrWhiteSpace(cultureName) || string.Equals(cultureName, "neutral", StringComparison.OrdinalIgnoreCase)

--- a/src/Nuplane.Loading/HostIntegratedAssemblyResolutionCatalog.cs
+++ b/src/Nuplane.Loading/HostIntegratedAssemblyResolutionCatalog.cs
@@ -37,20 +37,7 @@ internal sealed class HostIntegratedAssemblyResolutionCatalog
         ArgumentNullException.ThrowIfNull(selections);
         ArgumentNullException.ThrowIfNull(assembliesByPackageKey);
 
-        long nextGeneration;
-        lock (gate)
-        {
-            nextGeneration = generation + 1;
-        }
-        IReadOnlyList<HostIntegratedAssemblyResolutionEntry> snapshot;
-        lock (gate)
-        {
-            snapshot = entries;
-        }
-
-        var retained = snapshot
-            .Where(entry => !string.Equals(entry.GraphKey, graphKey, StringComparison.OrdinalIgnoreCase))
-            .ToList();
+        var additions = new List<HostIntegratedAssemblyResolutionEntry>();
 
         foreach (var selection in selections.Where(static selection => selection.LoadMode == PackageLoadMode.HostIntegrated))
         {
@@ -63,7 +50,7 @@ internal sealed class HostIntegratedAssemblyResolutionCatalog
             foreach (var assembly in assemblies.Where(static assembly => !string.IsNullOrWhiteSpace(assembly.Location)))
             {
                 var name = assembly.GetName();
-                retained.Add(new(
+                additions.Add(new(
                     name.Name ?? Path.GetFileNameWithoutExtension(assembly.Location),
                     assembly.FullName ?? name.FullName,
                     name.Version,
@@ -71,15 +58,21 @@ internal sealed class HostIntegratedAssemblyResolutionCatalog
                     selection.PackageId,
                     selection.Version,
                     graphKey,
-                    nextGeneration,
+                    0,
                     assembly));
             }
         }
 
-        ValidateNoConflicts(retained);
-
         lock (gate)
         {
+            var nextGeneration = generation + 1;
+            var retained = entries
+                .Where(entry => !string.Equals(entry.GraphKey, graphKey, StringComparison.OrdinalIgnoreCase))
+                .Concat(additions.Select(entry => entry with { Generation = nextGeneration }))
+                .ToArray();
+
+            ValidateNoConflicts(retained);
+
             entries = retained
                 .OrderBy(static entry => entry.AssemblySimpleName, StringComparer.OrdinalIgnoreCase)
                 .ThenBy(static entry => entry.Version?.ToString(), StringComparer.OrdinalIgnoreCase)
@@ -91,16 +84,51 @@ internal sealed class HostIntegratedAssemblyResolutionCatalog
     }
 
     /// <summary>
+    /// Validates that the specified graph can be published without conflicting with active entries.
+    /// </summary>
+    public void ValidateCanPublishGraph(
+        string graphKey,
+        IReadOnlyList<HostIntegratedAssemblyResolutionCandidate> candidates)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(graphKey);
+        ArgumentNullException.ThrowIfNull(candidates);
+
+        lock (gate)
+        {
+            var proposedEntries = entries
+                .Where(entry => !string.Equals(entry.GraphKey, graphKey, StringComparison.OrdinalIgnoreCase))
+                .Select(static entry => new ConflictCandidate(
+                    entry.AssemblySimpleName,
+                    entry.Version,
+                    entry.PackageId,
+                    entry.PackageVersion))
+                .Concat(candidates.Select(static candidate => new ConflictCandidate(
+                    candidate.AssemblySimpleName,
+                    candidate.Version,
+                    candidate.PackageId,
+                    candidate.PackageVersion)))
+                .ToArray();
+
+            ValidateNoConflicts(proposedEntries);
+        }
+    }
+
+    /// <summary>
     /// Removes all entries associated with the specified package version.
     /// </summary>
     public void RemovePackage(string packageId, string version)
     {
         lock (gate)
         {
-            entries = entries
+            var retained = entries
                 .Where(entry => !string.Equals(entry.PackageId, packageId, StringComparison.OrdinalIgnoreCase)
                     || !string.Equals(entry.PackageVersion, version, StringComparison.OrdinalIgnoreCase))
                 .ToArray();
+            if (retained.Length != entries.Count)
+            {
+                entries = retained;
+                generation++;
+            }
         }
     }
 
@@ -154,7 +182,14 @@ internal sealed class HostIntegratedAssemblyResolutionCatalog
         return false;
     }
 
-    private static void ValidateNoConflicts(IEnumerable<HostIntegratedAssemblyResolutionEntry> proposedEntries)
+    private static void ValidateNoConflicts(IEnumerable<HostIntegratedAssemblyResolutionEntry> proposedEntries) =>
+        ValidateNoConflicts(proposedEntries.Select(static entry => new ConflictCandidate(
+            entry.AssemblySimpleName,
+            entry.Version,
+            entry.PackageId,
+            entry.PackageVersion)));
+
+    private static void ValidateNoConflicts(IEnumerable<ConflictCandidate> proposedEntries)
     {
         var conflict = proposedEntries
             .GroupBy(static entry => entry.AssemblySimpleName, StringComparer.OrdinalIgnoreCase)
@@ -185,4 +220,10 @@ internal sealed class HostIntegratedAssemblyResolutionCatalog
         $"{entry.AssemblyFullName} from {entry.PackageId}@{entry.PackageVersion} at {entry.AssemblyPath}";
 
     private static string BuildPackageKey(string packageId, string version) => $"{packageId}@{version}";
+
+    private sealed record ConflictCandidate(
+        string AssemblySimpleName,
+        Version? Version,
+        string PackageId,
+        string PackageVersion);
 }

--- a/src/Nuplane.Loading/HostIntegratedAssemblyResolutionCatalog.cs
+++ b/src/Nuplane.Loading/HostIntegratedAssemblyResolutionCatalog.cs
@@ -159,7 +159,7 @@ internal sealed class HostIntegratedAssemblyResolutionCatalog
         if (assemblyName.Version is not null)
         {
             candidates = candidates
-                .Where(entry => Equals(entry.Version, assemblyName.Version))
+                .Where(entry => AssemblyNamesMatch(assemblyName, entry.Assembly.GetName()))
                 .ToArray();
         }
 
@@ -200,9 +200,13 @@ internal sealed class HostIntegratedAssemblyResolutionCatalog
                     .Select(static entry => entry.Version?.ToString() ?? string.Empty)
                     .Distinct(StringComparer.OrdinalIgnoreCase)
                     .ToArray(),
+                PackageKeys = group
+                    .Select(static entry => BuildPackageKey(entry.PackageId, entry.PackageVersion))
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
+                    .ToArray(),
                 Entries = group.ToArray()
             })
-            .FirstOrDefault(group => group.Versions.Length > 1);
+            .FirstOrDefault(group => group.Versions.Length > 1 || group.PackageKeys.Length > 1);
 
         if (conflict is null)
         {
@@ -213,13 +217,24 @@ internal sealed class HostIntegratedAssemblyResolutionCatalog
             .OrderBy(static entry => entry.PackageId, StringComparer.OrdinalIgnoreCase)
             .Select(static entry => $"{entry.PackageId}@{entry.PackageVersion} ({entry.Version})"));
         throw new InvalidOperationException(
-            $"Host-integrated assembly conflict for '{conflict.SimpleName}': active packages expose multiple versions. Candidates: {packages}.");
+            $"Host-integrated assembly conflict for '{conflict.SimpleName}': active packages expose ambiguous assembly identities. Candidates: {packages}.");
     }
 
     private static string FormatCandidate(HostIntegratedAssemblyResolutionEntry entry) =>
         $"{entry.AssemblyFullName} from {entry.PackageId}@{entry.PackageVersion} at {entry.AssemblyPath}";
 
     private static string BuildPackageKey(string packageId, string version) => $"{packageId}@{version}";
+
+    private static bool AssemblyNamesMatch(AssemblyName requested, AssemblyName definition) =>
+        string.Equals(requested.Name, definition.Name, StringComparison.OrdinalIgnoreCase)
+        && Equals(requested.Version, definition.Version)
+        && string.Equals(NormalizeCultureName(requested.CultureName), NormalizeCultureName(definition.CultureName), StringComparison.OrdinalIgnoreCase)
+        && requested.GetPublicKeyToken().AsSpan().SequenceEqual(definition.GetPublicKeyToken());
+
+    private static string NormalizeCultureName(string? cultureName) =>
+        string.IsNullOrWhiteSpace(cultureName) || string.Equals(cultureName, "neutral", StringComparison.OrdinalIgnoreCase)
+            ? string.Empty
+            : cultureName;
 
     private sealed record ConflictCandidate(
         string AssemblySimpleName,

--- a/src/Nuplane.Loading/HostIntegratedAssemblyResolutionCatalog.cs
+++ b/src/Nuplane.Loading/HostIntegratedAssemblyResolutionCatalog.cs
@@ -1,0 +1,188 @@
+using System.Reflection;
+
+namespace Nuplane.Loading;
+
+/// <summary>
+/// Maintains framework-visible assembly resolution entries for active host-integrated packages.
+/// </summary>
+internal sealed class HostIntegratedAssemblyResolutionCatalog
+{
+    private readonly object gate = new();
+    private IReadOnlyList<HostIntegratedAssemblyResolutionEntry> entries = [];
+    private long generation;
+
+    /// <summary>
+    /// Gets the current published generation.
+    /// </summary>
+    public long Generation
+    {
+        get
+        {
+            lock (gate)
+            {
+                return generation;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Publishes host-integrated assemblies for a successfully loaded graph.
+    /// </summary>
+    public void PublishGraph(
+        string graphKey,
+        IReadOnlyList<PackageLoadModeSelection> selections,
+        IReadOnlyDictionary<string, IReadOnlyList<Assembly>> assembliesByPackageKey)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(graphKey);
+        ArgumentNullException.ThrowIfNull(selections);
+        ArgumentNullException.ThrowIfNull(assembliesByPackageKey);
+
+        long nextGeneration;
+        lock (gate)
+        {
+            nextGeneration = generation + 1;
+        }
+        IReadOnlyList<HostIntegratedAssemblyResolutionEntry> snapshot;
+        lock (gate)
+        {
+            snapshot = entries;
+        }
+
+        var retained = snapshot
+            .Where(entry => !string.Equals(entry.GraphKey, graphKey, StringComparison.OrdinalIgnoreCase))
+            .ToList();
+
+        foreach (var selection in selections.Where(static selection => selection.LoadMode == PackageLoadMode.HostIntegrated))
+        {
+            var packageKey = BuildPackageKey(selection.PackageId, selection.Version);
+            if (!assembliesByPackageKey.TryGetValue(packageKey, out var assemblies))
+            {
+                continue;
+            }
+
+            foreach (var assembly in assemblies.Where(static assembly => !string.IsNullOrWhiteSpace(assembly.Location)))
+            {
+                var name = assembly.GetName();
+                retained.Add(new(
+                    name.Name ?? Path.GetFileNameWithoutExtension(assembly.Location),
+                    assembly.FullName ?? name.FullName,
+                    name.Version,
+                    assembly.Location,
+                    selection.PackageId,
+                    selection.Version,
+                    graphKey,
+                    nextGeneration,
+                    assembly));
+            }
+        }
+
+        ValidateNoConflicts(retained);
+
+        lock (gate)
+        {
+            entries = retained
+                .OrderBy(static entry => entry.AssemblySimpleName, StringComparer.OrdinalIgnoreCase)
+                .ThenBy(static entry => entry.Version?.ToString(), StringComparer.OrdinalIgnoreCase)
+                .ThenBy(static entry => entry.PackageId, StringComparer.OrdinalIgnoreCase)
+                .ThenBy(static entry => entry.PackageVersion, StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+            generation = nextGeneration;
+        }
+    }
+
+    /// <summary>
+    /// Removes all entries associated with the specified package version.
+    /// </summary>
+    public void RemovePackage(string packageId, string version)
+    {
+        lock (gate)
+        {
+            entries = entries
+                .Where(entry => !string.Equals(entry.PackageId, packageId, StringComparison.OrdinalIgnoreCase)
+                    || !string.Equals(entry.PackageVersion, version, StringComparison.OrdinalIgnoreCase))
+                .ToArray();
+        }
+    }
+
+    /// <summary>
+    /// Attempts to resolve the requested assembly name from active host-integrated entries.
+    /// </summary>
+    public bool TryResolve(AssemblyName assemblyName, out Assembly? assembly, out HostIntegratedAssemblyResolutionDiagnostic diagnostic)
+    {
+        ArgumentNullException.ThrowIfNull(assemblyName);
+
+        IReadOnlyList<HostIntegratedAssemblyResolutionEntry> snapshot;
+        lock (gate)
+        {
+            snapshot = entries;
+        }
+
+        var candidates = snapshot
+            .Where(entry => string.Equals(entry.AssemblySimpleName, assemblyName.Name, StringComparison.OrdinalIgnoreCase))
+            .ToArray();
+
+        if (candidates.Length == 0)
+        {
+            assembly = null;
+            diagnostic = new(assemblyName.FullName, "not-found", null, [], $"Assembly '{assemblyName.FullName}' was not found in active host-integrated packages.");
+            return false;
+        }
+
+        if (assemblyName.Version is not null)
+        {
+            candidates = candidates
+                .Where(entry => Equals(entry.Version, assemblyName.Version))
+                .ToArray();
+        }
+
+        if (candidates.Length == 1)
+        {
+            assembly = candidates[0].Assembly;
+            diagnostic = new(assemblyName.FullName, "success", candidates[0].AssemblyPath, [FormatCandidate(candidates[0])], $"Resolved '{assemblyName.FullName}' from '{candidates[0].PackageId}@{candidates[0].PackageVersion}'.");
+            return true;
+        }
+
+        assembly = null;
+        diagnostic = new(
+            assemblyName.FullName,
+            candidates.Length == 0 ? "not-found" : "ambiguity",
+            null,
+            candidates.Select(FormatCandidate).ToArray(),
+            candidates.Length == 0
+                ? $"Assembly '{assemblyName.FullName}' was not found with the requested version in active host-integrated packages."
+                : $"Assembly '{assemblyName.FullName}' is ambiguous across active host-integrated packages.");
+        return false;
+    }
+
+    private static void ValidateNoConflicts(IEnumerable<HostIntegratedAssemblyResolutionEntry> proposedEntries)
+    {
+        var conflict = proposedEntries
+            .GroupBy(static entry => entry.AssemblySimpleName, StringComparer.OrdinalIgnoreCase)
+            .Select(group => new
+            {
+                SimpleName = group.Key,
+                Versions = group
+                    .Select(static entry => entry.Version?.ToString() ?? string.Empty)
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
+                    .ToArray(),
+                Entries = group.ToArray()
+            })
+            .FirstOrDefault(group => group.Versions.Length > 1);
+
+        if (conflict is null)
+        {
+            return;
+        }
+
+        var packages = string.Join(", ", conflict.Entries
+            .OrderBy(static entry => entry.PackageId, StringComparer.OrdinalIgnoreCase)
+            .Select(static entry => $"{entry.PackageId}@{entry.PackageVersion} ({entry.Version})"));
+        throw new InvalidOperationException(
+            $"Host-integrated assembly conflict for '{conflict.SimpleName}': active packages expose multiple versions. Candidates: {packages}.");
+    }
+
+    private static string FormatCandidate(HostIntegratedAssemblyResolutionEntry entry) =>
+        $"{entry.AssemblyFullName} from {entry.PackageId}@{entry.PackageVersion} at {entry.AssemblyPath}";
+
+    private static string BuildPackageKey(string packageId, string version) => $"{packageId}@{version}";
+}

--- a/src/Nuplane.Loading/HostIntegratedAssemblyResolutionDiagnostic.cs
+++ b/src/Nuplane.Loading/HostIntegratedAssemblyResolutionDiagnostic.cs
@@ -1,0 +1,11 @@
+namespace Nuplane.Loading;
+
+/// <summary>
+/// Describes the outcome of a host-integrated assembly resolution decision.
+/// </summary>
+internal sealed record HostIntegratedAssemblyResolutionDiagnostic(
+    string RequestedAssemblyName,
+    string Outcome,
+    string? SelectedAssemblyPath,
+    IReadOnlyList<string> CandidateAssemblies,
+    string Message);

--- a/src/Nuplane.Loading/HostIntegratedAssemblyResolutionEntry.cs
+++ b/src/Nuplane.Loading/HostIntegratedAssemblyResolutionEntry.cs
@@ -1,0 +1,17 @@
+using System.Reflection;
+
+namespace Nuplane.Loading;
+
+/// <summary>
+/// Maps an assembly identity to an active host-integrated package assembly.
+/// </summary>
+internal sealed record HostIntegratedAssemblyResolutionEntry(
+    string AssemblySimpleName,
+    string AssemblyFullName,
+    Version? Version,
+    string AssemblyPath,
+    string PackageId,
+    string PackageVersion,
+    string GraphKey,
+    long Generation,
+    Assembly Assembly);

--- a/src/Nuplane.Loading/HostIntegratedAssemblyResolver.cs
+++ b/src/Nuplane.Loading/HostIntegratedAssemblyResolver.cs
@@ -1,0 +1,59 @@
+using System.Reflection;
+using System.Runtime.Loader;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Nuplane.Loading;
+
+/// <summary>
+/// Resolves host-integrated package assemblies for framework by-name assembly requests.
+/// </summary>
+internal sealed class HostIntegratedAssemblyResolver : IDisposable
+{
+    private readonly HostIntegratedAssemblyResolutionCatalog catalog;
+    private readonly ILogger<HostIntegratedAssemblyResolver> logger;
+    private bool disposed;
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="HostIntegratedAssemblyResolver"/>.
+    /// </summary>
+    public HostIntegratedAssemblyResolver(
+        HostIntegratedAssemblyResolutionCatalog catalog,
+        ILogger<HostIntegratedAssemblyResolver>? logger = null)
+    {
+        this.catalog = catalog ?? throw new ArgumentNullException(nameof(catalog));
+        this.logger = logger ?? NullLogger<HostIntegratedAssemblyResolver>.Instance;
+        AssemblyLoadContext.Default.Resolving += ResolveFromHostIntegratedPackages;
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        if (disposed)
+        {
+            return;
+        }
+
+        AssemblyLoadContext.Default.Resolving -= ResolveFromHostIntegratedPackages;
+        disposed = true;
+    }
+
+    private Assembly? ResolveFromHostIntegratedPackages(AssemblyLoadContext context, AssemblyName assemblyName)
+    {
+        if (catalog.TryResolve(assemblyName, out var assembly, out var diagnostic))
+        {
+            logger.LogDebug(
+                "Resolved host-integrated assembly {AssemblyName} from {AssemblyPath}.",
+                diagnostic.RequestedAssemblyName,
+                diagnostic.SelectedAssemblyPath);
+            return assembly;
+        }
+
+        logger.LogDebug(
+            "Host-integrated assembly resolution did not resolve {AssemblyName}. Outcome={Outcome} Message={Message}",
+            diagnostic.RequestedAssemblyName,
+            diagnostic.Outcome,
+            diagnostic.Message);
+        return null;
+    }
+}

--- a/src/Nuplane.Loading/HostIntegratedPackageGraphLoadContext.cs
+++ b/src/Nuplane.Loading/HostIntegratedPackageGraphLoadContext.cs
@@ -1,0 +1,11 @@
+namespace Nuplane.Loading;
+
+/// <summary>
+/// Non-collectible package graph context for host-integrated package assemblies.
+/// </summary>
+internal sealed class HostIntegratedPackageGraphLoadContext(
+    string graphKey,
+    IReadOnlyList<string> mainAssemblyPaths,
+    IReadOnlyList<SharedAssemblyPolicyEntry> sharedPolicy,
+    SharedAssemblyPolicyMatcher matcher)
+    : PackageGraphLoadContext(graphKey, mainAssemblyPaths, sharedPolicy, matcher, isCollectible: false);

--- a/src/Nuplane.Loading/LoadingCatalog.cs
+++ b/src/Nuplane.Loading/LoadingCatalog.cs
@@ -80,13 +80,13 @@ internal sealed class LoadingCatalog(
                 if (session.IsLoaded)
                 {
                     var candidates = _candidateProjector.Project(package);
-                    descriptors.Add(CreateDescriptor(package, PackageLoadStatus.Loaded, session.LoadedAt, [], candidates));
+                    descriptors.Add(CreateDescriptor(package, PackageLoadStatus.Loaded, session.LoadedAt, [], candidates, session));
                     continue;
                 }
 
                 issueCount++;
                 divergenceCount++;
-                descriptors.Add(CreateDescriptor(package, PackageLoadStatus.Failed, session.LoadedAt, BuildDiagnostics(session.LastError), []));
+                descriptors.Add(CreateDescriptor(package, PackageLoadStatus.Failed, session.LoadedAt, BuildDiagnostics(session.LastError), [], session));
                 continue;
             }
 
@@ -141,7 +141,9 @@ internal sealed class LoadingCatalog(
                 package.LoadedAtUtc,
                 package.Diagnostics,
                 package.AssemblyReferences.Select(static reference => reference.ToCandidate()).ToArray(),
-                null)).ToArray(),
+                null,
+                package.LoadMode,
+                package.FrameworkIntegrationSafe)).ToArray(),
             snapshot.Reason,
             snapshot.CorrelationId);
     }
@@ -151,7 +153,8 @@ internal sealed class LoadingCatalog(
         PackageLoadStatus status,
         DateTimeOffset? loadedAtUtc,
         IReadOnlyList<string> diagnostics,
-        IReadOnlyList<PackageAssemblyReference> assemblyReferences) =>
+        IReadOnlyList<PackageAssemblyReference> assemblyReferences,
+        PackageLoadSession? session = null) =>
         new(
             package.PackageId,
             package.Version,
@@ -160,7 +163,9 @@ internal sealed class LoadingCatalog(
             loadedAtUtc,
             diagnostics,
             assemblyReferences.ToArray(),
-            package.Discoverable);
+            package.Discoverable,
+            session?.LoadMode ?? PackageLoadMode.Collectible,
+            session?.FrameworkIntegrationSafe ?? false);
 
     private static IReadOnlyList<string> BuildDiagnostics(string? message)
     {

--- a/src/Nuplane.Loading/LoadingOptions.cs
+++ b/src/Nuplane.Loading/LoadingOptions.cs
@@ -22,6 +22,16 @@ public sealed class LoadingOptions
     public string? ActiveStoreRoot { get; set; }
 
     /// <summary>
+    /// Gets or sets the default load mode used for autoloaded packages.
+    /// </summary>
+    public PackageLoadMode DefaultLoadMode { get; set; } = PackageLoadMode.Collectible;
+
+    /// <summary>
+    /// Gets the package-specific load mode overrides keyed by package identifier.
+    /// </summary>
+    public ICollection<PackageLoadModeOverrideOptions> PackageLoadModes { get; } = new List<PackageLoadModeOverrideOptions>();
+
+    /// <summary>
     /// Gets the collection of shared assembly identities whose assemblies are loaded from
     /// the host's default context rather than package-specific contexts.
     /// </summary>

--- a/src/Nuplane.Loading/LoadingOptions.cs
+++ b/src/Nuplane.Loading/LoadingOptions.cs
@@ -27,7 +27,7 @@ public sealed class LoadingOptions
     public PackageLoadMode DefaultLoadMode { get; set; } = PackageLoadMode.Collectible;
 
     /// <summary>
-    /// Gets the package-specific load mode overrides keyed by package identifier.
+    /// Gets the collection of package-specific load mode overrides.
     /// </summary>
     public ICollection<PackageLoadModeOverrideOptions> PackageLoadModes { get; } = new List<PackageLoadModeOverrideOptions>();
 

--- a/src/Nuplane.Loading/LoadingOptionsValidator.cs
+++ b/src/Nuplane.Loading/LoadingOptionsValidator.cs
@@ -26,6 +26,31 @@ public sealed class LoadingOptionsValidator
             errors.Add("Loading deactivation timeout must be greater than zero.");
         }
 
+        if (!Enum.IsDefined(options.DefaultLoadMode))
+        {
+            errors.Add($"Loading default load mode '{options.DefaultLoadMode}' is not supported.");
+        }
+
+        var seenPackageOverrides = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var packageOverride in options.PackageLoadModes)
+        {
+            if (string.IsNullOrWhiteSpace(packageOverride.PackageId))
+            {
+                errors.Add("Package load mode override package ID is required.");
+                continue;
+            }
+
+            if (!Enum.IsDefined(packageOverride.LoadMode))
+            {
+                errors.Add($"Package load mode override for '{packageOverride.PackageId}' uses unsupported load mode '{packageOverride.LoadMode}'.");
+            }
+
+            if (!seenPackageOverrides.Add(packageOverride.PackageId))
+            {
+                errors.Add($"Duplicate package load mode override '{packageOverride.PackageId}'.");
+            }
+        }
+
         var seenIdentities = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
         foreach (var identity in options.SharedAssemblies)

--- a/src/Nuplane.Loading/LoadingOptionsValidator.cs
+++ b/src/Nuplane.Loading/LoadingOptionsValidator.cs
@@ -40,14 +40,21 @@ public sealed class LoadingOptionsValidator
                 continue;
             }
 
-            if (!Enum.IsDefined(packageOverride.LoadMode))
+            var packageId = packageOverride.PackageId.Trim();
+            if (!string.Equals(packageOverride.PackageId, packageId, StringComparison.Ordinal))
             {
-                errors.Add($"Package load mode override for '{packageOverride.PackageId}' uses unsupported load mode '{packageOverride.LoadMode}'.");
+                errors.Add($"Package load mode override package ID '{packageOverride.PackageId}' must not contain leading or trailing whitespace.");
+                continue;
             }
 
-            if (!seenPackageOverrides.Add(packageOverride.PackageId))
+            if (!Enum.IsDefined(packageOverride.LoadMode))
             {
-                errors.Add($"Duplicate package load mode override '{packageOverride.PackageId}'.");
+                errors.Add($"Package load mode override for '{packageId}' uses unsupported load mode '{packageOverride.LoadMode}'.");
+            }
+
+            if (!seenPackageOverrides.Add(packageId))
+            {
+                errors.Add($"Duplicate package load mode override '{packageId}'.");
             }
         }
 

--- a/src/Nuplane.Loading/PackageAssemblyCatalog.cs
+++ b/src/Nuplane.Loading/PackageAssemblyCatalog.cs
@@ -59,5 +59,7 @@ internal sealed class PackageAssemblyCatalog(
             package.PackageId,
             package.Version,
             _packageAssemblyProvider.GetAssemblies(package.PackageId, package.Version),
-            package.AssemblyReferences.ToArray());
+            package.AssemblyReferences.ToArray(),
+            package.LoadMode,
+            package.FrameworkIntegrationSafe);
 }

--- a/src/Nuplane.Loading/PackageGraphLoadContext.cs
+++ b/src/Nuplane.Loading/PackageGraphLoadContext.cs
@@ -3,7 +3,7 @@ using System.Runtime.Loader;
 
 namespace Nuplane.Loading;
 
-internal sealed class PackageGraphLoadContext : AssemblyLoadContext
+internal class PackageGraphLoadContext : AssemblyLoadContext
 {
     private readonly IReadOnlyDictionary<string, string> assemblyPathsByName;
     private readonly IReadOnlyList<AssemblyDependencyResolver> dependencyResolvers;
@@ -15,7 +15,17 @@ internal sealed class PackageGraphLoadContext : AssemblyLoadContext
         IReadOnlyList<string> mainAssemblyPaths,
         IReadOnlyList<SharedAssemblyPolicyEntry> sharedPolicy,
         SharedAssemblyPolicyMatcher matcher)
-        : base(contextName, isCollectible: true)
+        : this(contextName, mainAssemblyPaths, sharedPolicy, matcher, isCollectible: true)
+    {
+    }
+
+    protected PackageGraphLoadContext(
+        string contextName,
+        IReadOnlyList<string> mainAssemblyPaths,
+        IReadOnlyList<SharedAssemblyPolicyEntry> sharedPolicy,
+        SharedAssemblyPolicyMatcher matcher,
+        bool isCollectible)
+        : base(contextName, isCollectible)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(contextName);
         ArgumentNullException.ThrowIfNull(mainAssemblyPaths);

--- a/src/Nuplane.Loading/PackageLoadModeOverrideOptions.cs
+++ b/src/Nuplane.Loading/PackageLoadModeOverrideOptions.cs
@@ -1,0 +1,17 @@
+namespace Nuplane.Loading;
+
+/// <summary>
+/// Configures the package load mode for a specific package identifier.
+/// </summary>
+public sealed class PackageLoadModeOverrideOptions
+{
+    /// <summary>
+    /// Gets or sets the package identifier to match.
+    /// </summary>
+    public string PackageId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the load mode to apply to the matching package.
+    /// </summary>
+    public PackageLoadMode LoadMode { get; set; } = PackageLoadMode.Collectible;
+}

--- a/src/Nuplane.Loading/PackageLoadModeSelection.cs
+++ b/src/Nuplane.Loading/PackageLoadModeSelection.cs
@@ -1,0 +1,16 @@
+namespace Nuplane.Loading;
+
+/// <summary>
+/// Represents the effective load mode selected for a package.
+/// </summary>
+/// <param name="PackageId">The package identifier.</param>
+/// <param name="Version">The package version.</param>
+/// <param name="LoadMode">The effective package load mode.</param>
+/// <param name="SelectionReason">The deterministic reason the load mode was selected.</param>
+/// <param name="GraphKey">The graph key associated with the package load.</param>
+internal sealed record PackageLoadModeSelection(
+    string PackageId,
+    string Version,
+    PackageLoadMode LoadMode,
+    string SelectionReason,
+    string GraphKey);

--- a/src/Nuplane.Loading/PackageLoadModeSelector.cs
+++ b/src/Nuplane.Loading/PackageLoadModeSelector.cs
@@ -1,0 +1,26 @@
+using Nuplane.Abstractions;
+
+namespace Nuplane.Loading;
+
+/// <summary>
+/// Selects effective package load modes from loading options.
+/// </summary>
+internal sealed class PackageLoadModeSelector
+{
+    /// <summary>
+    /// Selects the effective load mode for the specified package.
+    /// </summary>
+    public PackageLoadModeSelection Select(ResolvedPackage package, LoadingOptions options, string graphKey)
+    {
+        ArgumentNullException.ThrowIfNull(package);
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentException.ThrowIfNullOrWhiteSpace(graphKey);
+
+        var packageOverride = options.PackageLoadModes
+            .FirstOrDefault(candidate => string.Equals(candidate.PackageId, package.Id, StringComparison.OrdinalIgnoreCase));
+
+        return packageOverride is null
+            ? new(package.Id, package.Version, options.DefaultLoadMode, "default", graphKey)
+            : new(package.Id, package.Version, packageOverride.LoadMode, "package-override", graphKey);
+    }
+}

--- a/src/Nuplane.Loading/PackageLoader.cs
+++ b/src/Nuplane.Loading/PackageLoader.cs
@@ -111,9 +111,10 @@ internal sealed class PackageLoader : IPackageLoader
             cancellationToken.ThrowIfCancellationRequested();
 
             var graphKey = BuildGraphKey(packageGraph);
-            var selections = packageGraph
+            var selectedModes = packageGraph
                 .Select(package => _loadModeSelector.Select(package, _options, graphKey))
                 .ToArray();
+            var selections = PromoteHostIntegratedGraphSelections(selectedModes);
 
             if (packageGraph.Count <= 1 && selections.All(static selection => selection.LoadMode == PackageLoadMode.Collectible))
             {
@@ -365,21 +366,39 @@ internal sealed class PackageLoader : IPackageLoader
             .ThenBy(static package => package.Version, StringComparer.OrdinalIgnoreCase)
             .Select(static package => BuildKey(package.Id, package.Version)));
 
+    private static IReadOnlyList<PackageLoadModeSelection> PromoteHostIntegratedGraphSelections(
+        IReadOnlyList<PackageLoadModeSelection> selections)
+    {
+        if (selections.All(static selection => selection.LoadMode == PackageLoadMode.Collectible))
+        {
+            return selections;
+        }
+
+        return selections
+            .Select(static selection => selection.LoadMode == PackageLoadMode.HostIntegrated
+                ? selection
+                : selection with
+                {
+                    LoadMode = PackageLoadMode.HostIntegrated,
+                    SelectionReason = "dependency-closure"
+                })
+            .ToArray();
+    }
+
     private IReadOnlyDictionary<string, IReadOnlyList<Assembly>> MaterializeHostIntegratedAssemblies(
         AssemblyLoadContext context,
         IReadOnlyList<ResolvedPackage> packages)
     {
         var result = new Dictionary<string, IReadOnlyList<Assembly>>(StringComparer.OrdinalIgnoreCase);
+        var assembliesByPath = context.Assemblies
+            .Where(static assembly => !string.IsNullOrWhiteSpace(assembly.Location))
+            .GroupBy(static assembly => assembly.Location, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(static group => group.Key, static group => group.First(), StringComparer.OrdinalIgnoreCase);
+
         foreach (var package in packages)
         {
-            var assembliesByPath = context.Assemblies
-                .Where(static assembly => !string.IsNullOrWhiteSpace(assembly.Location))
-                .GroupBy(static assembly => assembly.Location, StringComparer.OrdinalIgnoreCase)
-                .ToDictionary(static group => group.Key, static group => group.First(), StringComparer.OrdinalIgnoreCase);
-
             var packageAssemblies = new List<Assembly>();
-            foreach (var candidate in BuildScanCandidates(package.Id, package.InstallPath)
-                .OrderBy(static candidate => candidate.AssemblyPath, StringComparer.OrdinalIgnoreCase))
+            foreach (var candidate in BuildScanCandidates(package.Id, package.InstallPath))
             {
                 if (assembliesByPath.TryGetValue(candidate.AssemblyPath, out var existingAssembly))
                 {

--- a/src/Nuplane.Loading/PackageLoader.cs
+++ b/src/Nuplane.Loading/PackageLoader.cs
@@ -224,7 +224,8 @@ internal sealed class PackageLoader : IPackageLoader
                 .ToArray();
             if (graphLoadMode == PackageLoadMode.HostIntegrated)
             {
-                ValidateHostIntegratedAssemblyConflicts(packages);
+                var candidates = BuildHostIntegratedResolutionCandidates(graphKey, packages);
+                _hostIntegratedResolutionCatalog.ValidateCanPublishGraph(graphKey, candidates);
             }
 
             context = graphLoadMode == PackageLoadMode.HostIntegrated
@@ -406,9 +407,11 @@ internal sealed class PackageLoader : IPackageLoader
         return result;
     }
 
-    private void ValidateHostIntegratedAssemblyConflicts(IReadOnlyList<ResolvedPackage> packages)
+    private IReadOnlyList<HostIntegratedAssemblyResolutionCandidate> BuildHostIntegratedResolutionCandidates(
+        string graphKey,
+        IReadOnlyList<ResolvedPackage> packages)
     {
-        var entries = new List<(string SimpleName, Version? Version, string PackageId, string PackageVersion)>();
+        var entries = new List<HostIntegratedAssemblyResolutionCandidate>();
         foreach (var package in packages)
         {
             foreach (var candidate in BuildScanCandidates(package.Id, package.InstallPath))
@@ -416,7 +419,12 @@ internal sealed class PackageLoader : IPackageLoader
                 try
                 {
                     var assemblyName = AssemblyName.GetAssemblyName(candidate.AssemblyPath);
-                    entries.Add((assemblyName.Name ?? Path.GetFileNameWithoutExtension(candidate.AssemblyPath), assemblyName.Version, package.Id, package.Version));
+                    entries.Add(new(
+                        assemblyName.Name ?? Path.GetFileNameWithoutExtension(candidate.AssemblyPath),
+                        assemblyName.Version,
+                        package.Id,
+                        package.Version,
+                        graphKey));
                 }
                 catch (BadImageFormatException)
                 {
@@ -424,26 +432,7 @@ internal sealed class PackageLoader : IPackageLoader
             }
         }
 
-        var conflict = entries
-            .GroupBy(static entry => entry.SimpleName, StringComparer.OrdinalIgnoreCase)
-            .Select(static group => new
-            {
-                SimpleName = group.Key,
-                Versions = group.Select(static entry => entry.Version?.ToString() ?? string.Empty).Distinct(StringComparer.OrdinalIgnoreCase).ToArray(),
-                Entries = group.ToArray()
-            })
-            .FirstOrDefault(static group => group.Versions.Length > 1);
-
-        if (conflict is null)
-        {
-            return;
-        }
-
-        var packagesText = string.Join(", ", conflict.Entries
-            .OrderBy(static entry => entry.PackageId, StringComparer.OrdinalIgnoreCase)
-            .Select(static entry => $"{entry.PackageId}@{entry.PackageVersion} ({entry.Version})"));
-        throw new InvalidOperationException(
-            $"Host-integrated assembly conflict for '{conflict.SimpleName}': active packages expose multiple versions. Candidates: {packagesText}.");
+        return entries;
     }
 
     private static string? TryResolveTargetFrameworkMoniker(string assemblyPath, string installPath)

--- a/src/Nuplane.Loading/PackageLoader.cs
+++ b/src/Nuplane.Loading/PackageLoader.cs
@@ -2,6 +2,9 @@ using System.Collections.Concurrent;
 using System.Reflection;
 using System.Runtime.Loader;
 using System.Runtime.Versioning;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using Nuplane.Abstractions;
 
 namespace Nuplane.Loading;
@@ -14,15 +17,31 @@ namespace Nuplane.Loading;
 internal sealed class PackageLoader : IPackageLoader
 {
     private readonly SharedAssemblyPolicyMatcher _matcher;
+    private readonly HostIntegratedAssemblyResolutionCatalog _hostIntegratedResolutionCatalog;
+    private readonly PackageLoadModeSelector _loadModeSelector;
+    private readonly LoadingOptions _options;
+    private readonly ILogger<PackageLoader> _logger;
+    private readonly HostIntegratedAssemblyResolver? _hostIntegratedAssemblyResolver;
     private readonly ConcurrentDictionary<string, AssemblyLoadContext> _contexts = new(StringComparer.OrdinalIgnoreCase);
     private readonly ConcurrentDictionary<string, PackageLoadSession> _sessions = new(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>
     /// Initializes a new instance of <see cref="PackageLoader"/> with an optional shared assembly policy matcher.
     /// </summary>
-    public PackageLoader(SharedAssemblyPolicyMatcher? matcher = null)
+    public PackageLoader(
+        SharedAssemblyPolicyMatcher? matcher = null,
+        HostIntegratedAssemblyResolutionCatalog? hostIntegratedResolutionCatalog = null,
+        PackageLoadModeSelector? loadModeSelector = null,
+        IOptions<LoadingOptions>? options = null,
+        ILogger<PackageLoader>? logger = null,
+        HostIntegratedAssemblyResolver? hostIntegratedAssemblyResolver = null)
     {
         _matcher = matcher ?? new SharedAssemblyPolicyMatcher();
+        _hostIntegratedResolutionCatalog = hostIntegratedResolutionCatalog ?? new HostIntegratedAssemblyResolutionCatalog();
+        _loadModeSelector = loadModeSelector ?? new PackageLoadModeSelector();
+        _options = options?.Value ?? new LoadingOptions();
+        _logger = logger ?? NullLogger<PackageLoader>.Instance;
+        _hostIntegratedAssemblyResolver = hostIntegratedAssemblyResolver;
     }
 
     /// <summary>
@@ -91,13 +110,18 @@ internal sealed class PackageLoader : IPackageLoader
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            if (packageGraph.Count <= 1)
+            var graphKey = BuildGraphKey(packageGraph);
+            var selections = packageGraph
+                .Select(package => _loadModeSelector.Select(package, _options, graphKey))
+                .ToArray();
+
+            if (packageGraph.Count <= 1 && selections.All(static selection => selection.LoadMode == PackageLoadMode.Collectible))
             {
                 EnsurePackagesLoaded(packageGraph, sharedPolicy, cancellationToken, loaded, failed);
                 continue;
             }
 
-            EnsureGraphLoaded(packageGraph, sharedPolicy, loaded, failed);
+            EnsureGraphLoaded(packageGraph, selections, sharedPolicy, loaded, failed);
         }
 
         return Task.FromResult<PackageLoadResult>(new(loaded, failed));
@@ -137,7 +161,9 @@ internal sealed class PackageLoader : IPackageLoader
                     key,
                     DateTimeOffset.UtcNow,
                     IsLoaded: true,
-                    LastError: null);
+                    LastError: null,
+                    PackageLoadMode.Collectible,
+                    FrameworkIntegrationSafe: false);
 
                 _sessions[key] = session;
                 loaded.Add(session);
@@ -152,25 +178,31 @@ internal sealed class PackageLoader : IPackageLoader
                     key,
                     DateTimeOffset.UtcNow,
                     IsLoaded: false,
-                    LastError: ex.Message);
+                    LastError: ex.Message,
+                    PackageLoadMode.Collectible,
+                    FrameworkIntegrationSafe: false);
             }
         }
     }
 
     private PackageLoadResult EnsureGraphLoaded(
         IReadOnlyList<ResolvedPackage> packages,
+        IReadOnlyList<PackageLoadModeSelection> selections,
         IReadOnlyList<SharedAssemblyPolicyEntry> sharedPolicy,
         List<PackageLoadSession> loaded,
         Dictionary<string, string> failed)
     {
-        var graphKey = "graph:" + string.Join('|', packages
-            .OrderBy(static package => package.Id, StringComparer.OrdinalIgnoreCase)
-            .ThenBy(static package => package.Version, StringComparer.OrdinalIgnoreCase)
-            .Select(static package => BuildKey(package.Id, package.Version)));
+        var graphKey = BuildGraphKey(packages);
+        var graphLoadMode = selections.Any(static selection => selection.LoadMode == PackageLoadMode.HostIntegrated)
+            ? PackageLoadMode.HostIntegrated
+            : PackageLoadMode.Collectible;
 
         var existingGraphSessions = packages
             .Select(package => _sessions.TryGetValue(BuildKey(package.Id, package.Version), out var session) ? session : null)
-            .Where(session => session is not null && session.IsLoaded && string.Equals(session.ContextKey, graphKey, StringComparison.OrdinalIgnoreCase))
+            .Where(session => session is not null
+                && session.IsLoaded
+                && string.Equals(session.ContextKey, graphKey, StringComparison.OrdinalIgnoreCase)
+                && session.LoadMode == graphLoadMode)
             .Cast<PackageLoadSession>()
             .ToArray();
 
@@ -180,7 +212,7 @@ internal sealed class PackageLoader : IPackageLoader
             return new(loaded, failed);
         }
 
-        PackageGraphLoadContext? context = null;
+        AssemblyLoadContext? context = null;
         var replacedContexts = new List<AssemblyLoadContext>();
 
         try
@@ -190,11 +222,27 @@ internal sealed class PackageLoader : IPackageLoader
                 .ThenBy(static package => package.Version, StringComparer.OrdinalIgnoreCase)
                 .Select(static package => ResolveMainAssemblyPath(package.InstallPath, package.Id))
                 .ToArray();
-            context = new PackageGraphLoadContext(graphKey, mainAssemblyPaths, sharedPolicy, _matcher);
+            if (graphLoadMode == PackageLoadMode.HostIntegrated)
+            {
+                ValidateHostIntegratedAssemblyConflicts(packages);
+            }
+
+            context = graphLoadMode == PackageLoadMode.HostIntegrated
+                ? new HostIntegratedPackageGraphLoadContext(graphKey, mainAssemblyPaths, sharedPolicy, _matcher)
+                : new PackageGraphLoadContext(graphKey, mainAssemblyPaths, sharedPolicy, _matcher);
 
             foreach (var mainAssemblyPath in mainAssemblyPaths)
             {
                 context.LoadFromAssemblyName(AssemblyName.GetAssemblyName(mainAssemblyPath));
+            }
+
+            var assembliesByPackageKey = graphLoadMode == PackageLoadMode.HostIntegrated
+                ? MaterializeHostIntegratedAssemblies(context, packages)
+                : new Dictionary<string, IReadOnlyList<Assembly>>(StringComparer.OrdinalIgnoreCase);
+
+            if (graphLoadMode == PackageLoadMode.HostIntegrated)
+            {
+                _hostIntegratedResolutionCatalog.PublishGraph(graphKey, selections, assembliesByPackageKey);
             }
 
             foreach (var package in packages)
@@ -215,17 +263,29 @@ internal sealed class PackageLoader : IPackageLoader
                     graphKey,
                     DateTimeOffset.UtcNow,
                     IsLoaded: true,
-                    LastError: null);
+                    LastError: null,
+                    graphLoadMode,
+                    FrameworkIntegrationSafe: graphLoadMode == PackageLoadMode.HostIntegrated);
 
                 _sessions[key] = session;
                 loaded.Add(session);
+
+                _logger.LogInformation(
+                    "Loaded package {PackageId}@{Version} with LoadMode={LoadMode} ContextKey={ContextKey}.",
+                    package.Id,
+                    package.Version,
+                    graphLoadMode,
+                    graphKey);
             }
 
             UnloadUnreferencedContexts(replacedContexts);
         }
         catch (Exception ex)
         {
-            context?.Unload();
+            if (context?.IsCollectible == true)
+            {
+                context.Unload();
+            }
 
             foreach (var package in packages)
             {
@@ -245,7 +305,9 @@ internal sealed class PackageLoader : IPackageLoader
                     graphKey,
                     DateTimeOffset.UtcNow,
                     IsLoaded: false,
-                    LastError: ex.Message);
+                    LastError: ex.Message,
+                    graphLoadMode,
+                    FrameworkIntegrationSafe: false);
             }
         }
 
@@ -256,7 +318,7 @@ internal sealed class PackageLoader : IPackageLoader
     {
         foreach (var context in contexts.Distinct())
         {
-            if (!_contexts.Values.Any(existing => ReferenceEquals(existing, context)))
+            if (context.IsCollectible && !_contexts.Values.Any(existing => ReferenceEquals(existing, context)))
             {
                 context.Unload();
             }
@@ -272,6 +334,7 @@ internal sealed class PackageLoader : IPackageLoader
         if (_contexts.TryRemove(key, out var removed))
         {
             context = new(key, removed);
+            _hostIntegratedResolutionCatalog.RemovePackage(packageId, version);
             return true;
         }
 
@@ -294,6 +357,94 @@ internal sealed class PackageLoader : IPackageLoader
     }
 
     private static string BuildKey(string packageId, string version) => $"{packageId}@{version}";
+
+    private static string BuildGraphKey(IReadOnlyList<ResolvedPackage> packages) =>
+        "graph:" + string.Join('|', packages
+            .OrderBy(static package => package.Id, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(static package => package.Version, StringComparer.OrdinalIgnoreCase)
+            .Select(static package => BuildKey(package.Id, package.Version)));
+
+    private IReadOnlyDictionary<string, IReadOnlyList<Assembly>> MaterializeHostIntegratedAssemblies(
+        AssemblyLoadContext context,
+        IReadOnlyList<ResolvedPackage> packages)
+    {
+        var result = new Dictionary<string, IReadOnlyList<Assembly>>(StringComparer.OrdinalIgnoreCase);
+        foreach (var package in packages)
+        {
+            var assembliesByPath = context.Assemblies
+                .Where(static assembly => !string.IsNullOrWhiteSpace(assembly.Location))
+                .GroupBy(static assembly => assembly.Location, StringComparer.OrdinalIgnoreCase)
+                .ToDictionary(static group => group.Key, static group => group.First(), StringComparer.OrdinalIgnoreCase);
+
+            var packageAssemblies = new List<Assembly>();
+            foreach (var candidate in BuildScanCandidates(package.Id, package.InstallPath)
+                .OrderBy(static candidate => candidate.AssemblyPath, StringComparer.OrdinalIgnoreCase))
+            {
+                if (assembliesByPath.TryGetValue(candidate.AssemblyPath, out var existingAssembly))
+                {
+                    packageAssemblies.Add(existingAssembly);
+                    continue;
+                }
+
+                try
+                {
+                    AssemblyName.GetAssemblyName(candidate.AssemblyPath);
+                    var loadedAssembly = context.LoadFromAssemblyPath(candidate.AssemblyPath);
+                    assembliesByPath[candidate.AssemblyPath] = loadedAssembly;
+                    packageAssemblies.Add(loadedAssembly);
+                }
+                catch (BadImageFormatException)
+                {
+                }
+            }
+
+            result[BuildKey(package.Id, package.Version)] = packageAssemblies
+                .OrderBy(static assembly => assembly.Location, StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+        }
+
+        return result;
+    }
+
+    private void ValidateHostIntegratedAssemblyConflicts(IReadOnlyList<ResolvedPackage> packages)
+    {
+        var entries = new List<(string SimpleName, Version? Version, string PackageId, string PackageVersion)>();
+        foreach (var package in packages)
+        {
+            foreach (var candidate in BuildScanCandidates(package.Id, package.InstallPath))
+            {
+                try
+                {
+                    var assemblyName = AssemblyName.GetAssemblyName(candidate.AssemblyPath);
+                    entries.Add((assemblyName.Name ?? Path.GetFileNameWithoutExtension(candidate.AssemblyPath), assemblyName.Version, package.Id, package.Version));
+                }
+                catch (BadImageFormatException)
+                {
+                }
+            }
+        }
+
+        var conflict = entries
+            .GroupBy(static entry => entry.SimpleName, StringComparer.OrdinalIgnoreCase)
+            .Select(static group => new
+            {
+                SimpleName = group.Key,
+                Versions = group.Select(static entry => entry.Version?.ToString() ?? string.Empty).Distinct(StringComparer.OrdinalIgnoreCase).ToArray(),
+                Entries = group.ToArray()
+            })
+            .FirstOrDefault(static group => group.Versions.Length > 1);
+
+        if (conflict is null)
+        {
+            return;
+        }
+
+        var packagesText = string.Join(", ", conflict.Entries
+            .OrderBy(static entry => entry.PackageId, StringComparer.OrdinalIgnoreCase)
+            .Select(static entry => $"{entry.PackageId}@{entry.PackageVersion} ({entry.Version})"));
+        throw new InvalidOperationException(
+            $"Host-integrated assembly conflict for '{conflict.SimpleName}': active packages expose multiple versions. Candidates: {packagesText}.");
+    }
 
     private static string? TryResolveTargetFrameworkMoniker(string assemblyPath, string installPath)
     {

--- a/src/Nuplane.Loading/PackageLoader.cs
+++ b/src/Nuplane.Loading/PackageLoader.cs
@@ -215,6 +215,7 @@ internal sealed class PackageLoader : IPackageLoader
 
         AssemblyLoadContext? context = null;
         var replacedContexts = new List<AssemblyLoadContext>();
+        var catalogPublished = false;
 
         try
         {
@@ -245,6 +246,7 @@ internal sealed class PackageLoader : IPackageLoader
             if (graphLoadMode == PackageLoadMode.HostIntegrated)
             {
                 _hostIntegratedResolutionCatalog.PublishGraph(graphKey, selections, assembliesByPackageKey);
+                catalogPublished = true;
             }
 
             foreach (var package in packages)
@@ -297,6 +299,11 @@ internal sealed class PackageLoader : IPackageLoader
                     ReferenceEquals(existingContext, context))
                 {
                     _contexts.TryRemove(key, out _);
+                }
+
+                if (catalogPublished)
+                {
+                    _hostIntegratedResolutionCatalog.RemovePackage(package.Id, package.Version);
                 }
 
                 failed[package.Id] = ex.Message;

--- a/src/Nuplane.Loading/PackageUnloadCoordinator.cs
+++ b/src/Nuplane.Loading/PackageUnloadCoordinator.cs
@@ -83,6 +83,19 @@ internal sealed class PackageUnloadCoordinator : IPackageUnloadCoordinator
 
         var attempt = _attempts.AddOrUpdate(sessionKey, 1, (_, current) => current + 1);
 
+        if (!loadContext.IsCollectible)
+        {
+            var unloadSkipped = new UnloadOutcomeRecord(
+                packageId,
+                attempt,
+                DateTimeOffset.UtcNow,
+                UnloadOutcome.Failed,
+                "host-integrated-context-not-collectible",
+                RetryEligible: false,
+                correlationId);
+            return (deactivation, unloadSkipped);
+        }
+
         try
         {
             var weakReference = new WeakReference(loadContext);

--- a/src/Nuplane.Loading/Registration/LoadingRegistrationServices.cs
+++ b/src/Nuplane.Loading/Registration/LoadingRegistrationServices.cs
@@ -37,6 +37,9 @@ public static class LoadingRegistrationServices
         ReplaceSingleton<LoadingEventDispatcher, LoadingEventDispatcher>(services);
         services.TryAddSingleton<LoadingCatalogRefreshTracker>();
         services.TryAddSingleton<SharedAssemblyPolicyMatcher>();
+        services.TryAddSingleton<PackageLoadModeSelector>();
+        services.TryAddSingleton<HostIntegratedAssemblyResolutionCatalog>();
+        services.TryAddSingleton<HostIntegratedAssemblyResolver>();
         services.TryAddSingleton<PackageLoader>();
         services.TryAddSingleton<AssemblyScanCandidateProjector>();
         services.TryAddSingleton<PackageAssemblyProvider>();

--- a/test/Nuplane.Loading.Tests.Fixtures.Conflict/ConflictFixtureTypes.cs
+++ b/test/Nuplane.Loading.Tests.Fixtures.Conflict/ConflictFixtureTypes.cs
@@ -1,0 +1,3 @@
+namespace Nuplane.Loading.Tests.Fixtures.Conflict;
+
+public sealed class ConflictFixtureMarker;

--- a/test/Nuplane.Loading.Tests.Fixtures.Conflict/Nuplane.Loading.Tests.Fixtures.Conflict.csproj
+++ b/test/Nuplane.Loading.Tests.Fixtures.Conflict/Nuplane.Loading.Tests.Fixtures.Conflict.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <AssemblyName>Nuplane.Loading.Tests.Fixtures</AssemblyName>
+    <RootNamespace>Nuplane.Loading.Tests.Fixtures.Conflict</RootNamespace>
+    <Version>2.0.0</Version>
+    <AssemblyVersion>2.0.0.0</AssemblyVersion>
+    <FileVersion>2.0.0.0</FileVersion>
+  </PropertyGroup>
+
+</Project>

--- a/test/Nuplane.Loading.Tests.Fixtures/HostIntegratedFixtureTypes.cs
+++ b/test/Nuplane.Loading.Tests.Fixtures/HostIntegratedFixtureTypes.cs
@@ -1,0 +1,3 @@
+namespace Nuplane.Loading.Tests.Fixtures;
+
+public sealed class HostIntegratedFixtureMarker;

--- a/test/Nuplane.Loading.Tests/HostIntegratedAssemblyResolutionCatalogTests.cs
+++ b/test/Nuplane.Loading.Tests/HostIntegratedAssemblyResolutionCatalogTests.cs
@@ -166,6 +166,24 @@ public sealed class HostIntegratedAssemblyResolutionCatalogTests
         Assert.Equal("not-found", diagnostic.Outcome);
     }
 
+    [Fact]
+    public void TryResolve_WhenUnsignedFullIdentityMatches_Resolves()
+    {
+        var sut = new HostIntegratedAssemblyResolutionCatalog();
+        var assembly = typeof(FixtureMarker).Assembly;
+        sut.PublishGraph(
+            "graph:first",
+            [new PackageLoadModeSelection("pkg-a", "1.0.0", PackageLoadMode.HostIntegrated, "default", "graph:first")],
+            new Dictionary<string, IReadOnlyList<Assembly>>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["pkg-a@1.0.0"] = [assembly]
+            });
+
+        Assert.True(sut.TryResolve(new AssemblyName(assembly.FullName!), out var resolvedAssembly, out var diagnostic));
+        Assert.Same(assembly, resolvedAssembly);
+        Assert.Equal("success", diagnostic.Outcome);
+    }
+
     private static string GetConflictAssemblyPath()
     {
         var path = Path.GetFullPath(Path.Combine(

--- a/test/Nuplane.Loading.Tests/HostIntegratedAssemblyResolutionCatalogTests.cs
+++ b/test/Nuplane.Loading.Tests/HostIntegratedAssemblyResolutionCatalogTests.cs
@@ -1,0 +1,59 @@
+using System.Reflection;
+using Nuplane.Loading.Tests.Fixtures;
+
+namespace Nuplane.Loading.Tests;
+
+public sealed class HostIntegratedAssemblyResolutionCatalogTests
+{
+    [Fact]
+    public void PublishGraph_WhenReplacementConflicts_KeepsLastKnownGoodGenerationVisible()
+    {
+        var sut = new HostIntegratedAssemblyResolutionCatalog();
+        var assembly = typeof(FixtureMarker).Assembly;
+        var initialSelection = new PackageLoadModeSelection("pkg-a", "1.0.0", PackageLoadMode.HostIntegrated, "default", "graph:pkg-a");
+        sut.PublishGraph(
+            "graph:pkg-a",
+            [initialSelection],
+            new Dictionary<string, IReadOnlyList<Assembly>>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["pkg-a@1.0.0"] = [assembly]
+            });
+        var generation = sut.Generation;
+
+        var ex = Assert.Throws<InvalidOperationException>(() => sut.PublishGraph(
+            "graph:conflict",
+            [
+                new PackageLoadModeSelection("pkg-a", "1.0.0", PackageLoadMode.HostIntegrated, "default", "graph:conflict"),
+                new PackageLoadModeSelection("pkg-b", "2.0.0", PackageLoadMode.HostIntegrated, "default", "graph:conflict")
+            ],
+            new Dictionary<string, IReadOnlyList<Assembly>>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["pkg-a@1.0.0"] = [assembly],
+                ["pkg-b@2.0.0"] = [Assembly.LoadFile(GetConflictAssemblyPath())]
+            }));
+
+        Assert.Contains("Host-integrated assembly conflict", ex.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(generation, sut.Generation);
+        Assert.True(sut.TryResolve(assembly.GetName(), out var resolvedAssembly, out var diagnostic));
+        Assert.Same(assembly, resolvedAssembly);
+        Assert.Equal("success", diagnostic.Outcome);
+    }
+
+    private static string GetConflictAssemblyPath()
+    {
+        var path = Path.GetFullPath(Path.Combine(
+            AppContext.BaseDirectory,
+            "..",
+            "..",
+            "..",
+            "..",
+            "Nuplane.Loading.Tests.Fixtures.Conflict",
+            "bin",
+            "Debug",
+            "net10.0",
+            "Nuplane.Loading.Tests.Fixtures.dll"));
+
+        Assert.True(File.Exists(path), $"Expected conflict fixture at '{path}'.");
+        return path;
+    }
+}

--- a/test/Nuplane.Loading.Tests/HostIntegratedAssemblyResolutionCatalogTests.cs
+++ b/test/Nuplane.Loading.Tests/HostIntegratedAssemblyResolutionCatalogTests.cs
@@ -39,6 +39,74 @@ public sealed class HostIntegratedAssemblyResolutionCatalogTests
         Assert.Equal("success", diagnostic.Outcome);
     }
 
+    [Fact]
+    public void PublishGraph_WhenPublishingDifferentGraphs_PreservesPreviouslyPublishedEntries()
+    {
+        var sut = new HostIntegratedAssemblyResolutionCatalog();
+        var firstAssembly = typeof(FixtureMarker).Assembly;
+        var secondAssembly = typeof(HostIntegratedAssemblyResolutionCatalogTests).Assembly;
+
+        sut.PublishGraph(
+            "graph:first",
+            [new PackageLoadModeSelection("pkg-a", "1.0.0", PackageLoadMode.HostIntegrated, "default", "graph:first")],
+            new Dictionary<string, IReadOnlyList<Assembly>>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["pkg-a@1.0.0"] = [firstAssembly]
+            });
+        sut.PublishGraph(
+            "graph:second",
+            [new PackageLoadModeSelection("pkg-b", "1.0.0", PackageLoadMode.HostIntegrated, "default", "graph:second")],
+            new Dictionary<string, IReadOnlyList<Assembly>>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["pkg-b@1.0.0"] = [secondAssembly]
+            });
+
+        Assert.True(sut.TryResolve(firstAssembly.GetName(), out var resolvedFirst, out _));
+        Assert.True(sut.TryResolve(secondAssembly.GetName(), out var resolvedSecond, out _));
+        Assert.Same(firstAssembly, resolvedFirst);
+        Assert.Same(secondAssembly, resolvedSecond);
+    }
+
+    [Fact]
+    public void RemovePackage_WhenEntryExists_IncrementsGeneration()
+    {
+        var sut = new HostIntegratedAssemblyResolutionCatalog();
+        var assembly = typeof(FixtureMarker).Assembly;
+        sut.PublishGraph(
+            "graph:first",
+            [new PackageLoadModeSelection("pkg-a", "1.0.0", PackageLoadMode.HostIntegrated, "default", "graph:first")],
+            new Dictionary<string, IReadOnlyList<Assembly>>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["pkg-a@1.0.0"] = [assembly]
+            });
+        var generation = sut.Generation;
+
+        sut.RemovePackage("pkg-a", "1.0.0");
+
+        Assert.True(sut.Generation > generation);
+        Assert.False(sut.TryResolve(assembly.GetName(), out _, out _));
+    }
+
+    [Fact]
+    public void ValidateCanPublishGraph_WhenCandidateConflictsWithExistingEntry_FailsBeforeLoad()
+    {
+        var sut = new HostIntegratedAssemblyResolutionCatalog();
+        var assembly = typeof(FixtureMarker).Assembly;
+        sut.PublishGraph(
+            "graph:first",
+            [new PackageLoadModeSelection("pkg-a", "1.0.0", PackageLoadMode.HostIntegrated, "default", "graph:first")],
+            new Dictionary<string, IReadOnlyList<Assembly>>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["pkg-a@1.0.0"] = [assembly]
+            });
+
+        var ex = Assert.Throws<InvalidOperationException>(() => sut.ValidateCanPublishGraph(
+            "graph:second",
+            [new HostIntegratedAssemblyResolutionCandidate(assembly.GetName().Name!, new Version(99, 0, 0, 0), "pkg-b", "2.0.0", "graph:second")]));
+
+        Assert.Contains("Host-integrated assembly conflict", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
     private static string GetConflictAssemblyPath()
     {
         var path = Path.GetFullPath(Path.Combine(

--- a/test/Nuplane.Loading.Tests/HostIntegratedAssemblyResolutionCatalogTests.cs
+++ b/test/Nuplane.Loading.Tests/HostIntegratedAssemblyResolutionCatalogTests.cs
@@ -107,6 +107,65 @@ public sealed class HostIntegratedAssemblyResolutionCatalogTests
         Assert.Contains("Host-integrated assembly conflict", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 
+    [Fact]
+    public void ValidateCanPublishGraph_WhenSameAssemblyNameAndVersionComesFromDifferentPackage_FailsBeforeLoad()
+    {
+        var sut = new HostIntegratedAssemblyResolutionCatalog();
+        var assemblyName = typeof(FixtureMarker).Assembly.GetName();
+
+        var ex = Assert.Throws<InvalidOperationException>(() => sut.ValidateCanPublishGraph(
+            "graph:ambiguous",
+            [
+                new HostIntegratedAssemblyResolutionCandidate(assemblyName.Name!, assemblyName.Version, "pkg-a", "1.0.0", "graph:ambiguous"),
+                new HostIntegratedAssemblyResolutionCandidate(assemblyName.Name!, assemblyName.Version, "pkg-b", "1.0.0", "graph:ambiguous")
+            ]));
+
+        Assert.Contains("Host-integrated assembly conflict", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void PublishGraph_WhenSameAssemblyNameAndVersionComesFromDifferentPackage_KeepsLastKnownGoodGenerationVisible()
+    {
+        var sut = new HostIntegratedAssemblyResolutionCatalog();
+        var assembly = typeof(FixtureMarker).Assembly;
+
+        var ex = Assert.Throws<InvalidOperationException>(() => sut.PublishGraph(
+            "graph:ambiguous",
+            [
+                new PackageLoadModeSelection("pkg-a", "1.0.0", PackageLoadMode.HostIntegrated, "default", "graph:ambiguous"),
+                new PackageLoadModeSelection("pkg-b", "1.0.0", PackageLoadMode.HostIntegrated, "default", "graph:ambiguous")
+            ],
+            new Dictionary<string, IReadOnlyList<Assembly>>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["pkg-a@1.0.0"] = [assembly],
+                ["pkg-b@1.0.0"] = [assembly]
+            }));
+
+        Assert.Contains("Host-integrated assembly conflict", ex.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(0, sut.Generation);
+        Assert.False(sut.TryResolve(assembly.GetName(), out _, out _));
+    }
+
+    [Fact]
+    public void TryResolve_WhenFullIdentityDoesNotMatch_ReturnsNotFound()
+    {
+        var sut = new HostIntegratedAssemblyResolutionCatalog();
+        var assembly = typeof(FixtureMarker).Assembly;
+        sut.PublishGraph(
+            "graph:first",
+            [new PackageLoadModeSelection("pkg-a", "1.0.0", PackageLoadMode.HostIntegrated, "default", "graph:first")],
+            new Dictionary<string, IReadOnlyList<Assembly>>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["pkg-a@1.0.0"] = [assembly]
+            });
+        var requestedName = assembly.GetName();
+        requestedName.CultureName = "fr-FR";
+
+        Assert.False(sut.TryResolve(requestedName, out var resolvedAssembly, out var diagnostic));
+        Assert.Null(resolvedAssembly);
+        Assert.Equal("not-found", diagnostic.Outcome);
+    }
+
     private static string GetConflictAssemblyPath()
     {
         var path = Path.GetFullPath(Path.Combine(

--- a/test/Nuplane.Loading.Tests/HostIntegratedAssemblyResolverDiagnosticsTests.cs
+++ b/test/Nuplane.Loading.Tests/HostIntegratedAssemblyResolverDiagnosticsTests.cs
@@ -1,0 +1,19 @@
+using System.Reflection;
+
+namespace Nuplane.Loading.Tests;
+
+public sealed class HostIntegratedAssemblyResolverDiagnosticsTests
+{
+    [Fact]
+    public void TryResolve_WhenAssemblyIsNotActive_ReturnsNotFoundDiagnostic()
+    {
+        var sut = new HostIntegratedAssemblyResolutionCatalog();
+
+        var resolved = sut.TryResolve(new AssemblyName("Missing.Framework.Extension"), out var assembly, out var diagnostic);
+
+        Assert.False(resolved);
+        Assert.Null(assembly);
+        Assert.Equal("not-found", diagnostic.Outcome);
+        Assert.Contains("Missing.Framework.Extension", diagnostic.Message, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/test/Nuplane.Loading.Tests/LoadingOptionsValidatorTests.cs
+++ b/test/Nuplane.Loading.Tests/LoadingOptionsValidatorTests.cs
@@ -1,0 +1,41 @@
+namespace Nuplane.Loading.Tests;
+
+public sealed class LoadingOptionsValidatorTests
+{
+    [Fact]
+    public void Validate_DefaultOptions_ReturnsNoLoadModeErrors()
+    {
+        var sut = new LoadingOptionsValidator();
+
+        var errors = sut.Validate(new LoadingOptions());
+
+        Assert.DoesNotContain(errors, error => error.Contains("load mode", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void Validate_InvalidDefaultLoadMode_ReturnsError()
+    {
+        var sut = new LoadingOptionsValidator();
+        var options = new LoadingOptions
+        {
+            DefaultLoadMode = (PackageLoadMode)42
+        };
+
+        var errors = sut.Validate(options);
+
+        Assert.Contains(errors, error => error.Contains("default load mode", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void Validate_DuplicatePackageLoadModeOverrides_ReturnsError()
+    {
+        var sut = new LoadingOptionsValidator();
+        var options = new LoadingOptions();
+        options.PackageLoadModes.Add(new() { PackageId = "pkg-a", LoadMode = PackageLoadMode.HostIntegrated });
+        options.PackageLoadModes.Add(new() { PackageId = "PKG-A", LoadMode = PackageLoadMode.Collectible });
+
+        var errors = sut.Validate(options);
+
+        Assert.Contains(errors, error => error.Contains("Duplicate package load mode override", StringComparison.OrdinalIgnoreCase));
+    }
+}

--- a/test/Nuplane.Loading.Tests/LoadingOptionsValidatorTests.cs
+++ b/test/Nuplane.Loading.Tests/LoadingOptionsValidatorTests.cs
@@ -38,4 +38,16 @@ public sealed class LoadingOptionsValidatorTests
 
         Assert.Contains(errors, error => error.Contains("Duplicate package load mode override", StringComparison.OrdinalIgnoreCase));
     }
+
+    [Fact]
+    public void Validate_PackageLoadModeOverrideWithSurroundingWhitespace_ReturnsError()
+    {
+        var sut = new LoadingOptionsValidator();
+        var options = new LoadingOptions();
+        options.PackageLoadModes.Add(new() { PackageId = "pkg-a ", LoadMode = PackageLoadMode.HostIntegrated });
+
+        var errors = sut.Validate(options);
+
+        Assert.Contains(errors, error => error.Contains("leading or trailing whitespace", StringComparison.OrdinalIgnoreCase));
+    }
 }

--- a/test/Nuplane.Loading.Tests/LoadingRegistrationDeterminismTests.cs
+++ b/test/Nuplane.Loading.Tests/LoadingRegistrationDeterminismTests.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Nuplane.Operational;
+using Nuplane.Loading.Hosting.Builder;
 using Nuplane.Loading.Registration;
 
 namespace Nuplane.Loading.Tests;
@@ -75,5 +76,34 @@ public sealed class LoadingRegistrationDeterminismTests
         LoadingRegistrationServices.Register(services);
 
         Assert.Single(services, d => d.ServiceType == typeof(SharedAssemblyPolicyMatcher));
+    }
+
+    [Fact]
+    public void NuplaneLoadingBuilder_WithDefaultLoadMode_ConfiguresOptions()
+    {
+        var services = new ServiceCollection();
+        services.AddOptions();
+        var builder = new NuplaneLoadingBuilder(services);
+
+        builder.WithDefaultLoadMode(PackageLoadMode.HostIntegrated);
+
+        using var provider = services.BuildServiceProvider();
+        var options = provider.GetRequiredService<IOptions<LoadingOptions>>().Value;
+        Assert.Equal(PackageLoadMode.HostIntegrated, options.DefaultLoadMode);
+    }
+
+    [Fact]
+    public void NuplaneLoadingBuilder_PackageLoadMode_ConfiguresPackageOverride()
+    {
+        var services = new ServiceCollection();
+        services.AddOptions();
+        var builder = new NuplaneLoadingBuilder(services);
+
+        builder.PackageLoadMode("pkg-a", PackageLoadMode.HostIntegrated);
+
+        using var provider = services.BuildServiceProvider();
+        var packageOverride = Assert.Single(provider.GetRequiredService<IOptions<LoadingOptions>>().Value.PackageLoadModes);
+        Assert.Equal("pkg-a", packageOverride.PackageId);
+        Assert.Equal(PackageLoadMode.HostIntegrated, packageOverride.LoadMode);
     }
 }

--- a/test/Nuplane.Loading.Tests/LoadingRegistrationDeterminismTests.cs
+++ b/test/Nuplane.Loading.Tests/LoadingRegistrationDeterminismTests.cs
@@ -99,7 +99,7 @@ public sealed class LoadingRegistrationDeterminismTests
         services.AddOptions();
         var builder = new NuplaneLoadingBuilder(services);
 
-        builder.PackageLoadMode("pkg-a", PackageLoadMode.HostIntegrated);
+        builder.PackageLoadMode(" pkg-a ", PackageLoadMode.HostIntegrated);
 
         using var provider = services.BuildServiceProvider();
         var packageOverride = Assert.Single(provider.GetRequiredService<IOptions<LoadingOptions>>().Value.PackageLoadModes);

--- a/test/Nuplane.Loading.Tests/Nuplane.Loading.Tests.csproj
+++ b/test/Nuplane.Loading.Tests/Nuplane.Loading.Tests.csproj
@@ -14,6 +14,9 @@
     <ProjectReference Include="..\Nuplane.Loading.Tests.Fixtures.BrokenCandidate\Nuplane.Loading.Tests.Fixtures.BrokenCandidate.csproj"
                       ReferenceOutputAssembly="false"
                       PrivateAssets="all" />
+    <ProjectReference Include="..\Nuplane.Loading.Tests.Fixtures.Conflict\Nuplane.Loading.Tests.Fixtures.Conflict.csproj"
+                      ReferenceOutputAssembly="false"
+                      PrivateAssets="all" />
   </ItemGroup>
 
 </Project>

--- a/test/Nuplane.Loading.Tests/PackageAssemblyCatalogHostIntegratedTests.cs
+++ b/test/Nuplane.Loading.Tests/PackageAssemblyCatalogHostIntegratedTests.cs
@@ -1,0 +1,57 @@
+using System.Reflection;
+
+namespace Nuplane.Loading.Tests;
+
+public sealed class PackageAssemblyCatalogHostIntegratedTests
+{
+    [Fact]
+    public async Task GetPackagedAssembliesAsync_HostIntegratedState_ReturnsFrameworkSafetyMetadata()
+    {
+        var assembly = typeof(PackageAssemblyCatalogHostIntegratedTests).Assembly;
+        var loadingCatalog = new StubLoadingCatalog(new PackageLoadStateSnapshot(
+            PackageLoadStateAvailability.Available,
+            DateTimeOffset.UtcNow,
+            DateTimeOffset.UtcNow,
+            [
+                new PackageLoadState(
+                    "pkg-a",
+                    "1.0.0",
+                    PackageLoadStatus.Loaded,
+                    "/packages/pkg-a",
+                    DateTimeOffset.UtcNow,
+                    [],
+                    [new PackageAssemblyReference("/packages/pkg-a/a.dll", "a.dll", null, "PrimaryLoadAssembly", "selected")],
+                    LoadMode: PackageLoadMode.HostIntegrated,
+                    FrameworkIntegrationSafe: true)
+            ],
+            null,
+            "corr-host-integrated"));
+        var provider = new StubPackageAssemblyProvider(
+            new Dictionary<string, IReadOnlyList<Assembly>>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["pkg-a@1.0.0"] = [assembly]
+            });
+        var sut = new PackageAssemblyCatalog(loadingCatalog, provider);
+
+        var package = Assert.Single(await sut.GetPackagedAssembliesAsync(CancellationToken.None));
+
+        Assert.Equal(PackageLoadMode.HostIntegrated, package.LoadMode);
+        Assert.True(package.FrameworkIntegrationSafe);
+        Assert.Single(package.Assemblies, assembly);
+    }
+
+    private sealed class StubLoadingCatalog(PackageLoadStateSnapshot snapshot) : IPackageLoadStateCatalog
+    {
+        public Task<PackageLoadStateSnapshot> GetLoadStateAsync(CancellationToken cancellationToken) => Task.FromResult(snapshot);
+    }
+
+    private sealed class StubPackageAssemblyProvider(
+        IReadOnlyDictionary<string, IReadOnlyList<Assembly>> assembliesByPackage) : IPackageAssemblyProvider
+    {
+        public IReadOnlyList<Assembly> GetAssemblies(string packageId, string version)
+        {
+            var key = $"{packageId}@{version}";
+            return assembliesByPackage.TryGetValue(key, out var assemblies) ? assemblies : [];
+        }
+    }
+}

--- a/test/Nuplane.Loading.Tests/PackageLoadModeSelectorTests.cs
+++ b/test/Nuplane.Loading.Tests/PackageLoadModeSelectorTests.cs
@@ -1,0 +1,33 @@
+using Nuplane.Abstractions;
+
+namespace Nuplane.Loading.Tests;
+
+public sealed class PackageLoadModeSelectorTests
+{
+    [Fact]
+    public void Select_WhenNoOverride_UsesDefaultLoadMode()
+    {
+        var sut = new PackageLoadModeSelector();
+        var options = new LoadingOptions { DefaultLoadMode = PackageLoadMode.HostIntegrated };
+
+        var selection = sut.Select(Pkg("pkg-a"), options, "graph:pkg-a");
+
+        Assert.Equal(PackageLoadMode.HostIntegrated, selection.LoadMode);
+        Assert.Equal("default", selection.SelectionReason);
+    }
+
+    [Fact]
+    public void Select_WhenOverrideMatches_UsesPackageOverride()
+    {
+        var sut = new PackageLoadModeSelector();
+        var options = new LoadingOptions { DefaultLoadMode = PackageLoadMode.Collectible };
+        options.PackageLoadModes.Add(new() { PackageId = "PKG-A", LoadMode = PackageLoadMode.HostIntegrated });
+
+        var selection = sut.Select(Pkg("pkg-a"), options, "graph:pkg-a");
+
+        Assert.Equal(PackageLoadMode.HostIntegrated, selection.LoadMode);
+        Assert.Equal("package-override", selection.SelectionReason);
+    }
+
+    private static ResolvedPackage Pkg(string id) => new(id, "1.0.0", "feed-a", "/tmp/pkg", DateTimeOffset.UtcNow, id);
+}

--- a/test/Nuplane.Loading.Tests/PackageLoaderHostIntegratedConflictTests.cs
+++ b/test/Nuplane.Loading.Tests/PackageLoaderHostIntegratedConflictTests.cs
@@ -1,0 +1,63 @@
+using Microsoft.Extensions.Options;
+using Nuplane.Abstractions;
+using Nuplane.Loading.Tests.Fixtures;
+
+namespace Nuplane.Loading.Tests;
+
+public sealed class PackageLoaderHostIntegratedConflictTests : IDisposable
+{
+    private readonly DirectoryInfo tempDir = Directory.CreateTempSubdirectory("nuplane-host-integrated-conflict-test-");
+
+    public void Dispose() => tempDir.Delete(recursive: true);
+
+    [Fact]
+    public async Task EnsureGraphLoadedAsync_HostIntegratedVersionConflict_FailsBeforePublishingVisibility()
+    {
+        var firstPath = CreateInstallDir("pkg-a", typeof(FixtureMarker).Assembly.Location);
+        var secondPath = CreateInstallDir("pkg-b", GetConflictAssemblyPath());
+        var catalog = new HostIntegratedAssemblyResolutionCatalog();
+        var options = Options.Create(new LoadingOptions { DefaultLoadMode = PackageLoadMode.HostIntegrated });
+        var loader = new PackageLoader(options: options, hostIntegratedResolutionCatalog: catalog);
+
+        var result = await loader.EnsureGraphLoadedAsync(
+            [[
+                Pkg("pkg-a", "1.0.0", firstPath),
+                Pkg("pkg-b", "2.0.0", secondPath)
+            ]],
+            [],
+            CancellationToken.None);
+
+        Assert.Empty(result.Loaded);
+        Assert.Equal(["pkg-a", "pkg-b"], result.FailedByPackageId.Keys.Order(StringComparer.OrdinalIgnoreCase));
+        Assert.All(result.FailedByPackageId.Values, reason => Assert.Contains("Host-integrated assembly conflict", reason, StringComparison.OrdinalIgnoreCase));
+        Assert.Equal(0, catalog.Generation);
+    }
+
+    private string CreateInstallDir(string packageId, string sourceAssemblyPath)
+    {
+        var dir = tempDir.CreateSubdirectory(packageId);
+        File.Copy(sourceAssemblyPath, Path.Combine(dir.FullName, "Nuplane.Loading.Tests.Fixtures.dll"));
+        return dir.FullName;
+    }
+
+    private static string GetConflictAssemblyPath()
+    {
+        var path = Path.GetFullPath(Path.Combine(
+            AppContext.BaseDirectory,
+            "..",
+            "..",
+            "..",
+            "..",
+            "Nuplane.Loading.Tests.Fixtures.Conflict",
+            "bin",
+            "Debug",
+            "net10.0",
+            "Nuplane.Loading.Tests.Fixtures.dll"));
+
+        Assert.True(File.Exists(path), $"Expected conflict fixture at '{path}'.");
+        return path;
+    }
+
+    private static ResolvedPackage Pkg(string id, string version, string installPath) =>
+        new(id, version, "feed-a", installPath, DateTimeOffset.UtcNow, id);
+}

--- a/test/Nuplane.Loading.Tests/PackageLoaderHostIntegratedTests.cs
+++ b/test/Nuplane.Loading.Tests/PackageLoaderHostIntegratedTests.cs
@@ -49,10 +49,40 @@ public sealed class PackageLoaderHostIntegratedTests : IDisposable
         Assert.Equal("success", diagnostic.Outcome);
     }
 
-    private string CreateInstallDir(string packageId)
+    [Fact]
+    public async Task EnsureGraphLoadedAsync_WhenAnyPackageIsHostIntegrated_PromotesDependencyClosure()
+    {
+        var firstInstallPath = CreateInstallDir("pkg-a", typeof(FixtureMarker).Assembly);
+        var secondInstallPath = CreateInstallDir("pkg-b", typeof(PackageLoaderHostIntegratedTests).Assembly);
+        var catalog = new HostIntegratedAssemblyResolutionCatalog();
+        var loadingOptions = new LoadingOptions();
+        loadingOptions.PackageLoadModes.Add(new() { PackageId = "pkg-a", LoadMode = PackageLoadMode.HostIntegrated });
+        var options = Options.Create(loadingOptions);
+        var loader = new PackageLoader(options: options, hostIntegratedResolutionCatalog: catalog);
+
+        var result = await loader.EnsureGraphLoadedAsync(
+            [[Pkg("pkg-a", "1.0.0", firstInstallPath), Pkg("pkg-b", "1.0.0", secondInstallPath)]],
+            [],
+            CancellationToken.None);
+
+        Assert.Empty(result.FailedByPackageId);
+        Assert.Equal(2, result.Loaded.Count);
+        Assert.All(result.Loaded, session =>
+        {
+            Assert.Equal(PackageLoadMode.HostIntegrated, session.LoadMode);
+            Assert.True(session.FrameworkIntegrationSafe);
+        });
+        Assert.True(catalog.TryResolve(typeof(FixtureMarker).Assembly.GetName(), out _, out _));
+        Assert.True(catalog.TryResolve(typeof(PackageLoaderHostIntegratedTests).Assembly.GetName(), out _, out _));
+    }
+
+    private string CreateInstallDir(string packageId) =>
+        CreateInstallDir(packageId, typeof(FixtureMarker).Assembly);
+
+    private string CreateInstallDir(string packageId, Assembly assembly)
     {
         var dir = tempDir.CreateSubdirectory(packageId);
-        File.Copy(typeof(FixtureMarker).Assembly.Location, Path.Combine(dir.FullName, $"{packageId}.dll"));
+        File.Copy(assembly.Location, Path.Combine(dir.FullName, $"{packageId}.dll"));
         return dir.FullName;
     }
 

--- a/test/Nuplane.Loading.Tests/PackageLoaderHostIntegratedTests.cs
+++ b/test/Nuplane.Loading.Tests/PackageLoaderHostIntegratedTests.cs
@@ -1,5 +1,6 @@
 using System.Reflection;
 using System.Runtime.Loader;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Nuplane.Abstractions;
 using Nuplane.Loading.Tests.Fixtures;
@@ -10,7 +11,19 @@ public sealed class PackageLoaderHostIntegratedTests : IDisposable
 {
     private readonly DirectoryInfo tempDir = Directory.CreateTempSubdirectory("nuplane-host-integrated-test-");
 
-    public void Dispose() => tempDir.Delete(recursive: true);
+    public void Dispose()
+    {
+        try
+        {
+            tempDir.Delete(recursive: true);
+        }
+        catch (IOException)
+        {
+        }
+        catch (UnauthorizedAccessException)
+        {
+        }
+    }
 
     [Fact]
     public async Task EnsureGraphLoadedAsync_HostIntegratedPackage_RegistersNonCollectibleFrameworkSafeSession()
@@ -96,6 +109,25 @@ public sealed class PackageLoaderHostIntegratedTests : IDisposable
         Assert.Equal("success", diagnostic.Outcome);
     }
 
+    [Fact]
+    public async Task EnsureGraphLoadedAsync_WhenExceptionOccursAfterPublishingHostIntegratedGraph_RemovesCatalogEntries()
+    {
+        var installPath = CreateInstallDir("pkg-a", typeof(FixtureMarker).Assembly);
+        var catalog = new HostIntegratedAssemblyResolutionCatalog();
+        var options = Options.Create(new LoadingOptions { DefaultLoadMode = PackageLoadMode.HostIntegrated });
+        var loader = new PackageLoader(
+            options: options,
+            hostIntegratedResolutionCatalog: catalog,
+            logger: new ThrowingPackageLoaderLogger());
+        var package = Pkg("pkg-a", "1.0.0", installPath);
+
+        var result = await loader.EnsureGraphLoadedAsync([[package]], [], CancellationToken.None);
+
+        Assert.Contains("pkg-a", result.FailedByPackageId.Keys);
+        Assert.False(catalog.TryResolve(typeof(FixtureMarker).Assembly.GetName(), out _, out var diagnostic));
+        Assert.Equal("not-found", diagnostic.Outcome);
+    }
+
     private string CreateInstallDir(string packageId) =>
         CreateInstallDir(packageId, typeof(FixtureMarker).Assembly);
 
@@ -108,4 +140,30 @@ public sealed class PackageLoaderHostIntegratedTests : IDisposable
 
     private static ResolvedPackage Pkg(string id, string version, string installPath) =>
         new(id, version, "feed-a", installPath, DateTimeOffset.UtcNow, id);
+
+    private sealed class ThrowingPackageLoaderLogger : ILogger<PackageLoader>
+    {
+        public IDisposable BeginScope<TState>(TState state)
+            where TState : notnull =>
+            NullScope.Instance;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter) =>
+            throw new InvalidOperationException("Logger failure after catalog publish.");
+    }
+
+    private sealed class NullScope : IDisposable
+    {
+        public static readonly NullScope Instance = new();
+
+        public void Dispose()
+        {
+        }
+    }
 }

--- a/test/Nuplane.Loading.Tests/PackageLoaderHostIntegratedTests.cs
+++ b/test/Nuplane.Loading.Tests/PackageLoaderHostIntegratedTests.cs
@@ -1,0 +1,61 @@
+using System.Reflection;
+using System.Runtime.Loader;
+using Microsoft.Extensions.Options;
+using Nuplane.Abstractions;
+using Nuplane.Loading.Tests.Fixtures;
+
+namespace Nuplane.Loading.Tests;
+
+public sealed class PackageLoaderHostIntegratedTests : IDisposable
+{
+    private readonly DirectoryInfo tempDir = Directory.CreateTempSubdirectory("nuplane-host-integrated-test-");
+
+    public void Dispose() => tempDir.Delete(recursive: true);
+
+    [Fact]
+    public async Task EnsureGraphLoadedAsync_HostIntegratedPackage_RegistersNonCollectibleFrameworkSafeSession()
+    {
+        var installPath = CreateInstallDir("Nuplane.Loading.Tests.Fixtures");
+        var catalog = new HostIntegratedAssemblyResolutionCatalog();
+        var options = Options.Create(new LoadingOptions { DefaultLoadMode = PackageLoadMode.HostIntegrated });
+        var loader = new PackageLoader(options: options, hostIntegratedResolutionCatalog: catalog);
+        var package = Pkg("Nuplane.Loading.Tests.Fixtures", "1.0.0", installPath);
+
+        var result = await loader.EnsureGraphLoadedAsync([[package]], [], CancellationToken.None);
+
+        var session = Assert.Single(result.Loaded);
+        Assert.Empty(result.FailedByPackageId);
+        Assert.Equal(PackageLoadMode.HostIntegrated, session.LoadMode);
+        Assert.True(session.FrameworkIntegrationSafe);
+        Assert.True(loader.TryGetContext(package.Id, package.Version, out var handle));
+        var loadContext = Assert.IsAssignableFrom<AssemblyLoadContext>(handle!.Context);
+        Assert.False(loadContext.IsCollectible);
+    }
+
+    [Fact]
+    public async Task EnsureGraphLoadedAsync_HostIntegratedPackage_PublishesAssemblyResolutionEntry()
+    {
+        var installPath = CreateInstallDir("Nuplane.Loading.Tests.Fixtures");
+        var catalog = new HostIntegratedAssemblyResolutionCatalog();
+        var options = Options.Create(new LoadingOptions { DefaultLoadMode = PackageLoadMode.HostIntegrated });
+        var loader = new PackageLoader(options: options, hostIntegratedResolutionCatalog: catalog);
+        var package = Pkg("Nuplane.Loading.Tests.Fixtures", "1.0.0", installPath);
+
+        await loader.EnsureGraphLoadedAsync([[package]], [], CancellationToken.None);
+
+        var assemblyName = new AssemblyName(typeof(FixtureMarker).Assembly.FullName!);
+        Assert.True(catalog.TryResolve(assemblyName, out var assembly, out var diagnostic));
+        Assert.NotNull(assembly);
+        Assert.Equal("success", diagnostic.Outcome);
+    }
+
+    private string CreateInstallDir(string packageId)
+    {
+        var dir = tempDir.CreateSubdirectory(packageId);
+        File.Copy(typeof(FixtureMarker).Assembly.Location, Path.Combine(dir.FullName, $"{packageId}.dll"));
+        return dir.FullName;
+    }
+
+    private static ResolvedPackage Pkg(string id, string version, string installPath) =>
+        new(id, version, "feed-a", installPath, DateTimeOffset.UtcNow, id);
+}

--- a/test/Nuplane.Loading.Tests/PackageLoaderHostIntegratedTests.cs
+++ b/test/Nuplane.Loading.Tests/PackageLoaderHostIntegratedTests.cs
@@ -76,6 +76,26 @@ public sealed class PackageLoaderHostIntegratedTests : IDisposable
         Assert.True(catalog.TryResolve(typeof(PackageLoaderHostIntegratedTests).Assembly.GetName(), out _, out _));
     }
 
+    [Fact]
+    public async Task EnsureGraphLoadedAsync_WhenPackageMovesToDifferentHostIntegratedGraph_ReplacesCatalogEntries()
+    {
+        var firstInstallPath = CreateInstallDir("pkg-a", typeof(FixtureMarker).Assembly);
+        var secondInstallPath = CreateInstallDir("pkg-b", typeof(PackageLoaderHostIntegratedTests).Assembly);
+        var catalog = new HostIntegratedAssemblyResolutionCatalog();
+        var options = Options.Create(new LoadingOptions { DefaultLoadMode = PackageLoadMode.HostIntegrated });
+        var loader = new PackageLoader(options: options, hostIntegratedResolutionCatalog: catalog);
+        var firstPackage = Pkg("pkg-a", "1.0.0", firstInstallPath);
+        var secondPackage = Pkg("pkg-b", "1.0.0", secondInstallPath);
+
+        await loader.EnsureGraphLoadedAsync([[firstPackage]], [], CancellationToken.None);
+        var result = await loader.EnsureGraphLoadedAsync([[firstPackage, secondPackage]], [], CancellationToken.None);
+
+        Assert.Empty(result.FailedByPackageId);
+        Assert.True(catalog.TryResolve(typeof(FixtureMarker).Assembly.GetName(), out var resolvedAssembly, out var diagnostic));
+        Assert.NotNull(resolvedAssembly);
+        Assert.Equal("success", diagnostic.Outcome);
+    }
+
     private string CreateInstallDir(string packageId) =>
         CreateInstallDir(packageId, typeof(FixtureMarker).Assembly);
 


### PR DESCRIPTION
## Summary
- add explicit package load modes with collectible default and host-integrated configuration overrides
- add host-integrated non-collectible graph loading, assembly resolution catalog, and Nuplane-owned resolving bridge
- extend loading/catalog metadata, conflict diagnostics, LKG visibility fallback, tests, specs, and docs

## Validation
- dotnet test test/Nuplane.Loading.Tests/Nuplane.Loading.Tests.csproj --no-restore
- dotnet test nuplane.sln --no-restore