### PR TITLE
Fix dependency package version selection

### DIFF
--- a/specs/022-dependency-version-selection/checklists/requirements.md
+++ b/specs/022-dependency-version-selection/checklists/requirements.md
@@ -1,0 +1,27 @@
+# Specification Quality Checklist: Dependency Version Selection
+
+**Purpose**: Validate specification completeness and quality before implementation  
+**Created**: 2026-05-13  
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No unrelated implementation details
+- [X] Focused on operator/runtime package loading value
+- [X] Written for stakeholders familiar with NuGet package reconciliation
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Requirements are testable and unambiguous
+- [X] Success criteria are measurable
+- [X] Acceptance scenarios and edge cases are defined
+- [X] Scope is clearly bounded
+
+## Feature Readiness
+
+- [X] Functional requirements have acceptance coverage
+- [X] User scenarios cover the observed failure mode
+- [X] Feature meets measurable outcomes
+

--- a/specs/022-dependency-version-selection/plan.md
+++ b/specs/022-dependency-version-selection/plan.md
@@ -1,0 +1,45 @@
+# Implementation Plan: Dependency Version Selection
+
+**Branch**: `022-dependency-version-selection` | **Date**: 2026-05-13 | **Spec**: [spec.md](./spec.md)  
+**Input**: Feature specification from `/specs/022-dependency-version-selection/spec.md`
+
+## Summary
+
+Correct dependency graph version selection so dependency-originated requests select the nearest satisfying version, and graph expansion reuses already-selected compatible dependency nodes. This prevents open dependency baselines from floating to incompatible major/framework packages while preserving direct desired range behavior.
+
+## Technical Context
+
+**Language/Version**: C# with SDK-style .NET libraries targeting `net8.0;net9.0;net10.0`; tests target `net10.0`  
+**Primary Dependencies**: NuGet.Versioning, NuGet.Protocol, Microsoft.Extensions libraries, xUnit  
+**Storage**: File-backed Nuplane package store state; no new storage  
+**Testing**: xUnit via `dotnet test`  
+**Target Platform**: .NET host applications using Nuplane runtime package reconciliation  
+**Project Type**: Infrastructure library  
+**Performance Goals**: No additional feed enumeration beyond current dependency resolution  
+**Constraints**: Preserve direct desired highest-match semantics and existing graph-conflict behavior  
+**Scale/Scope**: Resolver behavior and focused runtime regression coverage
+
+## Constitution Check
+
+- Deterministic reconciliation: PASS. Selection and reuse are deterministic for fixed inputs.
+- Transactional store safety: PASS. Changes happen before activation and preserve existing LKG paths.
+- Source integrity: PASS. Resolution still uses configured feeds and acquisition validation.
+- Observability: PASS. Existing resolution and graph-conflict diagnostics are retained.
+- Test discipline: PASS. Regression tests cover the observed bug class.
+- Decomposition discipline: PASS. Tasks map to resolver selection and graph reuse.
+- Options validation discipline: PASS. No options are introduced.
+
+## Project Structure
+
+```text
+src/Nuplane/Feeds/MultiFeedPackageResolver.cs
+src/Nuplane/Reconciliation/PackageDependencyGraphResolver.cs
+test/Nuplane.Runtime.Tests/Feeds/MultiFeedPackageResolverTests.cs
+test/Nuplane.Runtime.Tests/Feeds/PackageDependencyGraphResolverTests.cs
+specs/022-dependency-version-selection/
+```
+
+## Complexity Tracking
+
+No constitution violations.
+

--- a/specs/022-dependency-version-selection/spec.md
+++ b/specs/022-dependency-version-selection/spec.md
@@ -1,0 +1,59 @@
+# Feature Specification: Dependency Version Selection
+
+**Feature Branch**: `022-dependency-version-selection`  
+**Created**: 2026-05-13  
+**Status**: Draft  
+**Input**: User description: "Fix dependency graph resolution after Nuplane 0.0.8-preview.43 selected EF Core 11 preview packages for a net10 host, causing graph load failures and missing QuartzSqlite feature discovery."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Resolve Dependency Baselines Without Floating To Incompatible Majors (Priority: P1)
+
+As an operator, I want dependency graph resolution to select the nearest satisfying dependency version unless a higher version is already selected in the graph, so dependency baselines do not float to incompatible framework-only package versions.
+
+**Why this priority**: Runtime package graphs can fail to load when open dependency ranges float to packages that do not contain compatible assets for the host target framework.
+
+**Independent Test**: Resolve a dependency request for `[10.0.3,)` with available versions `10.0.3`, `10.0.4`, and `11.0.0-preview`; Nuplane must select `10.0.3` for dependency requests.
+
+**Acceptance Scenarios**:
+
+1. **Given** a dependency request has an inclusive minimum range, **When** candidate versions are enumerated, **Then** the lowest satisfying version is selected.
+2. **Given** a graph already selected a higher direct dependency version, **When** a transitive package requests a lower compatible baseline, **Then** the existing selected dependency is reused and no duplicate dependency node is resolved.
+3. **Given** direct desired package requests use range semantics, **When** Nuplane resolves those requests, **Then** existing highest-match behavior remains unchanged.
+
+### Edge Cases
+
+- Invalid dependency ranges still fail with version-range diagnostics.
+- Exact bracketed dependency ranges still select the exact version.
+- Existing graph-conflict behavior remains for truly incompatible selected versions.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: `MultiFeedPackageResolver` MUST select the lowest satisfying version for dependency-originated remote feed requests.
+- **FR-002**: `MultiFeedPackageResolver` MUST preserve existing `IVersionRangeEvaluator.SelectBestMatch` behavior for direct desired requests.
+- **FR-003**: `PackageDependencyGraphResolver` MUST reuse an already-selected graph package when that package version satisfies a later dependency edge.
+- **FR-004**: `PackageDependencyGraphResolver` MUST still record dependency edges when reusing an existing selected package.
+
+### Operational & Safety Requirements *(mandatory)*
+
+- **OSR-001**: Reconciliation behavior MUST remain deterministic and idempotent.
+- **OSR-002**: Existing graph resolution failures and LKG behavior MUST be preserved.
+- **OSR-003**: Dependency resolution MUST continue to use configured feeds and existing acquisition/integrity paths.
+- **OSR-004**: Existing diagnostics for unsatisfied version ranges and graph conflicts MUST remain available.
+- **OSR-005**: Regression tests MUST cover dependency request version selection and selected-package reuse.
+
+### Key Entities
+
+- **Dependency-Originated Request**: A package request produced while expanding a dependency graph.
+- **Selected Graph Package**: A package node already chosen for the current graph and eligible for reuse by later compatible dependency edges.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Dependency requests for `[10.0.3,)` select `10.0.3` instead of `11.0.0-preview` when both are available.
+- **SC-002**: A graph with direct `10.0.3` and transitive bare `8.0.2` baselines contains one dependency node and two edges.
+- **SC-003**: Nuplane runtime tests pass locally.
+

--- a/specs/022-dependency-version-selection/tasks.md
+++ b/specs/022-dependency-version-selection/tasks.md
@@ -1,0 +1,19 @@
+# Tasks: Dependency Version Selection
+
+**Input**: Design documents from `/specs/022-dependency-version-selection/`
+
+## Phase 1: Tests
+
+- [X] T001 Add a `MultiFeedPackageResolver` regression proving dependency-originated requests select the lowest satisfying version.
+- [X] T002 Add a `PackageDependencyGraphResolver` regression proving a higher direct dependency satisfies a lower transitive baseline without duplicate resolution.
+
+## Phase 2: Implementation
+
+- [X] T003 Update `MultiFeedPackageResolver` to use lowest-satisfying selection for dependency-originated requests.
+- [X] T004 Update `PackageDependencyGraphResolver` to reuse already-selected compatible graph nodes and still record dependency edges.
+
+## Phase 3: Validation
+
+- [X] T005 Run focused runtime regressions.
+- [X] T006 Run full Nuplane runtime tests.
+- [X] T007 Run full solution tests.

--- a/src/Nuplane/Feeds/MultiFeedPackageResolver.cs
+++ b/src/Nuplane/Feeds/MultiFeedPackageResolver.cs
@@ -10,6 +10,7 @@ using Nuplane.Feeds.Versioning;
 using Nuplane.Observability;
 using Nuplane.Reconciliation.Models;
 using Nuplane.Versioning;
+using NuGet.Versioning;
 
 namespace Nuplane.Feeds;
 
@@ -202,7 +203,9 @@ public sealed class MultiFeedPackageResolver : IPackageResolver
         try
         {
             var versionList = await _versionEnumerator.EnumerateVersionsAsync(feed, request.Id, cancellationToken);
-            var result = _versionRangeEvaluator.SelectBestMatch(request.VersionRange, versionList.Versions);
+            var result = IsDependencyRequest(request)
+                ? SelectLowestDependencyMatch(request.VersionRange, versionList.Versions)
+                : _versionRangeEvaluator.SelectBestMatch(request.VersionRange, versionList.Versions);
             stopwatch.Stop();
 
             _logger.LogDebug(
@@ -316,6 +319,36 @@ public sealed class MultiFeedPackageResolver : IPackageResolver
 
     private static bool IsLocalDirectoryFeed(FeedDefinition feed) =>
         feed.ServiceIndex.Scheme.Equals("file", StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsDependencyRequest(PackageRequest request) =>
+        request.SourceName.StartsWith("dependency-of:", StringComparison.OrdinalIgnoreCase);
+
+    private static VersionResolutionResult SelectLowestDependencyMatch(string versionRange, IReadOnlyList<string> availableVersions)
+    {
+        var parsedVersions = availableVersions
+            .Select(static version => NuGetVersion.TryParse(version, out var parsed) ? parsed : null)
+            .OfType<NuGetVersion>()
+            .ToArray();
+
+        if (parsedVersions.Length == 0)
+        {
+            return new(false, null, availableVersions.Count, "Resolution failed: no versions available.");
+        }
+
+        if (!VersionRange.TryParse(versionRange, out var range))
+        {
+            return new(false, null, availableVersions.Count, $"Resolution failed: invalid version range '{versionRange}'.");
+        }
+
+        var selectedVersion = parsedVersions
+            .Where(range.Satisfies)
+            .Order()
+            .FirstOrDefault();
+
+        return selectedVersion is null
+            ? new(false, null, availableVersions.Count, $"Resolution failed: no version matched range '{versionRange}'.")
+            : new(true, selectedVersion.ToNormalizedString(), availableVersions.Count, null);
+    }
 
     /// <summary>
     /// Tries to retrieve the feed resolution decision for the specified package.

--- a/src/Nuplane/Reconciliation/PackageDependencyGraphResolver.cs
+++ b/src/Nuplane/Reconciliation/PackageDependencyGraphResolver.cs
@@ -63,6 +63,27 @@ public sealed class PackageDependencyGraphResolver(IPackageResolver packageResol
                     continue;
                 }
 
+                var existingDependencyPackage = FindExistingSatisfyingPackage(nodes.Values, resolvedPackages, dependency);
+                if (existingDependencyPackage is not null)
+                {
+                    var existingDependencyKey = BuildPackageKey(existingDependencyPackage.Id, existingDependencyPackage.Version);
+                    if (path.Contains(existingDependencyKey, StringComparer.OrdinalIgnoreCase))
+                    {
+                        throw new InvalidOperationException($"Dependency cycle detected: {FormatCyclePath(path, existingDependencyKey)}.");
+                    }
+
+                    edges.Add(new DependencyEdge(
+                        parent.Id,
+                        parent.Version,
+                        existingDependencyPackage.Id,
+                        dependency.VersionRange,
+                        existingDependencyPackage.Version,
+                        dependency.TargetFramework ?? string.Empty,
+                        Optional: false));
+
+                    continue;
+                }
+
                 var dependencyRequest = new PackageRequest(
                     dependency.PackageId,
                     dependency.VersionRange,
@@ -241,6 +262,27 @@ public sealed class PackageDependencyGraphResolver(IPackageResolver packageResol
         return NuGetVersion.TryParse(trimmed, out var version)
             ? $"[{version.ToNormalizedString()},)"
             : trimmed;
+    }
+
+    private static ResolvedPackage? FindExistingSatisfyingPackage(
+        IEnumerable<ResolvedPackageNode> nodes,
+        IReadOnlyDictionary<string, ResolvedPackage> resolvedPackages,
+        PackageDependencyMetadata dependency)
+    {
+        foreach (var node in nodes.Where(node => string.Equals(node.PackageId, dependency.PackageId, StringComparison.OrdinalIgnoreCase)))
+        {
+            if (!VersionSatisfiesRange(node.Version, dependency.VersionRange))
+            {
+                continue;
+            }
+
+            if (resolvedPackages.TryGetValue(BuildPackageKey(node.PackageId, node.Version), out var package))
+            {
+                return package;
+            }
+        }
+
+        return null;
     }
 
     private static IReadOnlyList<DependencyGroupMetadata> SelectDependencyGroups(IReadOnlyList<DependencyGroupMetadata> groups)

--- a/test/Nuplane.Runtime.Tests/Feeds/MultiFeedPackageResolverTests.cs
+++ b/test/Nuplane.Runtime.Tests/Feeds/MultiFeedPackageResolverTests.cs
@@ -194,6 +194,39 @@ public sealed class MultiFeedPackageResolverTests
     }
 
     [Fact]
+    public async Task ResolveAsync_DependencyRequest_SelectsLowestSatisfyingVersion()
+    {
+        var options = new FeedResolutionOptions();
+        options.Feeds.Add(new("remote", new("https://feed.example/v3/index.json")));
+        var wrappedOptions = new OptionsWrapper<FeedResolutionOptions>(options);
+        var policy = new FeedResolutionPolicy(wrappedOptions);
+
+        var enumerator = Substitute.For<IFeedVersionEnumerator>();
+        enumerator.EnumerateVersionsAsync(Arg.Any<FeedDefinition>(), "Microsoft.EntityFrameworkCore", Arg.Any<CancellationToken>())
+            .Returns(new PackageVersionList(
+                "Microsoft.EntityFrameworkCore",
+                "remote",
+                ["10.0.3", "10.0.4", "11.0.0-preview.4.26230.115"],
+                DateTimeOffset.UtcNow));
+
+        var evaluator = Substitute.For<IVersionRangeEvaluator>();
+
+        var acquirer = Substitute.For<IRemotePackageAcquirer>();
+        acquirer.AcquireAsync(Arg.Any<FeedDefinition>(), "Microsoft.EntityFrameworkCore", "10.0.3", Arg.Any<CancellationToken>())
+            .Returns("/installed/Microsoft.EntityFrameworkCore/10.0.3");
+
+        var resolver = new MultiFeedPackageResolver(
+            wrappedOptions, policy, acquirer, enumerator, evaluator,
+            NullLogger<MultiFeedPackageResolver>.Instance);
+
+        var request = new PackageRequest("Microsoft.EntityFrameworkCore", "[10.0.3,)", "remote", PackageUpdatePolicy.Exact, "dependency-of:Plugin.Root");
+        var result = await resolver.ResolveAsync(request, CancellationToken.None);
+
+        Assert.Equal("10.0.3", result.Version);
+        evaluator.DidNotReceiveWithAnyArgs().SelectBestMatch(default!, default!);
+    }
+
+    [Fact]
     public async Task ResolveAsync_NoMatch_DecisionContainsDiagnostic()
     {
         var options = new FeedResolutionOptions();

--- a/test/Nuplane.Runtime.Tests/Feeds/PackageDependencyGraphResolverTests.cs
+++ b/test/Nuplane.Runtime.Tests/Feeds/PackageDependencyGraphResolverTests.cs
@@ -87,6 +87,39 @@ public sealed class PackageDependencyGraphResolverTests : IDisposable
     }
 
     [Fact]
+    public async Task ResolveAsync_WhenHigherDirectDependencySatisfiesTransitiveBaseline_ReusesSelectedDependency()
+    {
+        var root = CreateInstalledPackage(
+            "Plugin.Root",
+            "1.0.0",
+            dependenciesXml: """
+                <dependencies>
+                  <dependency id="Plugin.Direct" version="10.0.3" />
+                  <dependency id="Plugin.Transitive" version="[1.0.0]" />
+                </dependencies>
+                """);
+        var direct = CreateInstalledPackage("Plugin.Direct", "10.0.3");
+        var transitive = CreateInstalledPackage("Plugin.Transitive", "1.0.0", dependencyId: "Plugin.Direct", dependencyVersionRange: "8.0.2");
+        var resolver = new VersionRangePackageResolver(
+            new Dictionary<string, IReadOnlyList<ResolvedPackage>>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["Plugin.Direct"] = [direct],
+                ["Plugin.Transitive"] = [transitive]
+            });
+        var sut = new PackageDependencyGraphResolver(resolver, new PassthroughRetryPolicy());
+
+        var result = await sut.ResolveAsync(
+            [new PackageRequest("Plugin.Root", "[1.0.0]", "test-feed", PackageUpdatePolicy.Exact, "test-source")],
+            (_, _) => Task.FromResult(root),
+            CancellationToken.None);
+
+        var graph = Assert.Single(result.ResolvedGraphs);
+        Assert.Single(graph.Nodes, static node => node.PackageId == "Plugin.Direct");
+        Assert.Equal(2, graph.Edges.Count(static edge => edge.ToPackageId == "Plugin.Direct"));
+        Assert.Single(resolver.Requests, static request => request.Id == "Plugin.Direct");
+    }
+
+    [Fact]
     public async Task ResolveAsync_DependencyProvidedByHost_DoesNotAcquireDependencyNode()
     {
         var root = CreateInstalledPackage("Plugin.Root", "1.0.0", dependencyId: "Nuplane.Abstractions", dependencyVersionRange: "[1.0.0]");


### PR DESCRIPTION
## Summary

Fix dependency graph resolution so dependency-originated package requests select the nearest satisfying version instead of floating to the highest matching package.

This addresses the follow-up failure seen after Nuplane `0.0.8-preview.43`: Quartz SQLite graphs resolved successfully, but EF Core floated to `11.0.0-preview.4...`, which only has `net11.0` assets and cannot load in the `net10.0` ElsaProServer host.

## Root Cause

The previous fix correctly normalized bare dependency versions such as `10.0.3` to `[10.0.3,)`, but Nuplane then reused the direct desired-package version evaluator for dependency-originated requests. That evaluator intentionally selects the highest matching version for user-desired ranges. For package dependencies, this can over-float baselines to incompatible future framework packages.

## Changes

- Dependency-originated remote feed requests now select the lowest satisfying package version.
- Direct desired package requests keep their existing highest-match behavior.
- Dependency graph expansion now reuses an already-selected graph package when it satisfies a later dependency edge.
- Added regressions for EF Core-style dependency floating and direct/transitive dependency reuse.
- Added Spec Kit notes for this follow-up fix.

## Validation

- `dotnet test test/Nuplane.Runtime.Tests/Nuplane.Runtime.Tests.csproj`
- `dotnet test nuplane.sln`
