### PR TITLE
Fix dependency graph version unification

### DIFF
--- a/specs/021-nuget-graph-version-unification/checklists/requirements.md
+++ b/specs/021-nuget-graph-version-unification/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: NuGet Graph Version Unification
+
+**Purpose**: Validate specification completeness and quality before implementation  
+**Created**: 2026-05-13  
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details beyond required architectural ownership
+- [X] Focused on operator value and runtime package compatibility
+- [X] Written for stakeholders familiar with NuGet package loading
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Requirements are testable and unambiguous
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic where practical for infrastructure behavior
+- [X] All acceptance scenarios are defined
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] User scenarios cover primary flows
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No unrelated implementation scope leaks into specification
+
+## Notes
+
+- This bug fix is scoped to dependency metadata version semantics and graph conflict preservation.
+

--- a/specs/021-nuget-graph-version-unification/plan.md
+++ b/specs/021-nuget-graph-version-unification/plan.md
@@ -1,0 +1,61 @@
+# Implementation Plan: NuGet Graph Version Unification
+
+**Branch**: `021-nuget-graph-version-unification` | **Date**: 2026-05-13 | **Spec**: [spec.md](./spec.md)  
+**Input**: Feature specification from `/specs/021-nuget-graph-version-unification/spec.md`
+
+## Summary
+
+Normalize bare NuGet dependency versions during dependency graph resolution so package metadata such as `version="8.0.2"` behaves as a minimum dependency requirement, allowing the existing feed resolver to select a higher compatible version. Preserve existing exact semantics for direct desired package requests and bracketed exact dependency ranges.
+
+## Technical Context
+
+**Language/Version**: C# with SDK-style .NET libraries targeting `net8.0;net9.0;net10.0`; tests target `net10.0`  
+**Primary Dependencies**: NuGet.Versioning, NuGet.Protocol, Microsoft.Extensions libraries, xUnit  
+**Storage**: File-backed Nuplane package store state; no new storage  
+**Testing**: xUnit via `dotnet test`  
+**Target Platform**: .NET host applications using Nuplane runtime package reconciliation  
+**Project Type**: Infrastructure library  
+**Performance Goals**: Preserve deterministic graph resolution with no extra feed scans beyond current dependency resolution  
+**Constraints**: Do not alter desired include-pattern version semantics; preserve LKG and graph-conflict behavior  
+**Scale/Scope**: One resolver behavior change plus focused runtime regression tests
+
+## Constitution Check
+
+- Deterministic reconciliation: PASS. Normalization is pure and deterministic for dependency metadata.
+- Transactional store safety: PASS. The change occurs before activation and preserves existing failure/LKG paths.
+- Source integrity: PASS. Resolution still uses configured `IPackageResolver` sources and acquisition validation.
+- Observability: PASS. Existing graph-conflict diagnostics remain for real conflicts; no new options or health surfaces are introduced.
+- Test discipline: PASS. Regression tests cover the bug and existing incompatible-conflict behavior remains.
+- Decomposition discipline: PASS. Tasks map to resolver tests, resolver implementation, and focused validation.
+- Options validation discipline: PASS. No options are introduced or changed.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/021-nuget-graph-version-unification/
+├── plan.md
+├── spec.md
+├── tasks.md
+└── checklists/
+    └── requirements.md
+```
+
+### Source Code (repository root)
+
+```text
+src/Nuplane/Reconciliation/
+└── PackageDependencyGraphResolver.cs
+
+test/Nuplane.Runtime.Tests/
+├── Feeds/PackageDependencyGraphResolverTests.cs
+└── Reconciliation/PackageApplyExecutorTests.cs
+```
+
+**Structure Decision**: Use the existing reconciliation resolver and runtime test projects. No new projects or public contracts are required.
+
+## Complexity Tracking
+
+No constitution violations.
+

--- a/specs/021-nuget-graph-version-unification/spec.md
+++ b/specs/021-nuget-graph-version-unification/spec.md
@@ -1,0 +1,60 @@
+# Feature Specification: NuGet Graph Version Unification
+
+**Feature Branch**: `021-nuget-graph-version-unification`  
+**Created**: 2026-05-13  
+**Status**: Draft  
+**Input**: User description: "Fix Nuplane dependency graph resolution so compatible overlapping transitive dependency requests inside a graph are unified to a single selected package version instead of causing resolve-graph-conflict failures, while preserving deterministic failures for truly incompatible root graph selections."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Load Packages With Compatible Transitive Baselines (Priority: P1)
+
+As an operator, I want runtime package roots that depend on older baseline dependency versions to resolve against the current compatible version already selected in the graph, so valid package sets are not rejected as conflicts.
+
+**Why this priority**: Real packages commonly declare dependency minimums using bare NuGet versions. Treating those minimums as exact pins prevents packages such as provider/migration packages from loading with newer compatible framework dependencies.
+
+**Independent Test**: Resolve a package graph where one dependency path requests a package using a bare version such as `8.0.2` while another path requests a higher compatible range such as `[10.0.3]`. The graph must select one compatible version and produce no graph-conflict failure.
+
+**Acceptance Scenarios**:
+
+1. **Given** package metadata declares a dependency with a bare version, **When** Nuplane resolves the dependency graph, **Then** the bare version is interpreted as a minimum version requirement rather than an exact pin.
+2. **Given** multiple graph paths request compatible versions of the same dependency package, **When** graph resolution completes, **Then** the graph contains one selected package version for that package id.
+3. **Given** two desired roots truly require incompatible exact versions of the same dependency package, **When** reconciliation resolves both roots, **Then** Nuplane still records graph-conflict diagnostics for the affected roots.
+
+### Edge Cases
+
+- Bare dependency versions must preserve Nuplane's existing exact-version behavior for direct desired package include patterns.
+- Bracketed exact dependency ranges such as `[1.0.0]` must remain exact.
+- Unsatisfied minimum dependency ranges must continue to fail resolution and preserve last-known-good state.
+- Existing host-provided dependency filtering must remain unchanged.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: `PackageDependencyGraphResolver` MUST normalize bare NuGet dependency version metadata to an inclusive minimum range before resolving dependency packages.
+- **FR-002**: `PackageDependencyGraphResolver` MUST leave explicit NuGet range syntax unchanged, including exact bracketed ranges.
+- **FR-003**: `PackageApplyExecutor` MUST continue to reject active root graphs that resolve genuinely different selected versions for the same package id after dependency normalization.
+- **FR-004**: Direct desired package requests MUST keep their existing version-range semantics and MUST NOT be changed by dependency metadata normalization.
+
+### Operational & Safety Requirements *(mandatory)*
+
+- **OSR-001**: Reconciliation/apply flows MUST remain deterministic and idempotent for repeated identical inputs.
+- **OSR-002**: Failed graph resolution MUST preserve existing last-known-good behavior.
+- **OSR-003**: Dependency resolution MUST continue to use only configured package sources and existing integrity validation paths.
+- **OSR-004**: Existing graph-conflict diagnostics MUST remain available for truly incompatible graphs.
+- **OSR-005**: The fix MUST include regression tests for bare dependency versions and incompatible exact graph conflicts.
+
+### Key Entities
+
+- **Dependency Version Requirement**: The version expression read from package metadata for a dependency edge.
+- **Resolved Package Graph**: The selected root, dependency nodes, and dependency edges activated together.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A graph containing compatible bare-version dependency baselines resolves without `resolve-graph-conflict` failures.
+- **SC-002**: Existing tests for incompatible exact dependency versions continue to pass.
+- **SC-003**: Focused runtime tests for graph resolver and apply conflict behavior pass locally.
+

--- a/specs/021-nuget-graph-version-unification/tasks.md
+++ b/specs/021-nuget-graph-version-unification/tasks.md
@@ -1,0 +1,20 @@
+# Tasks: NuGet Graph Version Unification
+
+**Input**: Design documents from `/specs/021-nuget-graph-version-unification/`
+
+**Tests**: Required. Add regression coverage before implementation.
+
+## Phase 1: Tests
+
+- [X] T001 Add resolver regression coverage for bare dependency version metadata selecting a higher compatible package version in `test/Nuplane.Runtime.Tests/Feeds/PackageDependencyGraphResolverTests.cs`.
+- [X] T002 Verify existing apply-executor conflict coverage still rejects incompatible exact dependency versions in `test/Nuplane.Runtime.Tests/Reconciliation/PackageApplyExecutorTests.cs`.
+
+## Phase 2: Implementation
+
+- [X] T003 Normalize bare dependency versions to NuGet minimum ranges inside `src/Nuplane/Reconciliation/PackageDependencyGraphResolver.cs`.
+- [X] T004 Keep direct desired request exact-version behavior unchanged.
+
+## Phase 3: Validation
+
+- [X] T005 Run focused Nuplane runtime tests for dependency graph resolution and apply conflict behavior.
+- [X] T006 Record validation outcome in the final response.

--- a/src/Nuplane/Reconciliation/PackageDependencyGraphResolver.cs
+++ b/src/Nuplane/Reconciliation/PackageDependencyGraphResolver.cs
@@ -196,7 +196,7 @@ public sealed class PackageDependencyGraphResolver(IPackageResolver packageResol
                     .Where(static element => element.Name.LocalName == "dependency")
                     .Select(element => new PackageDependencyMetadata(
                         element.Attribute("id")?.Value ?? string.Empty,
-                        element.Attribute("version")?.Value ?? string.Empty,
+                        NormalizeDependencyVersionRange(element.Attribute("version")?.Value ?? string.Empty),
                         group.Attribute("targetFramework")?.Value))
                     .ToArray()))
             .ToArray();
@@ -217,12 +217,30 @@ public sealed class PackageDependencyGraphResolver(IPackageResolver packageResol
             .Where(static element => element.Name.LocalName == "dependency" && element.Parent?.Name.LocalName == "dependencies")
             .Select(static element => new PackageDependencyMetadata(
                 element.Attribute("id")?.Value ?? string.Empty,
-                element.Attribute("version")?.Value ?? string.Empty,
+                NormalizeDependencyVersionRange(element.Attribute("version")?.Value ?? string.Empty),
                 TargetFramework: null))
             .Where(static dependency => !string.IsNullOrWhiteSpace(dependency.PackageId)
                 && !string.IsNullOrWhiteSpace(dependency.VersionRange))
             .OrderBy(static dependency => dependency.PackageId, StringComparer.OrdinalIgnoreCase)
             .ToArray();
+    }
+
+    private static string NormalizeDependencyVersionRange(string versionRange)
+    {
+        if (string.IsNullOrWhiteSpace(versionRange))
+        {
+            return versionRange;
+        }
+
+        var trimmed = versionRange.Trim();
+        if (trimmed.StartsWith('[') || trimmed.StartsWith('('))
+        {
+            return trimmed;
+        }
+
+        return NuGetVersion.TryParse(trimmed, out var version)
+            ? $"[{version.ToNormalizedString()},)"
+            : trimmed;
     }
 
     private static IReadOnlyList<DependencyGroupMetadata> SelectDependencyGroups(IReadOnlyList<DependencyGroupMetadata> groups)

--- a/test/Nuplane.Runtime.Tests/Feeds/PackageDependencyGraphResolverTests.cs
+++ b/test/Nuplane.Runtime.Tests/Feeds/PackageDependencyGraphResolverTests.cs
@@ -1,6 +1,7 @@
 using Nuplane.Abstractions;
 using Nuplane.Reconciliation;
 using Nuplane.Reconciliation.Models;
+using Nuplane.Runtime.Tests.TestSupport;
 using System.Reflection;
 using System.Reflection.Emit;
 
@@ -58,6 +59,31 @@ public sealed class PackageDependencyGraphResolverTests : IDisposable
         Assert.Equal("Plugin.Dependency", dependencyRequest.Id);
         Assert.Null(dependencyRequest.FeedName);
         Assert.Equal("dependency-of:Plugin.Root", dependencyRequest.SourceName);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_BareDependencyVersion_TreatsVersionAsInclusiveMinimum()
+    {
+        var root = CreateInstalledPackage("Plugin.Root", "1.0.0", dependencyId: "Plugin.Dependency", dependencyVersionRange: "8.0.2");
+        var dependency = CreateInstalledPackage("Plugin.Dependency", "10.0.3");
+        var resolver = new VersionRangePackageResolver(
+            new Dictionary<string, IReadOnlyList<ResolvedPackage>>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["Plugin.Dependency"] = [dependency]
+            });
+        var sut = new PackageDependencyGraphResolver(resolver, new PassthroughRetryPolicy());
+
+        var result = await sut.ResolveAsync(
+            [new PackageRequest("Plugin.Root", "[1.0.0]", "test-feed", PackageUpdatePolicy.Exact, "test-source")],
+            (_, _) => Task.FromResult(root),
+            CancellationToken.None);
+
+        var graph = Assert.Single(result.ResolvedGraphs);
+        Assert.Contains(graph.Nodes, static node => node.PackageId == "Plugin.Dependency" && node.Version == "10.0.3");
+        var edge = Assert.Single(graph.Edges);
+        Assert.Equal("[8.0.2,)", edge.RequestedVersionRange);
+        var request = Assert.Single(resolver.Requests);
+        Assert.Equal("[8.0.2,)", request.VersionRange);
     }
 
     [Fact]

--- a/test/Nuplane.Runtime.Tests/Reconciliation/PackageApplyExecutorTests.cs
+++ b/test/Nuplane.Runtime.Tests/Reconciliation/PackageApplyExecutorTests.cs
@@ -1,5 +1,6 @@
 using Nuplane.Abstractions;
 using Nuplane.Reconciliation;
+using Nuplane.Runtime.Tests.TestSupport;
 using Nuplane.Store.Activation;
 using Nuplane.Store.State;
 using Nuplane.Store.Transactions;
@@ -40,6 +41,39 @@ public sealed class PackageApplyExecutorTests : IDisposable
         Assert.DoesNotContain(recorder.Records, static record => record.PackageId == "Missing.Root" && record.Stage == "resolve-graph-conflict");
         Assert.Contains(recorder.Records, static record => record.PackageId == "Root.A" && record.Stage == "resolve-graph-conflict");
         Assert.Contains(recorder.Records, static record => record.PackageId == "Root.B" && record.Stage == "resolve-graph-conflict");
+    }
+
+    [Fact]
+    public async Task ResolveAsync_WhenCompatibleBareDependencyBaseline_DoesNotRecordGraphConflict()
+    {
+        var resolver = new VersionRangePackageResolver(new Dictionary<string, IReadOnlyList<ResolvedPackage>>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Root.Current"] = [CreateInstalledPackage("Root.Current", "1.0.0", "Shared.Dependency", "[10.0.3]")],
+            ["Root.Baseline"] = [CreateInstalledPackage("Root.Baseline", "1.0.0", "Shared.Dependency", "8.0.2")],
+            ["Shared.Dependency"] = [CreateInstalledPackage("Shared.Dependency", "10.0.3")]
+        });
+        var recorder = new RecordingFailureRecorder();
+        var sut = new PackageApplyExecutor(
+            resolver,
+            new PackageTransactionCoordinator(new AtomicPointerSwitcher(), recorder),
+            new PassthroughRetryPolicy(),
+            recorder);
+
+        var result = await sut.ResolveAsync(
+            [
+                new PackageRequest("Root.Current", "[1.0.0]", "test-feed", PackageUpdatePolicy.Exact, "test-source"),
+                new PackageRequest("Root.Baseline", "[1.0.0]", "test-feed", PackageUpdatePolicy.Exact, "test-source")
+            ],
+            "corr-1",
+            CancellationToken.None);
+
+        Assert.Empty(recorder.Records);
+        Assert.Contains(result.ResolvedPackages, static package => package.Id == "Shared.Dependency" && package.Version == "10.0.3");
+        Assert.Equal(2, result.ResolvedGraphs.Count);
+        Assert.All(result.ResolvedGraphs, graph =>
+        {
+            Assert.Contains(graph.Nodes, static node => node.PackageId == "Shared.Dependency" && node.Version == "10.0.3");
+        });
     }
 
     public void Dispose()

--- a/test/Nuplane.Runtime.Tests/TestSupport/VersionRangePackageResolver.cs
+++ b/test/Nuplane.Runtime.Tests/TestSupport/VersionRangePackageResolver.cs
@@ -15,15 +15,15 @@ internal sealed class VersionRangePackageResolver(IReadOnlyDictionary<string, IR
             return Task.FromException<ResolvedPackage>(new InvalidOperationException($"Package '{request.Id}' was not configured."));
         }
 
-        var normalizedRange = request.VersionRange;
-        if (NuGetVersion.TryParse(normalizedRange, out _) &&
-            !normalizedRange.StartsWith('[') &&
-            !normalizedRange.StartsWith('('))
+        if (NuGetVersion.TryParse(request.VersionRange, out _) &&
+            !request.VersionRange.StartsWith('[') &&
+            !request.VersionRange.StartsWith('('))
         {
-            normalizedRange = $"[{normalizedRange}]";
+            return Task.FromException<ResolvedPackage>(new InvalidOperationException(
+                $"Version range '{request.VersionRange}' must be normalized by the caller before using {nameof(VersionRangePackageResolver)}."));
         }
 
-        if (!VersionRange.TryParse(normalizedRange, out var range))
+        if (!VersionRange.TryParse(request.VersionRange, out var range))
         {
             return Task.FromException<ResolvedPackage>(new InvalidOperationException($"Version range '{request.VersionRange}' is invalid."));
         }

--- a/test/Nuplane.Runtime.Tests/TestSupport/VersionRangePackageResolver.cs
+++ b/test/Nuplane.Runtime.Tests/TestSupport/VersionRangePackageResolver.cs
@@ -1,0 +1,45 @@
+using Nuplane.Abstractions;
+using NuGet.Versioning;
+
+namespace Nuplane.Runtime.Tests.TestSupport;
+
+internal sealed class VersionRangePackageResolver(IReadOnlyDictionary<string, IReadOnlyList<ResolvedPackage>> packages) : IPackageResolver
+{
+    public List<PackageRequest> Requests { get; } = [];
+
+    public Task<ResolvedPackage> ResolveAsync(PackageRequest request, CancellationToken cancellationToken)
+    {
+        Requests.Add(request);
+        if (!packages.TryGetValue(request.Id, out var candidates))
+        {
+            return Task.FromException<ResolvedPackage>(new InvalidOperationException($"Package '{request.Id}' was not configured."));
+        }
+
+        var normalizedRange = request.VersionRange;
+        if (NuGetVersion.TryParse(normalizedRange, out _) &&
+            !normalizedRange.StartsWith('[') &&
+            !normalizedRange.StartsWith('('))
+        {
+            normalizedRange = $"[{normalizedRange}]";
+        }
+
+        if (!VersionRange.TryParse(normalizedRange, out var range))
+        {
+            return Task.FromException<ResolvedPackage>(new InvalidOperationException($"Version range '{request.VersionRange}' is invalid."));
+        }
+
+        var match = candidates
+            .Select(package => new
+            {
+                Package = package,
+                Version = NuGetVersion.Parse(package.Version)
+            })
+            .Where(candidate => range.Satisfies(candidate.Version))
+            .OrderByDescending(candidate => candidate.Version)
+            .FirstOrDefault();
+
+        return match is null
+            ? Task.FromException<ResolvedPackage>(new InvalidOperationException($"Package '{request.Id}' had no candidate for '{request.VersionRange}'."))
+            : Task.FromResult(match.Package);
+    }
+}


### PR DESCRIPTION
## Summary

Fix Nuplane dependency graph resolution so bare versions from NuGet dependency metadata are treated as inclusive minimum ranges instead of exact pins.

This lets valid dependency graphs resolve when a package declares an older baseline dependency, while another path selects a newer compatible version, matching NuGet dependency semantics more closely.

## Root Cause

`PackageDependencyGraphResolver` passed bare nuspec dependency versions such as `8.0.2` directly into package resolution. Nuplane's general version evaluator intentionally treats bare direct desired versions as exact, so dependency metadata was also resolved as exact. That caused compatible graphs, such as EF Core `8.0.2` baseline metadata plus EF Core `10.0.3` selected packages, to be rejected with `resolve-graph-conflict`.

## Changes

- Normalize bare dependency metadata versions to inclusive minimum ranges, e.g. `8.0.2` -> `[8.0.2,)`.
- Preserve explicit NuGet range syntax, including exact bracketed dependency ranges.
- Keep direct desired package request semantics unchanged.
- Add resolver and apply-level regressions for compatible bare dependency baselines.
- Add Spec Kit notes for the bug fix.

## Validation

- `dotnet test test/Nuplane.Runtime.Tests/Nuplane.Runtime.Tests.csproj`
- `dotnet test nuplane.sln`
