### PR TITLE
[codex] Tolerate facade packages in graph loading

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,3 +83,4 @@ Run focused tests first for the area changed, then run the full solution when pr
 ## Recent Changes
 - 017-dependency-closure-loading: Added C# with SDK-style .NET libraries targeting `net8.0;net9.0;net10.0`; tests target `net10.0` + Microsoft.Extensions.DependencyInjection/Options/Logging/Hosting, NuGet.Protocol and NuGet.Versioning already used by feed version resolution, System.Runtime.Loader, xUnit, NSubstitute
 - 018-host-integrated-loading: Added host-integrated package loading using non-collectible assembly load contexts and framework-visible resolution catalog metadata.
+- 019-tolerate-facade-packages: Added graph loading tolerance for no-assembly facade/support packages while preserving real loader failures.

--- a/specs/019-tolerate-facade-packages/checklists/requirements.md
+++ b/specs/019-tolerate-facade-packages/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Tolerate Facade Packages
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-12
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Validation passed on first review.

--- a/specs/019-tolerate-facade-packages/data-model.md
+++ b/specs/019-tolerate-facade-packages/data-model.md
@@ -1,0 +1,40 @@
+# Data Model: Tolerate Facade Packages
+
+## Resolved Package
+
+Existing package graph member with package identity, version, source information, and install path.
+
+## Loadable Graph Package
+
+Internal classification for a resolved package that has a deterministic main managed assembly for the selected host-compatible asset scope.
+
+Fields:
+- Package ID
+- Version
+- Install path
+- Main assembly path
+
+Validation rules:
+- Install path exists.
+- Framework asset selection is compatible with the host.
+- Exactly one main assembly is selected, or one assembly matches the package ID.
+
+## Non-Loadable Graph Member
+
+Internal classification for a resolved package that has no managed assemblies in the selected host-compatible asset scope.
+
+Validation rules:
+- Only applies to graph loading.
+- Does not create a package load session.
+- Does not create host-integrated assembly resolution entries.
+- Does emit a diagnostic skip log.
+
+## Package Load Session
+
+Existing record of a package whose assemblies were loaded.
+
+State transitions:
+- No prior session -> loaded session for loadable graph members.
+- No prior session -> no session for skipped non-loadable graph members.
+- Prior loaded session -> replaced only when the same package is loaded in a new context.
+- Genuine graph failure -> existing failure handling remains unchanged.

--- a/specs/019-tolerate-facade-packages/plan.md
+++ b/specs/019-tolerate-facade-packages/plan.md
@@ -1,0 +1,67 @@
+# Implementation Plan: Tolerate Facade Packages
+
+**Branch**: `019-tolerate-facade-packages` | **Date**: 2026-05-12 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/019-tolerate-facade-packages/spec.md`
+
+## Summary
+
+Package graph loading will distinguish packages that simply have no managed assemblies in the selected asset scope from packages that fail real validation or load steps. Graph members with no loadable assemblies are skipped with a structured diagnostic when at least one other graph member is loadable; only loadable graph members participate in main assembly selection, context loading, and host-integrated assembly resolution publication.
+
+## Technical Context
+
+**Language/Version**: C# on .NET 8.0, .NET 9.0, and .NET 10.0 for source projects; tests target .NET 10.0  
+**Primary Dependencies**: Nuplane loading abstractions, .NET assembly loading APIs, Microsoft.Extensions logging/options  
+**Storage**: N/A  
+**Testing**: xUnit via `dotnet test`  
+**Target Platform**: Host-neutral .NET runtime library  
+**Project Type**: Multi-targeted .NET library  
+**Performance Goals**: Preserve deterministic package graph loading without extra package extraction or network work  
+**Constraints**: Keep source trust boundaries unchanged; do not hide missing paths, incompatible frameworks, ambiguous assemblies, or load exceptions  
+**Scale/Scope**: One loader behavior change plus focused regression tests in loading tests
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- Deterministic reconciliation: PASS. The same graph deterministically produces the same loadable/skipped package classification and active sessions.
+- Transactional store safety: PASS. Genuine graph failures still fail the graph and preserve existing LKG behavior; skipped facade dependencies do not publish sessions.
+- Source integrity: PASS. Behavior applies after trusted source resolution; no source, credential, or integrity policy changes.
+- Observability: PASS. Skipped packages emit structured logs and are not recorded as failed loads.
+- Test discipline: PASS. Regression tests cover collectible graph skip, host-integrated graph skip, and all-no-assembly failure behavior.
+- Decomposition discipline: PASS. Work is limited to `PackageLoader` behavior and corresponding loading tests.
+- Options validation discipline: PASS. No configuration or options changes are introduced.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/019-tolerate-facade-packages/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── tasks.md
+└── checklists/
+    └── requirements.md
+```
+
+### Source Code (repository root)
+
+```text
+src/
+└── Nuplane.Loading/
+    └── PackageLoader.cs
+
+test/
+└── Nuplane.Loading.Tests/
+    ├── PackageLoaderGraphRegressionTests.cs
+    └── PackageLoaderHostIntegratedTests.cs
+```
+
+**Structure Decision**: Implement inside the existing loading project because the behavior belongs to graph assembly selection and context loading. Keep tests in the existing loading test project because the regression is isolated to loader behavior and host-integrated catalog publication.
+
+## Complexity Tracking
+
+No constitution violations.

--- a/specs/019-tolerate-facade-packages/quickstart.md
+++ b/specs/019-tolerate-facade-packages/quickstart.md
@@ -1,0 +1,22 @@
+# Quickstart: Tolerate Facade Packages
+
+## Validate Targeted Loading Behavior
+
+```bash
+dotnet test test/Nuplane.Loading.Tests/Nuplane.Loading.Tests.csproj
+```
+
+Expected result:
+- Loading tests pass.
+- Graph regression tests include a loadable package plus a `Microsoft.Data.Sqlite`-shaped no-assembly dependency.
+- Host-integrated tests verify the skipped dependency does not create a catalog entry.
+
+## Validate Whole Solution
+
+```bash
+dotnet restore nuplane.sln
+dotnet test nuplane.sln --no-restore
+```
+
+Expected result:
+- All solution tests pass.

--- a/specs/019-tolerate-facade-packages/research.md
+++ b/specs/019-tolerate-facade-packages/research.md
@@ -1,0 +1,24 @@
+# Research: Tolerate Facade Packages
+
+## Decision: Treat No-Assembly Graph Members As Skipped Dependencies
+
+**Rationale**: NuGet packages can legitimately contain no managed assembly for the host to load. Facade/support packages such as SQLite provider dependencies may include placeholder assets like `_._` to indicate compatibility without providing a runtime assembly in that package. Failing the whole graph in that case prevents otherwise valid plugin packages from loading.
+
+**Alternatives considered**:
+- Fail the graph whenever any package lacks an assembly. Rejected because it reproduces the SQLite provider failure.
+- Create successful sessions for skipped packages. Rejected because no assembly was loaded and downstream package assembly catalogs should only expose loaded packages.
+
+## Decision: Preserve Existing Failure Behavior For Non-Facade Errors
+
+**Rationale**: Missing install paths, incompatible framework assets, ambiguous assembly layouts, and load exceptions indicate real package or environment failures. These failures should continue to mark the graph failed so operators keep LKG protection and actionable diagnostics.
+
+**Alternatives considered**:
+- Treat all file-not-found outcomes as skipped. Rejected because missing package installation is not the same as an intentionally empty package.
+- Add configuration to opt into facade tolerance. Rejected because facade packages are valid package graph members and should not require host-specific configuration.
+
+## Decision: Publish Host-Integrated Assembly Resolution Only For Loadable Members
+
+**Rationale**: Host-integrated resolution maps assembly names to loaded assemblies. A no-assembly package has no assembly ownership to publish, so including it would add no value and could confuse diagnostics.
+
+**Alternatives considered**:
+- Publish empty ownership entries for skipped packages. Rejected because resolution lookups are assembly-centric and empty entries cannot satisfy any request.

--- a/specs/019-tolerate-facade-packages/spec.md
+++ b/specs/019-tolerate-facade-packages/spec.md
@@ -1,0 +1,82 @@
+# Feature Specification: Tolerate Facade Packages
+
+**Feature Branch**: `019-tolerate-facade-packages`  
+**Created**: 2026-05-12  
+**Status**: Draft  
+**Input**: User description: "Nuplane package loading should tolerate dependency/support NuGet packages that contain no loadable assemblies, such as facade packages like Microsoft.Data.Sqlite with lib/netstandard2.0/_._, so their presence does not fail or degrade the whole dependency graph while still loading packages in the graph that do contain assemblies and still reporting real load failures."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Load Graphs With Facade Dependencies (Priority: P1)
+
+An operator enables a plugin package whose resolved dependency graph includes support packages that have no managed assemblies for Nuplane to load. Nuplane treats those support packages as inert graph members and still activates the packages that do provide loadable assemblies.
+
+**Why this priority**: This resolves the observed SQLite provider failure where a legitimate facade package prevented the whole feature package graph from loading.
+
+**Independent Test**: Can be fully tested by loading a package graph containing one package with a loadable assembly and one dependency package with no loadable assemblies, then verifying that the graph succeeds and the loadable package is active.
+
+**Acceptance Scenarios**:
+
+1. **Given** a package graph with at least one loadable package and a dependency package containing no loadable assemblies, **When** Nuplane loads the graph, **Then** the loadable packages are activated and the dependency package does not create a failed load result.
+2. **Given** a host-integrated package graph with a facade dependency, **When** Nuplane publishes assembly resolution metadata, **Then** only packages with assemblies contribute assembly candidates and the facade dependency does not block publication.
+
+---
+
+### User Story 2 - Preserve Diagnostics For Real Failures (Priority: P2)
+
+An operator still receives clear failures when a package that appears to contain loadable assets cannot be selected or loaded correctly.
+
+**Why this priority**: Tolerating facade packages must not hide broken plugin packages, ambiguous assembly layouts, incompatible framework assets, or missing install paths.
+
+**Independent Test**: Can be tested by loading a package graph with an ambiguous assembly selection or missing install path and verifying that the graph still fails with an actionable diagnostic.
+
+**Acceptance Scenarios**:
+
+1. **Given** a package graph containing a package with multiple candidate assemblies and no deterministic main assembly, **When** Nuplane loads the graph, **Then** the package is reported as failed with the existing diagnostic.
+2. **Given** a package graph containing a missing install directory, **When** Nuplane loads the graph, **Then** the package is reported as failed and the graph does not silently succeed.
+
+---
+
+### Edge Cases
+
+- A dependency package contains only placeholder files such as `_._` under a compatible framework folder.
+- A dependency package contains no `lib` folder and no managed assemblies anywhere in the package directory.
+- A graph contains multiple facade dependencies and multiple loadable packages.
+- A host-integrated graph contains facade dependencies and must not publish empty assembly ownership entries that can confuse assembly resolution.
+- A package has compatible framework folders but no assemblies in the selected compatible folder while another framework folder has assemblies that are incompatible with the host.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The package graph loader MUST classify package members with no candidate managed assemblies in the selected asset search scope as non-loadable graph members instead of failed packages when at least one other package in the same graph provides loadable assemblies.
+- **FR-002**: The package graph loader MUST exclude non-loadable graph members from main assembly path selection, assembly load operations, and host-integrated assembly resolution candidate publication.
+- **FR-003**: The package graph loader MUST record successful loaded sessions only for packages whose assemblies were actually loaded.
+- **FR-004**: The package graph loader MUST leave existing failure behavior unchanged for missing install directories, incompatible target framework selections, ambiguous main assembly selection, invalid assemblies, and assembly load exceptions.
+- **FR-005**: The package graph loader MUST report an actionable failure when every package in a graph has no loadable assemblies, because such a graph cannot activate runtime behavior.
+- **FR-006**: The package graph loader MUST emit a diagnostic log entry for each non-loadable graph member that is skipped so operators can explain why a resolved package has no load session.
+- **FR-007**: The scan-candidate builder MUST continue to fail when asked directly to scan a package with no loadable assembly, preserving its current explicit caller contract.
+
+### Operational & Safety Requirements *(mandatory)*
+
+- **OSR-001**: Reconciliation/apply flows MUST remain idempotent for repeated identical package graphs containing facade dependencies.
+- **OSR-002**: Update flows MUST keep the existing last-known-good behavior for genuine loader failures; skipped facade dependencies MUST NOT replace or clear active load sessions for unrelated loaded packages.
+- **OSR-003**: Source trust and validation requirements remain unchanged; facade dependency tolerance MUST apply only after a package has already been resolved from trusted configured sources.
+- **OSR-004**: Observability MUST distinguish skipped non-loadable graph members from failed package loads through structured logs and must not increment failure health for skipped members.
+- **OSR-005**: Tests MUST include a regression case for a graph with a loadable package plus a no-assembly dependency, a host-integrated variant, and a graph that still fails when no graph member is loadable.
+
+### Key Entities *(include if feature involves data)*
+
+- **Resolved Package**: A package selected for a load graph, including identity, version, and install path.
+- **Loadable Graph Member**: A resolved package with a deterministic managed assembly selected for loading.
+- **Non-Loadable Graph Member**: A resolved package with no candidate managed assemblies in the selected asset search scope, treated as an inert dependency member.
+- **Package Load Session**: The recorded active state for a package whose assemblies were loaded.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A graph containing a loadable plugin package and a facade dependency completes without failed package entries.
+- **SC-002**: A host-integrated graph containing facade dependencies publishes resolution metadata for all loaded assemblies without treating skipped packages as owners.
+- **SC-003**: Existing tests for ambiguous assemblies, missing paths, and incompatible frameworks continue to fail with actionable diagnostics.
+- **SC-004**: Operators can identify each skipped no-assembly graph member from a structured log entry without seeing the reconciliation cycle marked degraded solely for that member.

--- a/specs/019-tolerate-facade-packages/tasks.md
+++ b/specs/019-tolerate-facade-packages/tasks.md
@@ -1,0 +1,59 @@
+# Tasks: Tolerate Facade Packages
+
+**Input**: Design documents from `/specs/019-tolerate-facade-packages/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md
+
+**Tests**: Test tasks are required because this changes package graph loading behavior.
+
+## Phase 1: Setup
+
+- [x] T001 Create Spec Kit feature branch and specification in `specs/019-tolerate-facade-packages/spec.md`.
+- [x] T002 Create requirement checklist in `specs/019-tolerate-facade-packages/checklists/requirements.md`.
+
+---
+
+## Phase 2: Foundational
+
+- [x] T003 Define no-assembly graph-member classification in `specs/019-tolerate-facade-packages/research.md` and `specs/019-tolerate-facade-packages/data-model.md`.
+
+---
+
+## Phase 3: User Story 1 - Load Graphs With Facade Dependencies (Priority: P1)
+
+**Goal**: A graph with loadable packages and no-assembly dependencies loads successfully.
+
+**Independent Test**: Run `dotnet test test/Nuplane.Loading.Tests/Nuplane.Loading.Tests.csproj`.
+
+### Tests for User Story 1
+
+- [x] T004 [US1] Add collectible graph regression coverage in `test/Nuplane.Loading.Tests/PackageLoaderGraphRegressionTests.cs`.
+- [x] T005 [US1] Add host-integrated graph regression coverage in `test/Nuplane.Loading.Tests/PackageLoaderHostIntegratedTests.cs`.
+
+### Implementation for User Story 1
+
+- [x] T006 [US1] Update graph assembly selection in `src/Nuplane.Loading/PackageLoader.cs` to skip no-assembly graph members.
+- [x] T007 [US1] Update host-integrated publication in `src/Nuplane.Loading/PackageLoader.cs` to use only loadable graph members.
+- [x] T008 [US1] Add diagnostic logging for skipped no-assembly graph members in `src/Nuplane.Loading/PackageLoader.cs`.
+
+---
+
+## Phase 4: User Story 2 - Preserve Diagnostics For Real Failures (Priority: P2)
+
+**Goal**: Genuine loader failures still fail and remain visible.
+
+**Independent Test**: Run `dotnet test test/Nuplane.Loading.Tests/Nuplane.Loading.Tests.csproj`.
+
+### Tests for User Story 2
+
+- [x] T009 [US2] Add all-no-assembly graph failure coverage in `test/Nuplane.Loading.Tests/PackageLoaderGraphRegressionTests.cs`.
+
+### Implementation for User Story 2
+
+- [x] T010 [US2] Keep missing path, incompatible framework, ambiguous assembly, and load exception behavior unchanged in `src/Nuplane.Loading/PackageLoader.cs`.
+
+---
+
+## Phase 5: Validation
+
+- [x] T011 Run targeted loading test project.
+- [x] T012 Restore solution and run full solution test suite.

--- a/src/Nuplane.Loading/PackageLoader.cs
+++ b/src/Nuplane.Loading/PackageLoader.cs
@@ -219,14 +219,20 @@ internal sealed class PackageLoader : IPackageLoader
 
         try
         {
-            var mainAssemblyPaths = packages
+            var loadablePackages = ResolveLoadableGraphPackages(packages);
+            if (loadablePackages.Count == 0)
+            {
+                throw new FileNotFoundException($"No loadable package assemblies were found in graph '{graphKey}'.");
+            }
+
+            var mainAssemblyPaths = loadablePackages
                 .OrderBy(static package => package.Id, StringComparer.OrdinalIgnoreCase)
                 .ThenBy(static package => package.Version, StringComparer.OrdinalIgnoreCase)
-                .Select(static package => ResolveMainAssemblyPath(package.InstallPath, package.Id))
+                .Select(static package => package.MainAssemblyPath)
                 .ToArray();
             if (graphLoadMode == PackageLoadMode.HostIntegrated)
             {
-                var candidates = BuildHostIntegratedResolutionCandidates(graphKey, packages);
+                var candidates = BuildHostIntegratedResolutionCandidates(graphKey, loadablePackages);
                 _hostIntegratedResolutionCatalog.ValidateCanPublishGraph(graphKey, candidates);
             }
 
@@ -240,7 +246,7 @@ internal sealed class PackageLoader : IPackageLoader
             }
 
             var assembliesByPackageKey = graphLoadMode == PackageLoadMode.HostIntegrated
-                ? MaterializeHostIntegratedAssemblies(context, packages)
+                ? MaterializeHostIntegratedAssemblies(context, loadablePackages)
                 : new Dictionary<string, IReadOnlyList<Assembly>>(StringComparer.OrdinalIgnoreCase);
 
             if (graphLoadMode == PackageLoadMode.HostIntegrated)
@@ -249,7 +255,7 @@ internal sealed class PackageLoader : IPackageLoader
                 catalogPublished = true;
             }
 
-            foreach (var package in packages)
+            foreach (var package in loadablePackages)
             {
                 var key = BuildKey(package.Id, package.Version);
                 if (_contexts.TryGetValue(key, out var previousContext) &&
@@ -323,6 +329,34 @@ internal sealed class PackageLoader : IPackageLoader
         return new(loaded, failed);
     }
 
+    private IReadOnlyList<LoadableGraphPackage> ResolveLoadableGraphPackages(IReadOnlyList<ResolvedPackage> packages)
+    {
+        var loadablePackages = new List<LoadableGraphPackage>(packages.Count);
+
+        foreach (var package in packages)
+        {
+            try
+            {
+                loadablePackages.Add(new(
+                    package.Id,
+                    package.Version,
+                    package.InstallPath,
+                    ResolveMainAssemblyPath(package.InstallPath, package.Id)));
+            }
+            catch (NoLoadableAssemblyException ex)
+            {
+                _logger.LogInformation(
+                    "Skipped package {PackageId}@{Version} in graph because it contains no loadable assemblies under {InstallPath}. Reason={Reason}",
+                    package.Id,
+                    package.Version,
+                    package.InstallPath,
+                    ex.Message);
+            }
+        }
+
+        return loadablePackages;
+    }
+
     private void UnloadUnreferencedContexts(IEnumerable<AssemblyLoadContext> contexts)
     {
         foreach (var context in contexts.Distinct())
@@ -394,7 +428,7 @@ internal sealed class PackageLoader : IPackageLoader
 
     private IReadOnlyDictionary<string, IReadOnlyList<Assembly>> MaterializeHostIntegratedAssemblies(
         AssemblyLoadContext context,
-        IReadOnlyList<ResolvedPackage> packages)
+        IReadOnlyList<LoadableGraphPackage> packages)
     {
         var result = new Dictionary<string, IReadOnlyList<Assembly>>(StringComparer.OrdinalIgnoreCase);
         var assembliesByPath = context.Assemblies
@@ -435,7 +469,7 @@ internal sealed class PackageLoader : IPackageLoader
 
     private IReadOnlyList<HostIntegratedAssemblyResolutionCandidate> BuildHostIntegratedResolutionCandidates(
         string graphKey,
-        IReadOnlyList<ResolvedPackage> packages)
+        IReadOnlyList<LoadableGraphPackage> packages)
     {
         var entries = new List<HostIntegratedAssemblyResolutionCandidate>();
         foreach (var package in packages)
@@ -565,7 +599,7 @@ internal sealed class PackageLoader : IPackageLoader
 
         if (assemblies.Length == 0)
         {
-            throw new FileNotFoundException($"No loadable assembly found under '{installPath}'.");
+            throw new NoLoadableAssemblyException($"No loadable assembly found under '{installPath}'.");
         }
 
         if (assemblies.Length == 1)
@@ -675,6 +709,14 @@ internal sealed class PackageLoader : IPackageLoader
     private sealed record FrameworkTarget(FrameworkKind Kind, Version Version, string DisplayName);
 
     private sealed record AssemblyAssetSelection(string MainAssemblyPath, string CandidateSearchRoot);
+
+    private sealed record LoadableGraphPackage(
+        string Id,
+        string Version,
+        string InstallPath,
+        string MainAssemblyPath);
+
+    private sealed class NoLoadableAssemblyException(string message) : FileNotFoundException(message);
 
     private sealed record FrameworkDirectory(string Path, string FolderName, FrameworkTarget Target)
     {

--- a/src/Nuplane.Loading/PackageLoader.cs
+++ b/src/Nuplane.Loading/PackageLoader.cs
@@ -24,6 +24,7 @@ internal sealed class PackageLoader : IPackageLoader
     private readonly HostIntegratedAssemblyResolver? _hostIntegratedAssemblyResolver;
     private readonly ConcurrentDictionary<string, AssemblyLoadContext> _contexts = new(StringComparer.OrdinalIgnoreCase);
     private readonly ConcurrentDictionary<string, PackageLoadSession> _sessions = new(StringComparer.OrdinalIgnoreCase);
+    private readonly ConcurrentDictionary<string, LoadedGraphCacheEntry> _loadedGraphs = new(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>
     /// Initializes a new instance of <see cref="PackageLoader"/> with an optional shared assembly policy matcher.
@@ -198,16 +199,9 @@ internal sealed class PackageLoader : IPackageLoader
             ? PackageLoadMode.HostIntegrated
             : PackageLoadMode.Collectible;
 
-        var existingGraphSessions = packages
-            .Select(package => _sessions.TryGetValue(BuildKey(package.Id, package.Version), out var session) ? session : null)
-            .Where(session => session is not null
-                && session.IsLoaded
-                && string.Equals(session.ContextKey, graphKey, StringComparison.OrdinalIgnoreCase)
-                && session.LoadMode == graphLoadMode)
-            .Cast<PackageLoadSession>()
-            .ToArray();
-
-        if (existingGraphSessions.Length == packages.Count)
+        if (_loadedGraphs.TryGetValue(graphKey, out var cachedGraph)
+            && cachedGraph.LoadMode == graphLoadMode
+            && TryGetLoadedGraphSessions(cachedGraph, graphKey, graphLoadMode, out var existingGraphSessions))
         {
             loaded.AddRange(existingGraphSessions);
             return new(loaded, failed);
@@ -219,20 +213,21 @@ internal sealed class PackageLoader : IPackageLoader
 
         try
         {
-            var loadablePackages = ResolveLoadableGraphPackages(packages);
-            if (loadablePackages.Count == 0)
+            var graphPackages = ResolveGraphPackages(packages);
+            if (graphPackages.LoadablePackages.Count == 0)
             {
-                throw new FileNotFoundException($"No loadable package assemblies were found in graph '{graphKey}'.");
+                throw new NoLoadableAssemblyException(
+                    $"No loadable assembly found in graph '{graphKey}'. Scanned install paths: {FormatQuotedList(graphPackages.SkippedInstallPaths)}.");
             }
 
-            var mainAssemblyPaths = loadablePackages
+            var mainAssemblyPaths = graphPackages.LoadablePackages
                 .OrderBy(static package => package.Id, StringComparer.OrdinalIgnoreCase)
                 .ThenBy(static package => package.Version, StringComparer.OrdinalIgnoreCase)
                 .Select(static package => package.MainAssemblyPath)
                 .ToArray();
             if (graphLoadMode == PackageLoadMode.HostIntegrated)
             {
-                var candidates = BuildHostIntegratedResolutionCandidates(graphKey, loadablePackages);
+                var candidates = BuildHostIntegratedResolutionCandidates(graphKey, graphPackages.LoadablePackages);
                 _hostIntegratedResolutionCatalog.ValidateCanPublishGraph(graphKey, candidates);
             }
 
@@ -246,7 +241,7 @@ internal sealed class PackageLoader : IPackageLoader
             }
 
             var assembliesByPackageKey = graphLoadMode == PackageLoadMode.HostIntegrated
-                ? MaterializeHostIntegratedAssemblies(context, loadablePackages)
+                ? MaterializeHostIntegratedAssemblies(context, graphPackages.LoadablePackages)
                 : new Dictionary<string, IReadOnlyList<Assembly>>(StringComparer.OrdinalIgnoreCase);
 
             if (graphLoadMode == PackageLoadMode.HostIntegrated)
@@ -255,7 +250,7 @@ internal sealed class PackageLoader : IPackageLoader
                 catalogPublished = true;
             }
 
-            foreach (var package in loadablePackages)
+            foreach (var package in graphPackages.LoadablePackages)
             {
                 var key = BuildKey(package.Id, package.Version);
                 if (_contexts.TryGetValue(key, out var previousContext) &&
@@ -287,6 +282,13 @@ internal sealed class PackageLoader : IPackageLoader
                     graphLoadMode,
                     graphKey);
             }
+
+            _loadedGraphs[graphKey] = new(
+                graphLoadMode,
+                graphPackages.LoadablePackages
+                    .Select(static package => BuildKey(package.Id, package.Version))
+                    .OrderBy(static key => key, StringComparer.OrdinalIgnoreCase)
+                    .ToArray());
 
             UnloadUnreferencedContexts(replacedContexts);
         }
@@ -329,9 +331,35 @@ internal sealed class PackageLoader : IPackageLoader
         return new(loaded, failed);
     }
 
-    private IReadOnlyList<LoadableGraphPackage> ResolveLoadableGraphPackages(IReadOnlyList<ResolvedPackage> packages)
+    private bool TryGetLoadedGraphSessions(
+        LoadedGraphCacheEntry cachedGraph,
+        string graphKey,
+        PackageLoadMode graphLoadMode,
+        out IReadOnlyList<PackageLoadSession> existingGraphSessions)
+    {
+        var sessions = new List<PackageLoadSession>(cachedGraph.LoadablePackageKeys.Count);
+        foreach (var key in cachedGraph.LoadablePackageKeys)
+        {
+            if (!_sessions.TryGetValue(key, out var session)
+                || !session.IsLoaded
+                || !string.Equals(session.ContextKey, graphKey, StringComparison.OrdinalIgnoreCase)
+                || session.LoadMode != graphLoadMode)
+            {
+                existingGraphSessions = [];
+                return false;
+            }
+
+            sessions.Add(session);
+        }
+
+        existingGraphSessions = sessions;
+        return true;
+    }
+
+    private GraphPackageResolution ResolveGraphPackages(IReadOnlyList<ResolvedPackage> packages)
     {
         var loadablePackages = new List<LoadableGraphPackage>(packages.Count);
+        var skippedInstallPaths = new List<string>();
 
         foreach (var package in packages)
         {
@@ -345,6 +373,7 @@ internal sealed class PackageLoader : IPackageLoader
             }
             catch (NoLoadableAssemblyException ex)
             {
+                skippedInstallPaths.Add(package.InstallPath);
                 _logger.LogInformation(
                     "Skipped package {PackageId}@{Version} in graph because it contains no loadable assemblies under {InstallPath}. Reason={Reason}",
                     package.Id,
@@ -354,7 +383,7 @@ internal sealed class PackageLoader : IPackageLoader
             }
         }
 
-        return loadablePackages;
+        return new(loadablePackages, skippedInstallPaths);
     }
 
     private void UnloadUnreferencedContexts(IEnumerable<AssemblyLoadContext> contexts)
@@ -400,6 +429,11 @@ internal sealed class PackageLoader : IPackageLoader
     }
 
     private static string BuildKey(string packageId, string version) => $"{packageId}@{version}";
+
+    private static string FormatQuotedList(IReadOnlyCollection<string> values) =>
+        values.Count == 0
+            ? "<none>"
+            : string.Join(", ", values.Select(static value => $"'{value}'"));
 
     private static string BuildGraphKey(IReadOnlyList<ResolvedPackage> packages) =>
         "graph:" + string.Join('|', packages
@@ -715,6 +749,14 @@ internal sealed class PackageLoader : IPackageLoader
         string Version,
         string InstallPath,
         string MainAssemblyPath);
+
+    private sealed record GraphPackageResolution(
+        IReadOnlyList<LoadableGraphPackage> LoadablePackages,
+        IReadOnlyList<string> SkippedInstallPaths);
+
+    private sealed record LoadedGraphCacheEntry(
+        PackageLoadMode LoadMode,
+        IReadOnlyList<string> LoadablePackageKeys);
 
     private sealed class NoLoadableAssemblyException(string message) : FileNotFoundException(message);
 

--- a/src/Nuplane.Loading/PackageLoader.cs
+++ b/src/Nuplane.Loading/PackageLoader.cs
@@ -210,10 +210,16 @@ internal sealed class PackageLoader : IPackageLoader
         AssemblyLoadContext? context = null;
         var replacedContexts = new List<AssemblyLoadContext>();
         var catalogPublished = false;
+        GraphPackageResolution? graphPackages = null;
 
         try
         {
-            var graphPackages = ResolveGraphPackages(packages);
+            graphPackages = ResolveGraphPackages(packages);
+            if (graphPackages.ResolutionFailure is not null)
+            {
+                throw graphPackages.ResolutionFailure;
+            }
+
             if (graphPackages.LoadablePackages.Count == 0)
             {
                 throw new NoLoadableAssemblyException(
@@ -299,7 +305,7 @@ internal sealed class PackageLoader : IPackageLoader
                 context.Unload();
             }
 
-            foreach (var package in packages)
+            foreach (var package in ResolveFailedGraphPackages(packages, graphPackages))
             {
                 var key = BuildKey(package.Id, package.Version);
                 if (context is not null &&
@@ -359,7 +365,9 @@ internal sealed class PackageLoader : IPackageLoader
     private GraphPackageResolution ResolveGraphPackages(IReadOnlyList<ResolvedPackage> packages)
     {
         var loadablePackages = new List<LoadableGraphPackage>(packages.Count);
-        var skippedInstallPaths = new List<string>();
+        var skippedPackages = new List<GraphPackage>();
+        var failedPackages = new List<GraphPackage>();
+        Exception? resolutionFailure = null;
 
         foreach (var package in packages)
         {
@@ -373,7 +381,7 @@ internal sealed class PackageLoader : IPackageLoader
             }
             catch (NoLoadableAssemblyException ex)
             {
-                skippedInstallPaths.Add(package.InstallPath);
+                skippedPackages.Add(new(package.Id, package.Version, package.InstallPath));
                 _logger.LogInformation(
                     "Skipped package {PackageId}@{Version} in graph because it contains no loadable assemblies under {InstallPath}. Reason={Reason}",
                     package.Id,
@@ -381,9 +389,14 @@ internal sealed class PackageLoader : IPackageLoader
                     package.InstallPath,
                     ex.Message);
             }
+            catch (Exception ex)
+            {
+                failedPackages.Add(new(package.Id, package.Version, package.InstallPath));
+                resolutionFailure ??= ex;
+            }
         }
 
-        return new(loadablePackages, skippedInstallPaths);
+        return new(loadablePackages, skippedPackages, failedPackages, resolutionFailure);
     }
 
     private void UnloadUnreferencedContexts(IEnumerable<AssemblyLoadContext> contexts)
@@ -434,6 +447,30 @@ internal sealed class PackageLoader : IPackageLoader
         values.Count == 0
             ? "<none>"
             : string.Join(", ", values.Select(static value => $"'{value}'"));
+
+    private static IReadOnlyList<GraphPackage> ResolveFailedGraphPackages(
+        IReadOnlyList<ResolvedPackage> packages,
+        GraphPackageResolution? graphPackages)
+    {
+        if (graphPackages is null)
+        {
+            return packages
+                .Select(static package => new GraphPackage(package.Id, package.Version, package.InstallPath))
+                .ToArray();
+        }
+
+        if (graphPackages.LoadablePackages.Count == 0 && graphPackages.FailedPackages.Count == 0)
+        {
+            return graphPackages.SkippedPackages;
+        }
+
+        return graphPackages.LoadablePackages
+            .Select(static package => new GraphPackage(package.Id, package.Version, package.InstallPath))
+            .Concat(graphPackages.FailedPackages)
+            .GroupBy(static package => BuildKey(package.Id, package.Version), StringComparer.OrdinalIgnoreCase)
+            .Select(static group => group.First())
+            .ToArray();
+    }
 
     private static string BuildGraphKey(IReadOnlyList<ResolvedPackage> packages) =>
         "graph:" + string.Join('|', packages
@@ -750,9 +787,19 @@ internal sealed class PackageLoader : IPackageLoader
         string InstallPath,
         string MainAssemblyPath);
 
+    private sealed record GraphPackage(
+        string Id,
+        string Version,
+        string InstallPath);
+
     private sealed record GraphPackageResolution(
         IReadOnlyList<LoadableGraphPackage> LoadablePackages,
-        IReadOnlyList<string> SkippedInstallPaths);
+        IReadOnlyList<GraphPackage> SkippedPackages,
+        IReadOnlyList<GraphPackage> FailedPackages,
+        Exception? ResolutionFailure)
+    {
+        public IReadOnlyList<string> SkippedInstallPaths => SkippedPackages.Select(static package => package.InstallPath).ToArray();
+    }
 
     private sealed record LoadedGraphCacheEntry(
         PackageLoadMode LoadMode,

--- a/test/Nuplane.Loading.Tests/PackageLoaderGraphRegressionTests.cs
+++ b/test/Nuplane.Loading.Tests/PackageLoaderGraphRegressionTests.cs
@@ -136,6 +136,30 @@ public sealed class PackageLoaderGraphRegressionTests : IDisposable
         Assert.Contains("No loadable assembly", failure.Value, StringComparison.OrdinalIgnoreCase);
     }
 
+    [Fact]
+    public async Task EnsureGraphLoadedAsync_NoAssemblyDependencyWithRealPackageFailure_DoesNotFailSkippedDependency()
+    {
+        var rootInstall = CreatePackageInstall("Plugin.Root", "Plugin.Root.dll");
+        var ambiguousInstall = CreateAmbiguousPackageInstall("Plugin.Ambiguous");
+        var facadeInstall = CreateNoAssemblyPackageInstall("Microsoft.Data.Sqlite");
+        var loader = new PackageLoader();
+
+        var result = await loader.EnsureGraphLoadedAsync(
+            [[
+                new ResolvedPackage("Plugin.Root", "1.0.0", "test-feed", rootInstall, DateTimeOffset.UtcNow, "test-source"),
+                new ResolvedPackage("Plugin.Ambiguous", "1.0.0", "test-feed", ambiguousInstall, DateTimeOffset.UtcNow, "test-source"),
+                new ResolvedPackage("Microsoft.Data.Sqlite", "10.0.3", "test-feed", facadeInstall, DateTimeOffset.UtcNow, "test-source")
+            ]],
+            [],
+            CancellationToken.None);
+
+        Assert.Empty(result.Loaded);
+        Assert.Equal(["Plugin.Ambiguous", "Plugin.Root"], result.FailedByPackageId.Keys.Order(StringComparer.OrdinalIgnoreCase));
+        Assert.DoesNotContain("Microsoft.Data.Sqlite", loader.Sessions.Keys, StringComparer.OrdinalIgnoreCase);
+        Assert.False(loader.TryGetContext("Plugin.Root", "1.0.0", out _));
+        Assert.False(loader.TryGetContext("Microsoft.Data.Sqlite", "10.0.3", out _));
+    }
+
     public void Dispose()
     {
         if (Directory.Exists(tempRoot))
@@ -167,6 +191,16 @@ public sealed class PackageLoaderGraphRegressionTests : IDisposable
         var libPath = Path.Combine(installPath, "lib", "netstandard2.0");
         Directory.CreateDirectory(libPath);
         File.WriteAllText(Path.Combine(libPath, "_._"), string.Empty);
+        return installPath;
+    }
+
+    private string CreateAmbiguousPackageInstall(string packageId)
+    {
+        var installPath = Path.Combine(tempRoot, packageId, "1.0.0");
+        var libPath = Path.Combine(installPath, "lib", "net10.0");
+        Directory.CreateDirectory(libPath);
+        File.Copy(FindFixtureAssembly("Plugin.Root.dll"), Path.Combine(libPath, "First.dll"), overwrite: true);
+        File.Copy(FindFixtureAssembly("Plugin.Dependency.dll"), Path.Combine(libPath, "Second.dll"), overwrite: true);
         return installPath;
     }
 

--- a/test/Nuplane.Loading.Tests/PackageLoaderGraphRegressionTests.cs
+++ b/test/Nuplane.Loading.Tests/PackageLoaderGraphRegressionTests.cs
@@ -79,6 +79,47 @@ public sealed class PackageLoaderGraphRegressionTests : IDisposable
     }
 
     [Fact]
+    public async Task EnsureGraphLoadedAsync_LoadablePackageWithNoAssemblyDependency_ReusesExistingGraphSession()
+    {
+        var rootInstall = CreatePackageInstall("Plugin.Root", "Plugin.Root.dll");
+        var facadeInstall = CreateNoAssemblyPackageInstall("Microsoft.Data.Sqlite");
+        var loader = new PackageLoader();
+        var graph =
+            new[]
+            {
+                new ResolvedPackage("Plugin.Root", "1.0.0", "test-feed", rootInstall, DateTimeOffset.UtcNow, "test-source"),
+                new ResolvedPackage("Microsoft.Data.Sqlite", "10.0.3", "test-feed", facadeInstall, DateTimeOffset.UtcNow, "test-source")
+            };
+
+        var first = await loader.EnsureGraphLoadedAsync([graph], [], CancellationToken.None);
+        Assert.True(loader.TryGetContext("Plugin.Root", "1.0.0", out var firstContext));
+
+        var second = await loader.EnsureGraphLoadedAsync([graph], [], CancellationToken.None);
+
+        var loaded = Assert.Single(second.Loaded);
+        Assert.Equal(Assert.Single(first.Loaded).ContextKey, loaded.ContextKey);
+        Assert.Empty(second.FailedByPackageId);
+        Assert.True(loader.TryGetContext("Plugin.Root", "1.0.0", out var secondContext));
+        Assert.Same(firstContext!.Context, secondContext!.Context);
+        Assert.Single(loader.Sessions);
+    }
+
+    [Fact]
+    public async Task EnsureGraphLoadedAsync_GraphWithOnlyNoAssemblyPackages_ReportsScannedInstallPath()
+    {
+        var facadeInstall = CreateNoAssemblyPackageInstall("Microsoft.Data.Sqlite");
+        var loader = new PackageLoader();
+
+        var result = await loader.EnsureGraphLoadedAsync(
+            [[new ResolvedPackage("Microsoft.Data.Sqlite", "10.0.3", "test-feed", facadeInstall, DateTimeOffset.UtcNow, "test-source")]],
+            [],
+            CancellationToken.None);
+
+        var failure = Assert.Single(result.FailedByPackageId);
+        Assert.Contains(facadeInstall, failure.Value, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public async Task EnsureGraphLoadedAsync_GraphWithOnlyNoAssemblyPackages_FailsGraph()
     {
         var facadeInstall = CreateNoAssemblyPackageInstall("Microsoft.Data.Sqlite");

--- a/test/Nuplane.Loading.Tests/PackageLoaderGraphRegressionTests.cs
+++ b/test/Nuplane.Loading.Tests/PackageLoaderGraphRegressionTests.cs
@@ -56,6 +56,45 @@ public sealed class PackageLoaderGraphRegressionTests : IDisposable
         Assert.Equal(2, result.Loaded.Count);
     }
 
+    [Fact]
+    public async Task EnsureGraphLoadedAsync_LoadablePackageWithNoAssemblyDependency_SkipsDependencyWithoutFailure()
+    {
+        var rootInstall = CreatePackageInstall("Plugin.Root", "Plugin.Root.dll");
+        var facadeInstall = CreateNoAssemblyPackageInstall("Microsoft.Data.Sqlite");
+        var loader = new PackageLoader();
+
+        var result = await loader.EnsureGraphLoadedAsync(
+            [[
+                new ResolvedPackage("Plugin.Root", "1.0.0", "test-feed", rootInstall, DateTimeOffset.UtcNow, "test-source"),
+                new ResolvedPackage("Microsoft.Data.Sqlite", "10.0.3", "test-feed", facadeInstall, DateTimeOffset.UtcNow, "test-source")
+            ]],
+            [],
+            CancellationToken.None);
+
+        var loaded = Assert.Single(result.Loaded);
+        Assert.Equal("Plugin.Root", loaded.PackageId);
+        Assert.Empty(result.FailedByPackageId);
+        Assert.True(loader.TryGetContext("Plugin.Root", "1.0.0", out _));
+        Assert.False(loader.TryGetContext("Microsoft.Data.Sqlite", "10.0.3", out _));
+    }
+
+    [Fact]
+    public async Task EnsureGraphLoadedAsync_GraphWithOnlyNoAssemblyPackages_FailsGraph()
+    {
+        var facadeInstall = CreateNoAssemblyPackageInstall("Microsoft.Data.Sqlite");
+        var loader = new PackageLoader();
+
+        var result = await loader.EnsureGraphLoadedAsync(
+            [[new ResolvedPackage("Microsoft.Data.Sqlite", "10.0.3", "test-feed", facadeInstall, DateTimeOffset.UtcNow, "test-source")]],
+            [],
+            CancellationToken.None);
+
+        Assert.Empty(result.Loaded);
+        var failure = Assert.Single(result.FailedByPackageId);
+        Assert.Equal("Microsoft.Data.Sqlite", failure.Key);
+        Assert.Contains("No loadable assembly", failure.Value, StringComparison.OrdinalIgnoreCase);
+    }
+
     public void Dispose()
     {
         if (Directory.Exists(tempRoot))
@@ -78,6 +117,15 @@ public sealed class PackageLoaderGraphRegressionTests : IDisposable
         var installPath = Path.Combine(tempRoot, packageId, "1.0.0");
         Directory.CreateDirectory(installPath);
         File.Copy(FindFixtureAssembly(assemblyFileName), Path.Combine(installPath, assemblyFileName), overwrite: true);
+        return installPath;
+    }
+
+    private string CreateNoAssemblyPackageInstall(string packageId)
+    {
+        var installPath = Path.Combine(tempRoot, packageId, "1.0.0");
+        var libPath = Path.Combine(installPath, "lib", "netstandard2.0");
+        Directory.CreateDirectory(libPath);
+        File.WriteAllText(Path.Combine(libPath, "_._"), string.Empty);
         return installPath;
     }
 

--- a/test/Nuplane.Loading.Tests/PackageLoaderHostIntegratedTests.cs
+++ b/test/Nuplane.Loading.Tests/PackageLoaderHostIntegratedTests.cs
@@ -90,6 +90,32 @@ public sealed class PackageLoaderHostIntegratedTests : IDisposable
     }
 
     [Fact]
+    public async Task EnsureGraphLoadedAsync_HostIntegratedGraphWithNoAssemblyDependency_SkipsDependencyWithoutCatalogEntry()
+    {
+        var rootInstallPath = CreateInstallDir("Nuplane.Loading.Tests.Fixtures");
+        var facadeInstallPath = CreateNoAssemblyInstallDir("Microsoft.Data.Sqlite");
+        var catalog = new HostIntegratedAssemblyResolutionCatalog();
+        var options = Options.Create(new LoadingOptions { DefaultLoadMode = PackageLoadMode.HostIntegrated });
+        var loader = new PackageLoader(options: options, hostIntegratedResolutionCatalog: catalog);
+
+        var result = await loader.EnsureGraphLoadedAsync(
+            [[
+                Pkg("Nuplane.Loading.Tests.Fixtures", "1.0.0", rootInstallPath),
+                Pkg("Microsoft.Data.Sqlite", "10.0.3", facadeInstallPath)
+            ]],
+            [],
+            CancellationToken.None);
+
+        var loaded = Assert.Single(result.Loaded);
+        Assert.Equal("Nuplane.Loading.Tests.Fixtures", loaded.PackageId);
+        Assert.Empty(result.FailedByPackageId);
+        Assert.True(loader.TryGetContext("Nuplane.Loading.Tests.Fixtures", "1.0.0", out _));
+        Assert.False(loader.TryGetContext("Microsoft.Data.Sqlite", "10.0.3", out _));
+        Assert.True(catalog.TryResolve(typeof(FixtureMarker).Assembly.GetName(), out _, out var diagnostic));
+        Assert.Equal("success", diagnostic.Outcome);
+    }
+
+    [Fact]
     public async Task EnsureGraphLoadedAsync_WhenPackageMovesToDifferentHostIntegratedGraph_ReplacesCatalogEntries()
     {
         var firstInstallPath = CreateInstallDir("pkg-a", typeof(FixtureMarker).Assembly);
@@ -135,6 +161,14 @@ public sealed class PackageLoaderHostIntegratedTests : IDisposable
     {
         var dir = tempDir.CreateSubdirectory(packageId);
         File.Copy(assembly.Location, Path.Combine(dir.FullName, $"{packageId}.dll"));
+        return dir.FullName;
+    }
+
+    private string CreateNoAssemblyInstallDir(string packageId)
+    {
+        var dir = tempDir.CreateSubdirectory(packageId);
+        var frameworkDir = Directory.CreateDirectory(Path.Combine(dir.FullName, "lib", "netstandard2.0"));
+        File.WriteAllText(Path.Combine(frameworkDir.FullName, "_._"), string.Empty);
         return dir.FullName;
     }
 

--- a/test/Nuplane.Loading.Tests/PackageLoaderHostIntegratedTests.cs
+++ b/test/Nuplane.Loading.Tests/PackageLoaderHostIntegratedTests.cs
@@ -116,6 +116,35 @@ public sealed class PackageLoaderHostIntegratedTests : IDisposable
     }
 
     [Fact]
+    public async Task EnsureGraphLoadedAsync_HostIntegratedGraphWithNoAssemblyDependency_ReusesPublishedGraph()
+    {
+        var rootInstallPath = CreateInstallDir("Nuplane.Loading.Tests.Fixtures");
+        var facadeInstallPath = CreateNoAssemblyInstallDir("Microsoft.Data.Sqlite");
+        var catalog = new HostIntegratedAssemblyResolutionCatalog();
+        var options = Options.Create(new LoadingOptions { DefaultLoadMode = PackageLoadMode.HostIntegrated });
+        var loader = new PackageLoader(options: options, hostIntegratedResolutionCatalog: catalog);
+        var graph =
+            new[]
+            {
+                Pkg("Nuplane.Loading.Tests.Fixtures", "1.0.0", rootInstallPath),
+                Pkg("Microsoft.Data.Sqlite", "10.0.3", facadeInstallPath)
+            };
+
+        await loader.EnsureGraphLoadedAsync([graph], [], CancellationToken.None);
+        var generation = catalog.Generation;
+        Assert.True(loader.TryGetContext("Nuplane.Loading.Tests.Fixtures", "1.0.0", out var firstContext));
+
+        var result = await loader.EnsureGraphLoadedAsync([graph], [], CancellationToken.None);
+
+        var loaded = Assert.Single(result.Loaded);
+        Assert.Equal("Nuplane.Loading.Tests.Fixtures", loaded.PackageId);
+        Assert.Empty(result.FailedByPackageId);
+        Assert.True(loader.TryGetContext("Nuplane.Loading.Tests.Fixtures", "1.0.0", out var secondContext));
+        Assert.Same(firstContext!.Context, secondContext!.Context);
+        Assert.Equal(generation, catalog.Generation);
+    }
+
+    [Fact]
     public async Task EnsureGraphLoadedAsync_WhenPackageMovesToDifferentHostIntegratedGraph_ReplacesCatalogEntries()
     {
         var firstInstallPath = CreateInstallDir("pkg-a", typeof(FixtureMarker).Assembly);


### PR DESCRIPTION
## Summary

Nuplane graph loading now treats dependency/support packages with no loadable managed assemblies as inert graph members instead of failing the entire graph. This covers facade-style packages such as `Microsoft.Data.Sqlite`, which can contain placeholder assets like `lib/netstandard2.0/_._` but no assembly for Nuplane to load.

## Root Cause

The loader resolved a main assembly path for every package in a dependency graph. When a valid support package had no `.dll`, `ResolveMainAssemblyPath` threw `No loadable assembly found`, and the catch path marked every package in the graph as failed. That prevented packages which did contain assemblies, such as provider packages, from being loaded and exposed to host integrations.

## Changes

- Classify graph members with no candidate managed assemblies separately from real load failures.
- Skip no-assembly graph members when building assembly load contexts and host-integrated resolution candidates.
- Keep successful load sessions limited to packages whose assemblies were actually loaded.
- Preserve existing failure behavior for missing install paths, incompatible frameworks, ambiguous assemblies, and load exceptions.
- Add Spec Kit artifacts for feature `019-tolerate-facade-packages`.

## Validation

- `dotnet test test/Nuplane.Loading.Tests/Nuplane.Loading.Tests.csproj`
- `dotnet restore nuplane.sln`
- `dotnet test nuplane.sln --no-restore`

## Operational Impact

Skipped facade/support packages emit a structured diagnostic log entry and do not increment loader failures. Genuine graph failures still preserve the existing LKG behavior and diagnostics.
