### PR TITLE
Adopt NuGet dependency resolver semantics

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -18,6 +18,7 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="NuGet.Protocol" Version="6.13.1" />
+    <PackageVersion Include="NuGet.Resolver" Version="6.13.1" />
     <PackageVersion Include="NuGet.Versioning" Version="6.13.1" />
     <PackageVersion Include="Polly.Extensions" Version="8.6.5" />
     <PackageVersion Include="xunit" Version="2.9.3" />

--- a/specs/022-dependency-version-selection/checklists/requirements.md
+++ b/specs/022-dependency-version-selection/checklists/requirements.md
@@ -1,0 +1,27 @@
+# Specification Quality Checklist: Dependency Version Selection
+
+**Purpose**: Validate specification completeness and quality before implementation  
+**Created**: 2026-05-13  
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No unrelated implementation details
+- [X] Focused on operator/runtime package loading value
+- [X] Written for stakeholders familiar with NuGet package reconciliation
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Requirements are testable and unambiguous
+- [X] Success criteria are measurable
+- [X] Acceptance scenarios and edge cases are defined
+- [X] Scope is clearly bounded
+
+## Feature Readiness
+
+- [X] Functional requirements have acceptance coverage
+- [X] User scenarios cover the observed failure mode
+- [X] Feature meets measurable outcomes
+

--- a/specs/022-dependency-version-selection/plan.md
+++ b/specs/022-dependency-version-selection/plan.md
@@ -1,0 +1,45 @@
+# Implementation Plan: Dependency Version Selection
+
+**Branch**: `022-dependency-version-selection` | **Date**: 2026-05-13 | **Spec**: [spec.md](./spec.md)  
+**Input**: Feature specification from `/specs/022-dependency-version-selection/spec.md`
+
+## Summary
+
+Correct dependency graph version selection so dependency-originated requests select the nearest satisfying version, and graph expansion reuses already-selected compatible dependency nodes. This prevents open dependency baselines from floating to incompatible major/framework packages while preserving direct desired range behavior.
+
+## Technical Context
+
+**Language/Version**: C# with SDK-style .NET libraries targeting `net8.0;net9.0;net10.0`; tests target `net10.0`  
+**Primary Dependencies**: NuGet.Versioning, NuGet.Protocol, Microsoft.Extensions libraries, xUnit  
+**Storage**: File-backed Nuplane package store state; no new storage  
+**Testing**: xUnit via `dotnet test`  
+**Target Platform**: .NET host applications using Nuplane runtime package reconciliation  
+**Project Type**: Infrastructure library  
+**Performance Goals**: No additional feed enumeration beyond current dependency resolution  
+**Constraints**: Preserve direct desired highest-match semantics and existing graph-conflict behavior  
+**Scale/Scope**: Resolver behavior and focused runtime regression coverage
+
+## Constitution Check
+
+- Deterministic reconciliation: PASS. Selection and reuse are deterministic for fixed inputs.
+- Transactional store safety: PASS. Changes happen before activation and preserve existing LKG paths.
+- Source integrity: PASS. Resolution still uses configured feeds and acquisition validation.
+- Observability: PASS. Existing resolution and graph-conflict diagnostics are retained.
+- Test discipline: PASS. Regression tests cover the observed bug class.
+- Decomposition discipline: PASS. Tasks map to resolver selection and graph reuse.
+- Options validation discipline: PASS. No options are introduced.
+
+## Project Structure
+
+```text
+src/Nuplane/Feeds/MultiFeedPackageResolver.cs
+src/Nuplane/Reconciliation/PackageDependencyGraphResolver.cs
+test/Nuplane.Runtime.Tests/Feeds/MultiFeedPackageResolverTests.cs
+test/Nuplane.Runtime.Tests/Feeds/PackageDependencyGraphResolverTests.cs
+specs/022-dependency-version-selection/
+```
+
+## Complexity Tracking
+
+No constitution violations.
+

--- a/specs/022-dependency-version-selection/spec.md
+++ b/specs/022-dependency-version-selection/spec.md
@@ -1,0 +1,59 @@
+# Feature Specification: Dependency Version Selection
+
+**Feature Branch**: `022-dependency-version-selection`  
+**Created**: 2026-05-13  
+**Status**: Draft  
+**Input**: User description: "Fix dependency graph resolution after Nuplane 0.0.8-preview.43 selected EF Core 11 preview packages for a net10 host, causing graph load failures and missing QuartzSqlite feature discovery."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Resolve Dependency Baselines Without Floating To Incompatible Majors (Priority: P1)
+
+As an operator, I want dependency graph resolution to select the nearest satisfying dependency version unless a higher version is already selected in the graph, so dependency baselines do not float to incompatible framework-only package versions.
+
+**Why this priority**: Runtime package graphs can fail to load when open dependency ranges float to packages that do not contain compatible assets for the host target framework.
+
+**Independent Test**: Resolve a dependency request for `[10.0.3,)` with available versions `10.0.3`, `10.0.4`, and `11.0.0-preview`; Nuplane must select `10.0.3` for dependency requests.
+
+**Acceptance Scenarios**:
+
+1. **Given** a dependency request has an inclusive minimum range, **When** candidate versions are enumerated, **Then** the lowest satisfying version is selected.
+2. **Given** a graph already selected a higher direct dependency version, **When** a transitive package requests a lower compatible baseline, **Then** the existing selected dependency is reused and no duplicate dependency node is resolved.
+3. **Given** direct desired package requests use range semantics, **When** Nuplane resolves those requests, **Then** existing highest-match behavior remains unchanged.
+
+### Edge Cases
+
+- Invalid dependency ranges still fail with version-range diagnostics.
+- Exact bracketed dependency ranges still select the exact version.
+- Existing graph-conflict behavior remains for truly incompatible selected versions.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: `MultiFeedPackageResolver` MUST select the lowest satisfying version for dependency-originated remote feed requests.
+- **FR-002**: `MultiFeedPackageResolver` MUST preserve existing `IVersionRangeEvaluator.SelectBestMatch` behavior for direct desired requests.
+- **FR-003**: `PackageDependencyGraphResolver` MUST reuse an already-selected graph package when that package version satisfies a later dependency edge.
+- **FR-004**: `PackageDependencyGraphResolver` MUST still record dependency edges when reusing an existing selected package.
+
+### Operational & Safety Requirements *(mandatory)*
+
+- **OSR-001**: Reconciliation behavior MUST remain deterministic and idempotent.
+- **OSR-002**: Existing graph resolution failures and LKG behavior MUST be preserved.
+- **OSR-003**: Dependency resolution MUST continue to use configured feeds and existing acquisition/integrity paths.
+- **OSR-004**: Existing diagnostics for unsatisfied version ranges and graph conflicts MUST remain available.
+- **OSR-005**: Regression tests MUST cover dependency request version selection and selected-package reuse.
+
+### Key Entities
+
+- **Dependency-Originated Request**: A package request produced while expanding a dependency graph.
+- **Selected Graph Package**: A package node already chosen for the current graph and eligible for reuse by later compatible dependency edges.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Dependency requests for `[10.0.3,)` select `10.0.3` instead of `11.0.0-preview` when both are available.
+- **SC-002**: A graph with direct `10.0.3` and transitive bare `8.0.2` baselines contains one dependency node and two edges.
+- **SC-003**: Nuplane runtime tests pass locally.
+

--- a/specs/022-dependency-version-selection/tasks.md
+++ b/specs/022-dependency-version-selection/tasks.md
@@ -1,0 +1,19 @@
+# Tasks: Dependency Version Selection
+
+**Input**: Design documents from `/specs/022-dependency-version-selection/`
+
+## Phase 1: Tests
+
+- [X] T001 Add a `MultiFeedPackageResolver` regression proving dependency-originated requests select the lowest satisfying version.
+- [X] T002 Add a `PackageDependencyGraphResolver` regression proving a higher direct dependency satisfies a lower transitive baseline without duplicate resolution.
+
+## Phase 2: Implementation
+
+- [X] T003 Update `MultiFeedPackageResolver` to use lowest-satisfying selection for dependency-originated requests.
+- [X] T004 Update `PackageDependencyGraphResolver` to reuse already-selected compatible graph nodes and still record dependency edges.
+
+## Phase 3: Validation
+
+- [X] T005 Run focused runtime regressions.
+- [X] T006 Run full Nuplane runtime tests.
+- [X] T007 Run full solution tests.

--- a/specs/023-nuget-restore-feasibility/plan.md
+++ b/specs/023-nuget-restore-feasibility/plan.md
@@ -1,0 +1,49 @@
+# Implementation Plan: NuGet Restore Semantics Feasibility
+
+**Branch**: `023-nuget-restore-feasibility` | **Date**: 2026-05-13 | **Spec**: `specs/023-nuget-restore-feasibility/spec.md`
+
+## Summary
+
+Investigate whether Nuplane can delegate dependency version solving to NuGet libraries while keeping Nuplane-owned feed policy, store activation, graph persistence, and runtime loading. The spike confirms that `NuGet.Resolver.PackageResolver` can solve the current dependency selection regressions from in-memory package metadata.
+
+## Technical Context
+
+**Language/Version**: C# targeting `net10.0` for tests; production libraries multi-target `net8.0;net9.0;net10.0`  
+**Primary Dependencies**: `NuGet.Resolver`, `NuGet.Protocol`, `NuGet.Packaging`, `NuGet.Versioning`, `NuGet.Frameworks`  
+**Storage**: Existing Nuplane file-backed store; no new storage required for the feasibility spike  
+**Testing**: xUnit focused runtime tests  
+**Target Platform**: .NET runtime library  
+**Project Type**: Library/runtime control plane  
+**Performance Goals**: Dependency solving should remain bounded to reconciliation cycles and avoid package activation until after resolution succeeds  
+**Constraints**: No real network calls in feasibility tests; no MSBuild project evaluation; no package loading during solve  
+**Scale/Scope**: Optional package dependency graphs loaded by Nuplane host applications
+
+## Constitution Check
+
+- Deterministic reconciliation: PASS. The proposed resolver input is a deterministic aggregate of trusted feed metadata and desired roots.
+- Transactional store safety: PASS. Package acquisition/activation remains after resolution and under existing transaction/LKG flow.
+- Source integrity: PASS. Resolver candidates are built only after existing feed trust policy accepts sources.
+- Observability: PASS. Follow-up implementation must project NuGet resolver decisions into existing feed/graph diagnostics.
+- Test discipline: PASS. Feasibility tests cover lowest dependency selection, direct dependency wins, cousin unification, and multi-root aggregate unification.
+- Decomposition discipline: PASS. NuGet solving, metadata collection, host-provided filtering, acquisition, and graph projection are separate concerns.
+- Options validation discipline: PASS. No new options are introduced by the spike.
+
+## Project Structure
+
+```text
+Directory.Packages.props
+test/Nuplane.Runtime.Tests/
+├── Nuplane.Runtime.Tests.csproj
+└── Feeds/
+    └── NuGetResolverFeasibilityTests.cs
+specs/023-nuget-restore-feasibility/
+├── spec.md
+├── plan.md
+└── research.md
+```
+
+**Structure Decision**: Production graph resolution lives in `PackageDependencyGraphResolver`, while `PackageApplyExecutor` keeps root acquisition failure isolation and passes successful roots into one aggregate dependency solve.
+
+## Complexity Tracking
+
+No constitution violations.

--- a/specs/023-nuget-restore-feasibility/research.md
+++ b/specs/023-nuget-restore-feasibility/research.md
@@ -1,0 +1,65 @@
+# Research: NuGet Restore Semantics Feasibility
+
+**Date**: 2026-05-13  
+**Branch**: `023-nuget-restore-feasibility`
+
+## Decision
+
+Nuplane should reuse NuGet resolver libraries for dependency version solving instead of continuing to expand custom graph/version logic.
+
+The most feasible near-term API is `NuGet.Resolver.PackageResolver` with `DependencyBehavior.Lowest`, fed by `NuGet.Protocol.Core.Types.SourcePackageDependencyInfo` values. This API is public, easy to test in memory, and reproduces the active failure cases:
+
+- lowest applicable dependency version
+- direct dependency wins
+- cousin dependency unification
+- aggregate unification across multiple top-level roots
+
+## Evidence
+
+Added feasibility tests in `test/Nuplane.Runtime.Tests/Feeds/NuGetResolverFeasibilityTests.cs`:
+
+- `Resolve_LowestDependencyBehavior_SelectsLowestApplicableDependencyVersion`
+- `Resolve_DirectDependencyWins_ReusesDirectVersionForLowerTransitiveBaseline`
+- `Resolve_CousinDependencies_SelectsLowestVersionThatSatisfiesAllRanges`
+- `Resolve_MultipleTopLevelRoots_UnifiesSharedDependencyAcrossAggregateGraph`
+
+Validation:
+
+```text
+dotnet test test/Nuplane.Runtime.Tests/Nuplane.Runtime.Tests.csproj --filter FullyQualifiedName~NuGetResolverFeasibilityTests
+Passed: 4
+```
+
+## NuGet Packages Evaluated
+
+- `NuGet.Resolver`: Public `PackageResolver` and `PackageResolverContext`. Feasible for solving a pre-collected candidate graph.
+- `NuGet.Protocol`: Public feed/resource APIs and `SourcePackageDependencyInfo`. Feasible for collecting package dependency metadata from feeds.
+- `NuGet.Packaging`: Public nuspec/package metadata APIs. Feasible for local package metadata extraction and dependency group parsing.
+- `NuGet.Versioning`: Already used by Nuplane. Continue using for version/range parsing.
+- `NuGet.Frameworks`: Should replace custom TFM compatibility parsing when selecting dependency groups.
+- `NuGet.DependencyResolver.Core`: Public `RemoteDependencyWalker` exists, but public feed/provider adapter coverage is awkward. It is closer to PackageReference restore internals, but adopting it directly appears heavier and requires custom `IRemoteDependencyProvider` plumbing.
+- `NuGet.Commands`/`NuGet.ProjectModel`: More complete restore machinery, but likely too MSBuild/project-assets oriented for Nuplane's runtime control-plane use case.
+
+## Implemented Architecture
+
+1. Keep the existing root package resolution policy for desired packages.
+2. Build an aggregate desired root set for each reconciliation cycle.
+3. Collect dependency metadata for candidate package versions during graph discovery.
+4. Project candidates into `SourcePackageDependencyInfo`.
+5. Filter Nuplane host-provided dependencies before solving.
+6. Run `PackageResolver` with `DependencyBehavior.Lowest`.
+7. Project the selected identities and dependency relationships back into a single aggregate Nuplane `ResolvedPackageGraph`.
+8. Preserve independent root acquisition failures before aggregate graph solving so one missing root does not poison otherwise resolvable roots.
+
+## Open Risks
+
+- `NuGet.Resolver` is documented as the packages.config resolver, while `NuGet.DependencyResolver.Core` is documented as the PackageReference dependency resolver implementation. The feasibility tests show `NuGet.Resolver` matches the required rules for the current cases, but a deeper implementation plan should compare edge cases before final adoption.
+- Nuplane currently resolves one graph per desired root. NuGet-like behavior should solve the desired root set as one aggregate graph, then project root-specific graph metadata. This is a behavior change with positive consistency but a broader blast radius.
+- The resolver needs a complete enough candidate set. Nuplane must decide whether to enumerate all versions for each discovered dependency or fetch progressively until the lowest compatible solve is possible.
+- Target framework group selection should be delegated to `NuGet.Frameworks`/`NuGet.Packaging`; this spike did not yet replace the current custom string parser.
+
+## Rejected Option
+
+Continue growing custom graph resolution rules inside `PackageDependencyGraphResolver`.
+
+Reason: each new bug is another rediscovery of NuGet restore behavior. The current implementation already needs lowest applicable versions, direct wins, cousin unification, multi-root aggregate unification, TFM selection, prerelease handling, exact conflict behavior, and diagnostics. NuGet libraries already encode most of that logic.

--- a/specs/023-nuget-restore-feasibility/spec.md
+++ b/specs/023-nuget-restore-feasibility/spec.md
@@ -1,0 +1,76 @@
+# Feature Specification: NuGet Restore Semantics Feasibility
+
+**Feature Branch**: `023-nuget-restore-feasibility`  
+**Created**: 2026-05-13  
+**Status**: Draft  
+**Input**: User description: "Investigate whether Nuplane should adopt NuGet nuspec/dependency resolution semantics completely and whether an existing NuGet package can supply the algorithm."
+
+## User Scenarios & Testing
+
+### User Story 1 - Match NuGet Dependency Selection (Priority: P1)
+
+As a Nuplane operator loading optional packages, I want transitive dependency versions to be selected the same way NuGet would select them for PackageReference restore so Nuplane does not float dependency baselines into incompatible preview frameworks.
+
+**Why this priority**: This is the active production failure mode: a dependency baseline such as `[10.0.3,)` must not select a `net11.0` preview package when the host runs `net10.0`.
+
+**Independent Test**: Use NuGet's public resolver APIs against an in-memory graph containing `Microsoft.EntityFrameworkCore` versions `10.0.3`, `10.0.4`, and `11.0.0-preview.4.26230.115`; the selected dependency must be `10.0.3`.
+
+**Acceptance Scenarios**:
+
+1. **Given** a transitive dependency asks for `[10.0.3,)`, **When** Nuplane resolves with NuGet lowest dependency behavior, **Then** the selected version is `10.0.3`.
+2. **Given** a higher direct dependency already satisfies a lower transitive baseline, **When** the graph is resolved, **Then** the direct version is reused.
+3. **Given** cousin dependencies require different minimum versions, **When** the graph is resolved, **Then** the lowest version satisfying all ranges is selected.
+
+### User Story 2 - Preserve Nuplane Runtime Policy (Priority: P2)
+
+As a Nuplane maintainer, I want NuGet to solve package dependency versions while Nuplane continues to own feed trust, optional package desired state, acquisition, graph persistence, host-provided dependency filtering, and runtime loading.
+
+**Why this priority**: Full NuGet restore behavior is useful only if Nuplane can keep its runtime control-plane semantics.
+
+**Independent Test**: Demonstrate the resolver can run against Nuplane-shaped in-memory package metadata without invoking MSBuild or writing project assets files.
+
+**Acceptance Scenarios**:
+
+1. **Given** package metadata has already been collected from trusted feeds, **When** NuGet's resolver is invoked, **Then** it returns a package identity set without performing package loading or store mutation.
+2. **Given** Nuplane host-provided dependencies are configured, **When** package dependency metadata is projected into the NuGet resolver, **Then** those host-provided dependencies can be filtered before solving.
+
+### Edge Cases
+
+- Multiple desired roots can impose cousin constraints on the same dependency; Nuplane should solve the desired aggregate as one graph before projecting per-root graph records.
+- Exact version conflicts should surface as deterministic resolution failures before acquisition/loading.
+- Target framework dependency groups should be selected with NuGet framework compatibility APIs, not custom string parsing.
+- Nuplane's desired package version policy can remain "latest/highest" for roots while dependency-originated requests use NuGet lowest applicable behavior.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: Nuplane dependency graph resolution MUST use NuGet-compatible dependency version selection for transitive dependencies.
+- **FR-002**: Nuplane MUST preserve its existing root desired package version policy for feed include patterns unless a root request specifies an exact/ranged version.
+- **FR-003**: Nuplane MUST evaluate the desired root package set as an aggregate dependency solve so cousin dependencies across different roots unify to one selected version.
+- **FR-004**: Nuplane MUST use NuGet package metadata types (`SourcePackageDependencyInfo`, `PackageDependency`, `VersionRange`, `PackageIdentity`) or equivalent NuGet SDK types when invoking the resolver.
+- **FR-005**: Nuplane MUST keep source trust, feed ordering, package acquisition, local store activation, graph persistence, and runtime loading outside the NuGet resolver.
+- **FR-006**: Nuplane MUST filter host-provided dependencies before dependency solving or otherwise model them so the NuGet resolver does not require package acquisition for host-owned assemblies.
+- **FR-007**: Nuplane SHOULD replace custom nuspec XML dependency parsing with `NuGet.Packaging`/`NuGet.Protocol` metadata APIs where package metadata is available.
+
+### Operational & Safety Requirements
+
+- **OSR-001**: Repeated identical desired inputs and feed metadata MUST produce identical resolved package identities.
+- **OSR-002**: Resolution failures MUST occur before package activation and preserve existing LKG behavior.
+- **OSR-003**: Resolver inputs MUST be built only from feeds that pass existing Nuplane feed trust policy.
+- **OSR-004**: Resolution diagnostics MUST identify the selected NuGet resolver policy, selected versions, rejected ranges, and missing/conflicting packages.
+- **OSR-005**: Regression tests MUST cover lowest applicable dependency selection, direct dependency wins, cousin dependency unification, and multi-root aggregate unification.
+
+### Key Entities
+
+- **Desired Root Set**: The package requests collected from configured sources for one reconciliation cycle.
+- **Resolver Candidate Set**: The package versions and dependency metadata collected from trusted feeds and projected into NuGet resolver types.
+- **Resolved Aggregate Graph**: The NuGet-selected package identity set plus dependency edges projected back into Nuplane graph records.
+
+## Success Criteria
+
+### Measurable Outcomes
+
+- **SC-001**: The EF Core regression graph resolves `Microsoft.EntityFrameworkCore` to `10.0.3`, not `11.0.0-preview.4.26230.115`.
+- **SC-002**: Multi-root dependency constraints resolve to one selected shared dependency version when a common satisfying version exists.
+- **SC-003**: Resolver feasibility tests run without real network calls, MSBuild project evaluation, package extraction, or runtime package loading.

--- a/specs/023-nuget-restore-feasibility/tasks.md
+++ b/specs/023-nuget-restore-feasibility/tasks.md
@@ -1,0 +1,38 @@
+# Tasks: NuGet Restore Semantics Feasibility
+
+**Input**: `specs/023-nuget-restore-feasibility/spec.md`
+
+## Phase 1: Feasibility Setup
+
+- [x] T001 Create feature branch `023-nuget-restore-feasibility`.
+- [x] T002 Add test-only central package version for `NuGet.Resolver` in `Directory.Packages.props`.
+- [x] T003 Add test project reference to `NuGet.Resolver` in `test/Nuplane.Runtime.Tests/Nuplane.Runtime.Tests.csproj`.
+
+## Phase 2: Regression Proof
+
+- [x] T004 Add EF Core lowest-applicable dependency feasibility test in `test/Nuplane.Runtime.Tests/Feeds/NuGetResolverFeasibilityTests.cs`.
+- [x] T005 Add direct-dependency-wins feasibility test in `test/Nuplane.Runtime.Tests/Feeds/NuGetResolverFeasibilityTests.cs`.
+- [x] T006 Add cousin dependency unification feasibility test in `test/Nuplane.Runtime.Tests/Feeds/NuGetResolverFeasibilityTests.cs`.
+- [x] T007 Add multi-root aggregate unification feasibility test in `test/Nuplane.Runtime.Tests/Feeds/NuGetResolverFeasibilityTests.cs`.
+
+## Phase 3: Documentation
+
+- [x] T008 Capture feasibility requirements in `specs/023-nuget-restore-feasibility/spec.md`.
+- [x] T009 Capture API evaluation and architecture recommendation in `specs/023-nuget-restore-feasibility/research.md`.
+- [x] T010 Capture implementation plan in `specs/023-nuget-restore-feasibility/plan.md`.
+
+## Phase 4: Validation
+
+- [x] T011 Run focused feasibility tests with `dotnet test test/Nuplane.Runtime.Tests/Nuplane.Runtime.Tests.csproj --filter FullyQualifiedName~NuGetResolverFeasibilityTests`.
+
+## Phase 5: Production Implementation
+
+- [x] T012 Add production `NuGet.Resolver` dependency in `src/Nuplane/Nuplane.csproj`.
+- [x] T013 Update `src/Nuplane/Reconciliation/PackageDependencyGraphResolver.cs` to solve discovered package candidates through `PackageResolver` with `DependencyBehavior.Lowest`.
+- [x] T014 Update `src/Nuplane/Reconciliation/PackageDependencyGraphResolver.cs` to project selected package identities into one aggregate graph with all resolved roots.
+- [x] T015 Update `src/Nuplane/Reconciliation/PackageApplyExecutor.cs` to keep root acquisition failure isolation before aggregate graph solving.
+- [x] T016 Add production aggregate root regression coverage in `test/Nuplane.Runtime.Tests/Feeds/PackageDependencyGraphResolverTests.cs`.
+- [x] T017 Update apply-executor graph-count expectation in `test/Nuplane.Runtime.Tests/Reconciliation/PackageApplyExecutorTests.cs`.
+- [x] T018 Run focused resolver/apply tests.
+- [x] T019 Run `dotnet test test/Nuplane.Runtime.Tests/Nuplane.Runtime.Tests.csproj`.
+- [x] T020 Run `dotnet test nuplane.sln`.

--- a/src/Nuplane/Feeds/MultiFeedPackageResolver.cs
+++ b/src/Nuplane/Feeds/MultiFeedPackageResolver.cs
@@ -325,12 +325,16 @@ public sealed class MultiFeedPackageResolver : IPackageResolver
 
     private static VersionResolutionResult SelectLowestDependencyMatch(string versionRange, IReadOnlyList<string> availableVersions)
     {
-        var parsedVersions = availableVersions
-            .Select(static version => NuGetVersion.TryParse(version, out var parsed) ? parsed : null)
-            .OfType<NuGetVersion>()
-            .ToArray();
+        var parsedVersions = new List<(string OriginalVersion, NuGetVersion ParsedVersion)>();
+        foreach (var version in availableVersions)
+        {
+            if (NuGetVersion.TryParse(version, out var parsedVersion))
+            {
+                parsedVersions.Add((version, parsedVersion));
+            }
+        }
 
-        if (parsedVersions.Length == 0)
+        if (parsedVersions.Count == 0)
         {
             return new(false, null, availableVersions.Count, "Resolution failed: no versions available.");
         }
@@ -341,13 +345,13 @@ public sealed class MultiFeedPackageResolver : IPackageResolver
         }
 
         var selectedVersion = parsedVersions
-            .Where(range.Satisfies)
-            .Order()
+            .Where(candidate => range.Satisfies(candidate.ParsedVersion))
+            .OrderBy(candidate => candidate.ParsedVersion)
             .FirstOrDefault();
 
-        return selectedVersion is null
+        return string.IsNullOrEmpty(selectedVersion.OriginalVersion)
             ? new(false, null, availableVersions.Count, $"Resolution failed: no version matched range '{versionRange}'.")
-            : new(true, selectedVersion.ToNormalizedString(), availableVersions.Count, null);
+            : new(true, selectedVersion.OriginalVersion, availableVersions.Count, null);
     }
 
     /// <summary>

--- a/src/Nuplane/Feeds/MultiFeedPackageResolver.cs
+++ b/src/Nuplane/Feeds/MultiFeedPackageResolver.cs
@@ -10,6 +10,7 @@ using Nuplane.Feeds.Versioning;
 using Nuplane.Observability;
 using Nuplane.Reconciliation.Models;
 using Nuplane.Versioning;
+using NuGet.Versioning;
 
 namespace Nuplane.Feeds;
 
@@ -202,7 +203,9 @@ public sealed class MultiFeedPackageResolver : IPackageResolver
         try
         {
             var versionList = await _versionEnumerator.EnumerateVersionsAsync(feed, request.Id, cancellationToken);
-            var result = _versionRangeEvaluator.SelectBestMatch(request.VersionRange, versionList.Versions);
+            var result = IsDependencyRequest(request)
+                ? SelectLowestDependencyMatch(request.VersionRange, versionList.Versions)
+                : _versionRangeEvaluator.SelectBestMatch(request.VersionRange, versionList.Versions);
             stopwatch.Stop();
 
             _logger.LogDebug(
@@ -316,6 +319,36 @@ public sealed class MultiFeedPackageResolver : IPackageResolver
 
     private static bool IsLocalDirectoryFeed(FeedDefinition feed) =>
         feed.ServiceIndex.Scheme.Equals("file", StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsDependencyRequest(PackageRequest request) =>
+        request.SourceName.StartsWith("dependency-of:", StringComparison.OrdinalIgnoreCase);
+
+    private static VersionResolutionResult SelectLowestDependencyMatch(string versionRange, IReadOnlyList<string> availableVersions)
+    {
+        var parsedVersions = availableVersions
+            .Select(static version => NuGetVersion.TryParse(version, out var parsed) ? parsed : null)
+            .OfType<NuGetVersion>()
+            .ToArray();
+
+        if (parsedVersions.Length == 0)
+        {
+            return new(false, null, availableVersions.Count, "Resolution failed: no versions available.");
+        }
+
+        if (!VersionRange.TryParse(versionRange, out var range))
+        {
+            return new(false, null, availableVersions.Count, $"Resolution failed: invalid version range '{versionRange}'.");
+        }
+
+        var selectedVersion = parsedVersions
+            .Where(range.Satisfies)
+            .Order()
+            .FirstOrDefault();
+
+        return selectedVersion is null
+            ? new(false, null, availableVersions.Count, $"Resolution failed: no version matched range '{versionRange}'.")
+            : new(true, selectedVersion.ToNormalizedString(), availableVersions.Count, null);
+    }
 
     /// <summary>
     /// Tries to retrieve the feed resolution decision for the specified package.

--- a/src/Nuplane/Nuplane.csproj
+++ b/src/Nuplane/Nuplane.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="Microsoft.Extensions.Options" />
     <PackageReference Include="Microsoft.Extensions.Resilience" />
     <PackageReference Include="NuGet.Protocol" />
+    <PackageReference Include="NuGet.Resolver" />
     <PackageReference Include="NuGet.Versioning" />
     <PackageReference Include="Polly.Extensions" />
     <ProjectReference Include="..\Nuplane.Abstractions\Nuplane.Abstractions.csproj" />

--- a/src/Nuplane/Reconciliation/PackageApplyExecutor.cs
+++ b/src/Nuplane/Reconciliation/PackageApplyExecutor.cs
@@ -5,6 +5,7 @@ using Nuplane.Reconciliation.Models;
 using Nuplane.Store.State;
 using Nuplane.Store.Transactions;
 using Nuplane.Versioning;
+using NuGet.Resolver;
 
 namespace Nuplane.Reconciliation;
 
@@ -39,13 +40,43 @@ public sealed class PackageApplyExecutor(
         var decisions = new List<FeedResolutionDecision>();
         var graphs = new List<ResolvedPackageGraph>();
 
+        var resolvedRootsById = new Dictionary<string, ResolvedPackage>(StringComparer.OrdinalIgnoreCase);
+        var resolvableRequests = new List<PackageRequest>();
+
         foreach (var request in desiredRequests)
         {
             try
             {
+                var root = await ResolveRootAsync(request, cancellationToken);
+                resolvedRootsById[request.Id] = root;
+                resolvableRequests.Add(request);
+            }
+            catch (Exception ex)
+            {
+                failed.Add(request.Id);
+                var stage = ex switch
+                {
+                    FeedUnavailableException => "resolve-feed-unavailable",
+                    NoEligibleFeedException => "resolve-no-eligible-feed",
+                    _ => "resolve"
+                };
+                await _failureRecorder.RecordAsync(request.Id, stage, ex.Message, correlationId, cancellationToken);
+
+                if (_packageResolver is MultiFeedPackageResolver multiFeedResolver &&
+                    multiFeedResolver.TryGetDecision(request.Id, out var decision))
+                {
+                    decisions.Add(decision with { CorrelationId = correlationId });
+                }
+            }
+        }
+
+        if (resolvableRequests.Count > 0)
+        {
+            try
+            {
                 var graphResult = await _graphResolver.ResolveAsync(
-                    [request],
-                    ResolveRootAsync,
+                    resolvableRequests,
+                    ResolveCachedRootAsync,
                     cancellationToken);
                 resolved.AddRange(graphResult.ResolvedPackages);
                 graphs.AddRange(graphResult.ResolvedGraphs);
@@ -63,19 +94,24 @@ public sealed class PackageApplyExecutor(
             }
             catch (Exception ex)
             {
-                failed.Add(request.Id);
                 var stage = ex switch
                 {
                     FeedUnavailableException => "resolve-feed-unavailable",
                     NoEligibleFeedException => "resolve-no-eligible-feed",
+                    NuGetResolverException => "resolve-graph-conflict",
                     _ => "resolve"
                 };
-                await _failureRecorder.RecordAsync(request.Id, stage, ex.Message, correlationId, cancellationToken);
 
-                if (_packageResolver is MultiFeedPackageResolver multiFeedResolver &&
-                    multiFeedResolver.TryGetDecision(request.Id, out var decision))
+                foreach (var request in resolvableRequests)
                 {
-                    decisions.Add(decision with { CorrelationId = correlationId });
+                    failed.Add(request.Id);
+                    await _failureRecorder.RecordAsync(request.Id, stage, ex.Message, correlationId, cancellationToken);
+
+                    if (_packageResolver is MultiFeedPackageResolver multiFeedResolver &&
+                        multiFeedResolver.TryGetDecision(request.Id, out var decision))
+                    {
+                        decisions.Add(decision with { CorrelationId = correlationId });
+                    }
                 }
             }
         }
@@ -139,6 +175,11 @@ public sealed class PackageApplyExecutor(
             _retryPolicy.ExecuteAsync(
                 token => _packageResolver.ResolveAsync(packageRequest, token),
                 ct);
+
+        Task<ResolvedPackage> ResolveCachedRootAsync(PackageRequest packageRequest, CancellationToken ct) =>
+            resolvedRootsById.TryGetValue(packageRequest.Id, out var root)
+                ? Task.FromResult(root)
+                : ResolveRootAsync(packageRequest, ct);
     }
 
     /// <inheritdoc />

--- a/src/Nuplane/Reconciliation/PackageDependencyGraphResolver.cs
+++ b/src/Nuplane/Reconciliation/PackageDependencyGraphResolver.cs
@@ -1,9 +1,14 @@
 using System.Runtime.Versioning;
 using System.Text.Json;
 using System.Xml.Linq;
+using NuGet.Common;
+using NuGet.Configuration;
+using NuGet.Packaging.Core;
+using NuGet.Protocol.Core.Types;
+using NuGet.Resolver;
+using NuGet.Versioning;
 using Nuplane.Abstractions;
 using Nuplane.Reconciliation.Models;
-using NuGet.Versioning;
 
 namespace Nuplane.Reconciliation;
 
@@ -31,7 +36,8 @@ public sealed class PackageDependencyGraphResolver(IPackageResolver packageResol
         ArgumentNullException.ThrowIfNull(resolveRootAsync);
 
         var resolvedPackages = new Dictionary<string, ResolvedPackage>(StringComparer.OrdinalIgnoreCase);
-        var graphs = new List<ResolvedPackageGraph>();
+        var rootPackages = new List<ResolvedPackage>();
+        var discoveredEdges = new List<DiscoveredDependencyEdge>();
         var generationId = Guid.NewGuid().ToString("N");
 
         foreach (var request in desiredRequests.OrderBy(static request => request.Id, StringComparer.OrdinalIgnoreCase))
@@ -40,50 +46,35 @@ public sealed class PackageDependencyGraphResolver(IPackageResolver packageResol
 
             var rootPackage = await resolveRootAsync(request, cancellationToken);
             resolvedPackages[BuildPackageKey(rootPackage.Id, rootPackage.Version)] = rootPackage;
+            rootPackages.Add(rootPackage);
+        }
 
-            var rootNode = CreateNode(rootPackage, PackageNodeRole.Root);
-            var nodes = new Dictionary<string, ResolvedPackageNode>(StringComparer.OrdinalIgnoreCase)
-            {
-                [BuildPackageKey(rootPackage.Id, rootPackage.Version)] = rootNode
-            };
-            var edges = new List<DependencyEdge>();
-            var queue = new Queue<(ResolvedPackage Parent, PackageDependencyMetadata Dependency, IReadOnlyList<string> Path)>();
+        if (rootPackages.Count == 0)
+        {
+            return new([], []);
+        }
+
+        var queue = new Queue<(ResolvedPackage Parent, PackageDependencyMetadata Dependency, IReadOnlyList<string> Path)>();
+        foreach (var rootPackage in rootPackages)
+        {
             var rootKey = BuildPackageKey(rootPackage.Id, rootPackage.Version);
-
             foreach (var dependency in ReadDependencyMetadata(rootPackage))
             {
                 queue.Enqueue((rootPackage, dependency, [rootKey]));
             }
+        }
 
-            while (queue.Count > 0)
+        while (queue.Count > 0)
+        {
+            var (parent, dependency, path) = queue.Dequeue();
+            if (IsHostProvidedDependency(dependency.PackageId, dependency.VersionRange))
             {
-                var (parent, dependency, path) = queue.Dequeue();
-                if (IsHostProvidedDependency(dependency.PackageId, dependency.VersionRange))
-                {
-                    continue;
-                }
+                continue;
+            }
 
-                var existingDependencyPackage = FindExistingSatisfyingPackage(nodes.Values, resolvedPackages, dependency);
-                if (existingDependencyPackage is not null)
-                {
-                    var existingDependencyKey = BuildPackageKey(existingDependencyPackage.Id, existingDependencyPackage.Version);
-                    if (path.Contains(existingDependencyKey, StringComparer.OrdinalIgnoreCase))
-                    {
-                        throw new InvalidOperationException($"Dependency cycle detected: {FormatCyclePath(path, existingDependencyKey)}.");
-                    }
-
-                    edges.Add(new DependencyEdge(
-                        parent.Id,
-                        parent.Version,
-                        existingDependencyPackage.Id,
-                        dependency.VersionRange,
-                        existingDependencyPackage.Version,
-                        dependency.TargetFramework ?? string.Empty,
-                        Optional: false));
-
-                    continue;
-                }
-
+            var dependencyPackage = FindExistingSatisfyingPackage(resolvedPackages.Values, dependency);
+            if (dependencyPackage is null)
+            {
                 var dependencyRequest = new PackageRequest(
                     dependency.PackageId,
                     dependency.VersionRange,
@@ -91,72 +82,171 @@ public sealed class PackageDependencyGraphResolver(IPackageResolver packageResol
                     PackageUpdatePolicy.Exact,
                     $"dependency-of:{parent.Id}");
 
-                var dependencyPackage = await retryPolicy.ExecuteAsync(
+                dependencyPackage = await retryPolicy.ExecuteAsync(
                     ct => packageResolver.ResolveAsync(dependencyRequest, ct),
                     cancellationToken);
-                var dependencyKey = BuildPackageKey(dependencyPackage.Id, dependencyPackage.Version);
-                resolvedPackages[dependencyKey] = dependencyPackage;
-
-                if (path.Contains(dependencyKey, StringComparer.OrdinalIgnoreCase))
-                {
-                    throw new InvalidOperationException($"Dependency cycle detected: {FormatCyclePath(path, dependencyKey)}.");
-                }
-
-                edges.Add(new DependencyEdge(
-                    parent.Id,
-                    parent.Version,
-                    dependencyPackage.Id,
-                    dependency.VersionRange,
-                    dependencyPackage.Version,
-                    dependency.TargetFramework ?? string.Empty,
-                    Optional: false));
-
-                if (nodes.ContainsKey(dependencyKey))
-                {
-                    continue;
-                }
-
-                nodes[dependencyKey] = CreateNode(dependencyPackage, PackageNodeRole.Dependency);
-
-                foreach (var transitiveDependency in ReadDependencyMetadata(dependencyPackage))
-                {
-                    queue.Enqueue((dependencyPackage, transitiveDependency, path.Concat([dependencyKey]).ToArray()));
-                }
+                resolvedPackages[BuildPackageKey(dependencyPackage.Id, dependencyPackage.Version)] = dependencyPackage;
             }
 
-            var orderedNodes = nodes.Values
-                .OrderBy(static node => node.PackageId, StringComparer.OrdinalIgnoreCase)
-                .ThenBy(static node => node.Version, StringComparer.OrdinalIgnoreCase)
-                .ToArray();
-            var orderedEdges = edges
-                .OrderBy(static edge => edge.FromPackageId, StringComparer.OrdinalIgnoreCase)
-                .ThenBy(static edge => edge.ToPackageId, StringComparer.OrdinalIgnoreCase)
-                .ThenBy(static edge => edge.SelectedVersion, StringComparer.OrdinalIgnoreCase)
-                .ToArray();
-            var graphId = ResolvedPackageGraph.CreateGraphId(
-                TargetFrameworkMonikerProvider.Current,
-                [rootNode],
-                orderedNodes,
-                orderedEdges,
-                []);
+            var dependencyKey = BuildPackageKey(dependencyPackage.Id, dependencyPackage.Version);
+            if (path.Contains(dependencyKey, StringComparer.OrdinalIgnoreCase))
+            {
+                throw new InvalidOperationException($"Dependency cycle detected: {FormatCyclePath(path, dependencyKey)}.");
+            }
 
-            graphs.Add(new ResolvedPackageGraph(
-                graphId,
-                generationId,
-                TargetFrameworkMonikerProvider.Current,
-                [rootNode],
-                orderedNodes,
-                orderedEdges,
-                [],
-                DateTimeOffset.UtcNow));
+            discoveredEdges.Add(new(parent, dependency));
+
+            foreach (var transitiveDependency in ReadDependencyMetadata(dependencyPackage))
+            {
+                queue.Enqueue((dependencyPackage, transitiveDependency, path.Concat([dependencyKey]).ToArray()));
+            }
         }
 
+        var selectedPackages = SelectNuGetResolvedPackages(rootPackages, resolvedPackages.Values);
+        var selectedKeys = selectedPackages
+            .Select(package => BuildPackageKey(package.Id, package.Version))
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var rootKeys = rootPackages
+            .Select(package => BuildPackageKey(package.Id, package.Version))
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        var nodes = selectedPackages
+            .Select(package => CreateNode(package, DetermineNodeRole(package, rootKeys, selectedKeys, discoveredEdges)))
+            .OrderBy(static node => node.PackageId, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(static node => node.Version, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        var rootNodes = nodes
+            .Where(static node => node.Role is PackageNodeRole.Root or PackageNodeRole.RootAndDependency)
+            .OrderBy(static node => node.PackageId, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(static node => node.Version, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        var orderedEdges = discoveredEdges
+            .Where(edge => selectedKeys.Contains(BuildPackageKey(edge.Parent.Id, edge.Parent.Version)))
+            .Select(edge => CreateSelectedDependencyEdge(edge, selectedPackages))
+            .Distinct()
+            .OrderBy(static edge => edge.FromPackageId, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(static edge => edge.ToPackageId, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(static edge => edge.SelectedVersion, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        var graphId = ResolvedPackageGraph.CreateGraphId(
+            TargetFrameworkMonikerProvider.Current,
+            rootNodes,
+            nodes,
+            orderedEdges,
+            []);
+        var graph = new ResolvedPackageGraph(
+            graphId,
+            generationId,
+            TargetFrameworkMonikerProvider.Current,
+            rootNodes,
+            nodes,
+            orderedEdges,
+            [],
+            DateTimeOffset.UtcNow);
+
         return new PackageDependencyGraphResolutionResult(
-            resolvedPackages.Values
+            selectedPackages
                 .OrderBy(static package => package.Id, StringComparer.OrdinalIgnoreCase)
                 .ThenBy(static package => package.Version, StringComparer.OrdinalIgnoreCase)
                 .ToArray(),
-            graphs);
+            [graph]);
+    }
+
+    private static IReadOnlyList<ResolvedPackage> SelectNuGetResolvedPackages(
+        IReadOnlyList<ResolvedPackage> rootPackages,
+        IEnumerable<ResolvedPackage> candidatePackages)
+    {
+        var source = new SourceRepository(
+            new PackageSource("https://nuplane.local/aggregate", "nuplane-aggregate"),
+            Enumerable.Empty<INuGetResourceProvider>());
+        var packagesByKey = candidatePackages
+            .GroupBy(package => BuildPackageKey(package.Id, package.Version), StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(static group => group.Key, static group => group.First(), StringComparer.OrdinalIgnoreCase);
+        var availablePackages = packagesByKey.Values
+            .Select(package => new SourcePackageDependencyInfo(
+                package.Id,
+                NuGetVersion.Parse(package.Version),
+                ReadDependencyMetadata(package)
+                    .Where(static dependency => !IsHostProvidedDependency(dependency.PackageId, dependency.VersionRange))
+                    .Select(static dependency => new PackageDependency(
+                        dependency.PackageId,
+                        VersionRange.Parse(dependency.VersionRange)))
+                    .ToArray(),
+                listed: true,
+                source))
+            .ToArray();
+        var targetIds = rootPackages
+            .Select(static package => package.Id)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        var context = new PackageResolverContext(
+            DependencyBehavior.Lowest,
+            targetIds,
+            requiredPackageIds: targetIds,
+            packagesConfig: [],
+            preferredVersions: rootPackages.Select(static package => new PackageIdentity(package.Id, NuGetVersion.Parse(package.Version))).ToArray(),
+            availablePackages,
+            [source.PackageSource],
+            NullLogger.Instance);
+
+        return new PackageResolver()
+            .Resolve(context, CancellationToken.None)
+            .Select(identity => packagesByKey.TryGetValue(BuildPackageKey(identity.Id, identity.Version.ToNormalizedString()), out var package)
+                ? package
+                : throw new InvalidOperationException($"NuGet selected package '{identity.Id}@{identity.Version.ToNormalizedString()}' but no resolved package candidate was available."))
+            .ToArray();
+    }
+
+    private static PackageNodeRole DetermineNodeRole(
+        ResolvedPackage package,
+        ISet<string> rootKeys,
+        ISet<string> selectedKeys,
+        IReadOnlyList<DiscoveredDependencyEdge> discoveredEdges)
+    {
+        var key = BuildPackageKey(package.Id, package.Version);
+        var root = rootKeys.Contains(key);
+        var dependency = discoveredEdges.Any(edge =>
+            selectedKeys.Contains(BuildPackageKey(edge.Parent.Id, edge.Parent.Version)) &&
+            string.Equals(edge.Dependency.PackageId, package.Id, StringComparison.OrdinalIgnoreCase) &&
+            VersionSatisfiesRange(package.Version, edge.Dependency.VersionRange));
+
+        return root && dependency
+            ? PackageNodeRole.RootAndDependency
+            : root
+                ? PackageNodeRole.Root
+                : PackageNodeRole.Dependency;
+    }
+
+    private static DependencyEdge CreateSelectedDependencyEdge(
+        DiscoveredDependencyEdge edge,
+        IReadOnlyList<ResolvedPackage> selectedPackages)
+    {
+        var selectedDependency = selectedPackages
+            .Where(package => string.Equals(package.Id, edge.Dependency.PackageId, StringComparison.OrdinalIgnoreCase))
+            .Select(package => new
+            {
+                Package = package,
+                Version = NuGetVersion.Parse(package.Version)
+            })
+            .Where(candidate => VersionRange.Parse(edge.Dependency.VersionRange).Satisfies(candidate.Version))
+            .OrderBy(static candidate => candidate.Version)
+            .FirstOrDefault();
+
+        if (selectedDependency is null)
+        {
+            throw new InvalidOperationException(
+                $"Resolved graph did not contain a selected package for dependency '{edge.Parent.Id}@{edge.Parent.Version}' -> '{edge.Dependency.PackageId} {edge.Dependency.VersionRange}'.");
+        }
+
+        return new DependencyEdge(
+            edge.Parent.Id,
+            edge.Parent.Version,
+            selectedDependency.Package.Id,
+            edge.Dependency.VersionRange,
+            selectedDependency.Package.Version,
+            edge.Dependency.TargetFramework ?? string.Empty,
+            Optional: false);
     }
 
     private static ResolvedPackageNode CreateNode(
@@ -265,18 +355,12 @@ public sealed class PackageDependencyGraphResolver(IPackageResolver packageResol
     }
 
     private static ResolvedPackage? FindExistingSatisfyingPackage(
-        IEnumerable<ResolvedPackageNode> nodes,
-        IReadOnlyDictionary<string, ResolvedPackage> resolvedPackages,
+        IEnumerable<ResolvedPackage> packages,
         PackageDependencyMetadata dependency)
     {
-        foreach (var node in nodes.Where(node => string.Equals(node.PackageId, dependency.PackageId, StringComparison.OrdinalIgnoreCase)))
+        foreach (var package in packages.Where(package => string.Equals(package.Id, dependency.PackageId, StringComparison.OrdinalIgnoreCase)))
         {
-            if (!VersionSatisfiesRange(node.Version, dependency.VersionRange))
-            {
-                continue;
-            }
-
-            if (resolvedPackages.TryGetValue(BuildPackageKey(node.PackageId, node.Version), out var package))
+            if (VersionSatisfiesRange(package.Version, dependency.VersionRange))
             {
                 return package;
             }
@@ -418,14 +502,9 @@ public sealed class PackageDependencyGraphResolver(IPackageResolver packageResol
         packageId.Equals("Elsa.Workflows.Runtime", StringComparison.OrdinalIgnoreCase) ||
         packageId.StartsWith("Microsoft.Extensions.", StringComparison.OrdinalIgnoreCase);
 
-    private static bool VersionSatisfiesRange(string hostVersion, string versionRange)
+    private static bool VersionSatisfiesRange(string version, string versionRange)
     {
-        if (!NuGetVersion.TryParse(hostVersion, out var parsedHostVersion))
-        {
-            return false;
-        }
-
-        if (string.IsNullOrWhiteSpace(versionRange))
+        if (!NuGetVersion.TryParse(version, out var parsedVersion))
         {
             return false;
         }
@@ -437,7 +516,7 @@ public sealed class PackageDependencyGraphResolver(IPackageResolver packageResol
             versionRange = $"[{versionRange}]";
         }
 
-        return VersionRange.TryParse(versionRange, out var range) && range.Satisfies(parsedHostVersion);
+        return VersionRange.TryParse(versionRange, out var range) && range.Satisfies(parsedVersion);
     }
 
     private static IReadOnlyDictionary<string, string> LoadHostPackageVersions()
@@ -479,6 +558,8 @@ public sealed class PackageDependencyGraphResolver(IPackageResolver packageResol
 
         return packageVersions;
     }
+
+    private sealed record DiscoveredDependencyEdge(ResolvedPackage Parent, PackageDependencyMetadata Dependency);
 
     private sealed record DependencyGroupMetadata(string? TargetFramework, IReadOnlyList<PackageDependencyMetadata> Dependencies);
 

--- a/src/Nuplane/Reconciliation/PackageDependencyGraphResolver.cs
+++ b/src/Nuplane/Reconciliation/PackageDependencyGraphResolver.cs
@@ -55,6 +55,7 @@ public sealed class PackageDependencyGraphResolver(IPackageResolver packageResol
         }
 
         var queue = new Queue<(ResolvedPackage Parent, PackageDependencyMetadata Dependency, IReadOnlyList<string> Path)>();
+        var expandedPackageKeys = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         foreach (var rootPackage in rootPackages)
         {
             var rootKey = BuildPackageKey(rootPackage.Id, rootPackage.Version);
@@ -96,13 +97,18 @@ public sealed class PackageDependencyGraphResolver(IPackageResolver packageResol
 
             discoveredEdges.Add(new(parent, dependency));
 
+            if (!expandedPackageKeys.Add(dependencyKey))
+            {
+                continue;
+            }
+
             foreach (var transitiveDependency in ReadDependencyMetadata(dependencyPackage))
             {
                 queue.Enqueue((dependencyPackage, transitiveDependency, path.Concat([dependencyKey]).ToArray()));
             }
         }
 
-        var selectedPackages = SelectNuGetResolvedPackages(rootPackages, resolvedPackages.Values);
+        var selectedPackages = SelectNuGetResolvedPackages(rootPackages, resolvedPackages.Values, cancellationToken);
         var selectedKeys = selectedPackages
             .Select(package => BuildPackageKey(package.Id, package.Version))
             .ToHashSet(StringComparer.OrdinalIgnoreCase);
@@ -155,23 +161,32 @@ public sealed class PackageDependencyGraphResolver(IPackageResolver packageResol
 
     private static IReadOnlyList<ResolvedPackage> SelectNuGetResolvedPackages(
         IReadOnlyList<ResolvedPackage> rootPackages,
-        IEnumerable<ResolvedPackage> candidatePackages)
+        IEnumerable<ResolvedPackage> candidatePackages,
+        CancellationToken cancellationToken)
     {
         var source = new SourceRepository(
             new PackageSource("https://nuplane.local/aggregate", "nuplane-aggregate"),
             Enumerable.Empty<INuGetResourceProvider>());
-        var packagesByKey = candidatePackages
+        var orderedCandidatePackages = candidatePackages
+            .OrderBy(static package => package.Id, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(static package => NuGetVersion.Parse(package.Version))
+            .ThenBy(static package => package.FeedName, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(static package => package.SourceName, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(static package => package.InstallPath, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        var packagesByKey = orderedCandidatePackages
             .GroupBy(package => BuildPackageKey(package.Id, package.Version), StringComparer.OrdinalIgnoreCase)
             .ToDictionary(static group => group.Key, static group => group.First(), StringComparer.OrdinalIgnoreCase);
-        var availablePackages = packagesByKey.Values
+        var availablePackages = orderedCandidatePackages
+            .GroupBy(package => BuildPackageKey(package.Id, package.Version), StringComparer.OrdinalIgnoreCase)
+            .Select(static group => group.First())
             .Select(package => new SourcePackageDependencyInfo(
                 package.Id,
                 NuGetVersion.Parse(package.Version),
                 ReadDependencyMetadata(package)
                     .Where(static dependency => !IsHostProvidedDependency(dependency.PackageId, dependency.VersionRange))
-                    .Select(static dependency => new PackageDependency(
-                        dependency.PackageId,
-                        VersionRange.Parse(dependency.VersionRange)))
+                    .Select(static dependency => TryCreatePackageDependency(dependency))
+                    .OfType<PackageDependency>()
                     .ToArray(),
                 listed: true,
                 source))
@@ -179,24 +194,35 @@ public sealed class PackageDependencyGraphResolver(IPackageResolver packageResol
         var targetIds = rootPackages
             .Select(static package => package.Id)
             .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Order(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        var preferredVersions = rootPackages
+            .OrderBy(static package => package.Id, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(static package => NuGetVersion.Parse(package.Version))
+            .Select(static package => new PackageIdentity(package.Id, NuGetVersion.Parse(package.Version)))
             .ToArray();
         var context = new PackageResolverContext(
             DependencyBehavior.Lowest,
             targetIds,
             requiredPackageIds: targetIds,
             packagesConfig: [],
-            preferredVersions: rootPackages.Select(static package => new PackageIdentity(package.Id, NuGetVersion.Parse(package.Version))).ToArray(),
+            preferredVersions,
             availablePackages,
             [source.PackageSource],
             NullLogger.Instance);
 
         return new PackageResolver()
-            .Resolve(context, CancellationToken.None)
+            .Resolve(context, cancellationToken)
             .Select(identity => packagesByKey.TryGetValue(BuildPackageKey(identity.Id, identity.Version.ToNormalizedString()), out var package)
                 ? package
                 : throw new InvalidOperationException($"NuGet selected package '{identity.Id}@{identity.Version.ToNormalizedString()}' but no resolved package candidate was available."))
             .ToArray();
     }
+
+    private static PackageDependency? TryCreatePackageDependency(PackageDependencyMetadata dependency) =>
+        VersionRange.TryParse(dependency.VersionRange, out var range)
+            ? new PackageDependency(dependency.PackageId, range)
+            : null;
 
     private static PackageNodeRole DetermineNodeRole(
         ResolvedPackage package,
@@ -222,6 +248,12 @@ public sealed class PackageDependencyGraphResolver(IPackageResolver packageResol
         DiscoveredDependencyEdge edge,
         IReadOnlyList<ResolvedPackage> selectedPackages)
     {
+        if (!VersionRange.TryParse(edge.Dependency.VersionRange, out var requestedRange))
+        {
+            throw new InvalidOperationException(
+                $"Dependency '{edge.Parent.Id}@{edge.Parent.Version}' declares invalid version range '{edge.Dependency.VersionRange}' for '{edge.Dependency.PackageId}'.");
+        }
+
         var selectedDependency = selectedPackages
             .Where(package => string.Equals(package.Id, edge.Dependency.PackageId, StringComparison.OrdinalIgnoreCase))
             .Select(package => new
@@ -229,7 +261,7 @@ public sealed class PackageDependencyGraphResolver(IPackageResolver packageResol
                 Package = package,
                 Version = NuGetVersion.Parse(package.Version)
             })
-            .Where(candidate => VersionRange.Parse(edge.Dependency.VersionRange).Satisfies(candidate.Version))
+            .Where(candidate => requestedRange.Satisfies(candidate.Version))
             .OrderBy(static candidate => candidate.Version)
             .FirstOrDefault();
 

--- a/src/Nuplane/Reconciliation/PackageDependencyGraphResolver.cs
+++ b/src/Nuplane/Reconciliation/PackageDependencyGraphResolver.cs
@@ -63,6 +63,27 @@ public sealed class PackageDependencyGraphResolver(IPackageResolver packageResol
                     continue;
                 }
 
+                var existingDependencyPackage = FindExistingSatisfyingPackage(nodes.Values, resolvedPackages, dependency);
+                if (existingDependencyPackage is not null)
+                {
+                    var existingDependencyKey = BuildPackageKey(existingDependencyPackage.Id, existingDependencyPackage.Version);
+                    if (path.Contains(existingDependencyKey, StringComparer.OrdinalIgnoreCase))
+                    {
+                        throw new InvalidOperationException($"Dependency cycle detected: {FormatCyclePath(path, existingDependencyKey)}.");
+                    }
+
+                    edges.Add(new DependencyEdge(
+                        parent.Id,
+                        parent.Version,
+                        existingDependencyPackage.Id,
+                        dependency.VersionRange,
+                        existingDependencyPackage.Version,
+                        dependency.TargetFramework ?? string.Empty,
+                        Optional: false));
+
+                    continue;
+                }
+
                 var dependencyRequest = new PackageRequest(
                     dependency.PackageId,
                     dependency.VersionRange,
@@ -241,6 +262,27 @@ public sealed class PackageDependencyGraphResolver(IPackageResolver packageResol
         return NuGetVersion.TryParse(trimmed, out var version)
             ? $"[{version.ToNormalizedString()},)"
             : trimmed;
+    }
+
+    private static ResolvedPackage? FindExistingSatisfyingPackage(
+        IEnumerable<ResolvedPackageNode> nodes,
+        IReadOnlyDictionary<string, ResolvedPackage> resolvedPackages,
+        PackageDependencyMetadata dependency)
+    {
+        foreach (var node in nodes.Where(node => string.Equals(node.PackageId, dependency.PackageId, StringComparison.OrdinalIgnoreCase)))
+        {
+            if (!VersionSatisfiesRange(node.Version, dependency.VersionRange))
+            {
+                continue;
+            }
+
+            if (resolvedPackages.TryGetValue(BuildPackageKey(node.PackageId, node.Version), out var package))
+            {
+                return package;
+            }
+        }
+
+        return null;
     }
 
     private static IReadOnlyList<DependencyGroupMetadata> SelectDependencyGroups(IReadOnlyList<DependencyGroupMetadata> groups)

--- a/src/Nuplane/Reconciliation/PackageDependencyGraphResolver.cs
+++ b/src/Nuplane/Reconciliation/PackageDependencyGraphResolver.cs
@@ -169,20 +169,20 @@ public sealed class PackageDependencyGraphResolver(IPackageResolver packageResol
             Enumerable.Empty<INuGetResourceProvider>());
         var orderedCandidatePackages = candidatePackages
             .OrderBy(static package => package.Id, StringComparer.OrdinalIgnoreCase)
-            .ThenBy(static package => NuGetVersion.Parse(package.Version))
+            .ThenBy(static package => TryParsePackageVersion(package.Version, out var version) ? version : NuGetVersion.Parse("0.0.0"))
             .ThenBy(static package => package.FeedName, StringComparer.OrdinalIgnoreCase)
             .ThenBy(static package => package.SourceName, StringComparer.OrdinalIgnoreCase)
             .ThenBy(static package => package.InstallPath, StringComparer.OrdinalIgnoreCase)
             .ToArray();
         var packagesByKey = orderedCandidatePackages
-            .GroupBy(package => BuildPackageKey(package.Id, package.Version), StringComparer.OrdinalIgnoreCase)
+            .GroupBy(static package => BuildNormalizedPackageKey(package.Id, package.Version), StringComparer.OrdinalIgnoreCase)
             .ToDictionary(static group => group.Key, static group => group.First(), StringComparer.OrdinalIgnoreCase);
         var availablePackages = orderedCandidatePackages
-            .GroupBy(package => BuildPackageKey(package.Id, package.Version), StringComparer.OrdinalIgnoreCase)
+            .GroupBy(static package => BuildNormalizedPackageKey(package.Id, package.Version), StringComparer.OrdinalIgnoreCase)
             .Select(static group => group.First())
             .Select(package => new SourcePackageDependencyInfo(
                 package.Id,
-                NuGetVersion.Parse(package.Version),
+                ParsePackageVersion(package),
                 ReadDependencyMetadata(package)
                     .Where(static dependency => !IsHostProvidedDependency(dependency.PackageId, dependency.VersionRange))
                     .Select(static dependency => TryCreatePackageDependency(dependency))
@@ -198,8 +198,8 @@ public sealed class PackageDependencyGraphResolver(IPackageResolver packageResol
             .ToArray();
         var preferredVersions = rootPackages
             .OrderBy(static package => package.Id, StringComparer.OrdinalIgnoreCase)
-            .ThenBy(static package => NuGetVersion.Parse(package.Version))
-            .Select(static package => new PackageIdentity(package.Id, NuGetVersion.Parse(package.Version)))
+            .ThenBy(static package => TryParsePackageVersion(package.Version, out var version) ? version : NuGetVersion.Parse("0.0.0"))
+            .Select(static package => new PackageIdentity(package.Id, ParsePackageVersion(package)))
             .ToArray();
         var context = new PackageResolverContext(
             DependencyBehavior.Lowest,
@@ -213,11 +213,22 @@ public sealed class PackageDependencyGraphResolver(IPackageResolver packageResol
 
         return new PackageResolver()
             .Resolve(context, cancellationToken)
-            .Select(identity => packagesByKey.TryGetValue(BuildPackageKey(identity.Id, identity.Version.ToNormalizedString()), out var package)
+            .Select(identity => packagesByKey.TryGetValue(BuildNormalizedPackageKey(identity.Id, identity.Version.ToNormalizedString()), out var package)
                 ? package
                 : throw new InvalidOperationException($"NuGet selected package '{identity.Id}@{identity.Version.ToNormalizedString()}' but no resolved package candidate was available."))
             .ToArray();
     }
+
+    private static NuGetVersion ParsePackageVersion(ResolvedPackage package) =>
+        TryParsePackageVersion(package.Version, out var version)
+            ? version
+            : throw new InvalidOperationException($"Resolved package '{package.Id}' has invalid NuGet version '{package.Version}'.");
+
+    private static bool TryParsePackageVersion(string version, out NuGetVersion parsedVersion) =>
+        NuGetVersion.TryParse(version, out parsedVersion!);
+
+    private static string BuildNormalizedPackageKey(string packageId, string version) =>
+        BuildPackageKey(packageId, TryParsePackageVersion(version, out var parsedVersion) ? parsedVersion.ToNormalizedString() : version);
 
     private static PackageDependency? TryCreatePackageDependency(PackageDependencyMetadata dependency) =>
         VersionRange.TryParse(dependency.VersionRange, out var range)

--- a/test/Nuplane.Runtime.Tests/Feeds/MultiFeedPackageResolverTests.cs
+++ b/test/Nuplane.Runtime.Tests/Feeds/MultiFeedPackageResolverTests.cs
@@ -227,6 +227,40 @@ public sealed class MultiFeedPackageResolverTests
     }
 
     [Fact]
+    public async Task ResolveAsync_DependencyRequest_PreservesFeedAdvertisedVersionString()
+    {
+        var options = new FeedResolutionOptions();
+        options.Feeds.Add(new("remote", new("https://feed.example/v3/index.json")));
+        var wrappedOptions = new OptionsWrapper<FeedResolutionOptions>(options);
+        var policy = new FeedResolutionPolicy(wrappedOptions);
+
+        var enumerator = Substitute.For<IFeedVersionEnumerator>();
+        enumerator.EnumerateVersionsAsync(Arg.Any<FeedDefinition>(), "Plugin.Dependency", Arg.Any<CancellationToken>())
+            .Returns(new PackageVersionList(
+                "Plugin.Dependency",
+                "remote",
+                ["1.0", "1.0.1"],
+                DateTimeOffset.UtcNow));
+
+        var evaluator = Substitute.For<IVersionRangeEvaluator>();
+
+        var acquirer = Substitute.For<IRemotePackageAcquirer>();
+        acquirer.AcquireAsync(Arg.Any<FeedDefinition>(), "Plugin.Dependency", "1.0", Arg.Any<CancellationToken>())
+            .Returns("/installed/Plugin.Dependency/1.0");
+
+        var resolver = new MultiFeedPackageResolver(
+            wrappedOptions, policy, acquirer, enumerator, evaluator,
+            NullLogger<MultiFeedPackageResolver>.Instance);
+
+        var request = new PackageRequest("Plugin.Dependency", "[1.0.0,)", "remote", PackageUpdatePolicy.Exact, "dependency-of:Plugin.Root");
+        var result = await resolver.ResolveAsync(request, CancellationToken.None);
+
+        Assert.Equal("1.0", result.Version);
+        await acquirer.Received(1).AcquireAsync(Arg.Any<FeedDefinition>(), "Plugin.Dependency", "1.0", Arg.Any<CancellationToken>());
+        evaluator.DidNotReceiveWithAnyArgs().SelectBestMatch(default!, default!);
+    }
+
+    [Fact]
     public async Task ResolveAsync_NoMatch_DecisionContainsDiagnostic()
     {
         var options = new FeedResolutionOptions();

--- a/test/Nuplane.Runtime.Tests/Feeds/MultiFeedPackageResolverTests.cs
+++ b/test/Nuplane.Runtime.Tests/Feeds/MultiFeedPackageResolverTests.cs
@@ -194,6 +194,39 @@ public sealed class MultiFeedPackageResolverTests
     }
 
     [Fact]
+    public async Task ResolveAsync_DependencyRequest_SelectsLowestSatisfyingVersion()
+    {
+        var options = new FeedResolutionOptions();
+        options.Feeds.Add(new("remote", new("https://feed.example/v3/index.json")));
+        var wrappedOptions = new OptionsWrapper<FeedResolutionOptions>(options);
+        var policy = new FeedResolutionPolicy(wrappedOptions);
+
+        var enumerator = Substitute.For<IFeedVersionEnumerator>();
+        enumerator.EnumerateVersionsAsync(Arg.Any<FeedDefinition>(), "Microsoft.EntityFrameworkCore", Arg.Any<CancellationToken>())
+            .Returns(new PackageVersionList(
+                "Microsoft.EntityFrameworkCore",
+                "remote",
+                ["10.0.3", "10.0.4", "11.0.0-preview.4.26230.115"],
+                DateTimeOffset.UtcNow));
+
+        var evaluator = Substitute.For<IVersionRangeEvaluator>();
+
+        var acquirer = Substitute.For<IRemotePackageAcquirer>();
+        acquirer.AcquireAsync(Arg.Any<FeedDefinition>(), "Microsoft.EntityFrameworkCore", "10.0.3", Arg.Any<CancellationToken>())
+            .Returns("/installed/Microsoft.EntityFrameworkCore/10.0.3");
+
+        var resolver = new MultiFeedPackageResolver(
+            wrappedOptions, policy, acquirer, enumerator, evaluator,
+            NullLogger<MultiFeedPackageResolver>.Instance);
+
+        var request = new PackageRequest("Microsoft.EntityFrameworkCore", "[10.0.3,)", "remote", PackageUpdatePolicy.Exact, "dependency-of:Plugin.Root");
+        var result = await resolver.ResolveAsync(request, CancellationToken.None);
+
+        Assert.Equal("10.0.3", result.Version);
+        evaluator.DidNotReceiveWithAnyArgs().SelectBestMatch(default!, default!);
+    }
+
+    [Fact]
     public async Task ResolveAsync_NoMatch_DecisionContainsDiagnostic()
     {
         var options = new FeedResolutionOptions();

--- a/test/Nuplane.Runtime.Tests/Feeds/NuGetResolverFeasibilityTests.cs
+++ b/test/Nuplane.Runtime.Tests/Feeds/NuGetResolverFeasibilityTests.cs
@@ -1,0 +1,121 @@
+using NuGet.Common;
+using NuGet.Configuration;
+using NuGet.Packaging;
+using NuGet.Packaging.Core;
+using NuGet.Protocol.Core.Types;
+using NuGet.Resolver;
+using NuGet.Versioning;
+
+namespace Nuplane.Runtime.Tests.Feeds;
+
+public sealed class NuGetResolverFeasibilityTests
+{
+    private readonly SourceRepository source = new(
+        new PackageSource("https://feed.example/v3/index.json", "test-feed"),
+        Enumerable.Empty<INuGetResourceProvider>());
+
+    [Fact]
+    public void Resolve_LowestDependencyBehavior_SelectsLowestApplicableDependencyVersion()
+    {
+        var resolved = Resolve(
+            targetIds: ["Plugin.Root"],
+            preferredVersions: [Identity("Plugin.Root", "1.0.0")],
+            availablePackages:
+            [
+                Package("Plugin.Root", "1.0.0", Dependency("Microsoft.EntityFrameworkCore", "[10.0.3,)")),
+                Package("Microsoft.EntityFrameworkCore", "10.0.3"),
+                Package("Microsoft.EntityFrameworkCore", "10.0.4"),
+                Package("Microsoft.EntityFrameworkCore", "11.0.0-preview.4.26230.115")
+            ]);
+
+        Assert.Contains(resolved, static package => package.Id == "Microsoft.EntityFrameworkCore" && package.Version.ToNormalizedString() == "10.0.3");
+        Assert.DoesNotContain(resolved, static package => package.Id == "Microsoft.EntityFrameworkCore" && package.Version.ToNormalizedString().StartsWith("11.0.0-preview", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void Resolve_DirectDependencyWins_ReusesDirectVersionForLowerTransitiveBaseline()
+    {
+        var resolved = Resolve(
+            targetIds: ["Plugin.Root", "Plugin.Direct"],
+            preferredVersions: [Identity("Plugin.Root", "1.0.0"), Identity("Plugin.Direct", "10.0.3")],
+            availablePackages:
+            [
+                Package("Plugin.Root", "1.0.0", Dependency("Plugin.Direct", "[10.0.3]"), Dependency("Plugin.Transitive", "[1.0.0]")),
+                Package("Plugin.Direct", "10.0.3"),
+                Package("Plugin.Transitive", "1.0.0", Dependency("Plugin.Direct", "[8.0.2,)"))
+            ]);
+
+        Assert.Single(resolved, static package => package.Id == "Plugin.Direct");
+        Assert.Contains(resolved, static package => package.Id == "Plugin.Direct" && package.Version.ToNormalizedString() == "10.0.3");
+    }
+
+    [Fact]
+    public void Resolve_CousinDependencies_SelectsLowestVersionThatSatisfiesAllRanges()
+    {
+        var resolved = Resolve(
+            targetIds: ["Plugin.Root"],
+            preferredVersions: [Identity("Plugin.Root", "1.0.0")],
+            availablePackages:
+            [
+                Package("Plugin.Root", "1.0.0", Dependency("Plugin.Left", "[1.0.0]"), Dependency("Plugin.Right", "[1.0.0]")),
+                Package("Plugin.Left", "1.0.0", Dependency("Plugin.Shared", "[1.0.0,)")),
+                Package("Plugin.Right", "1.0.0", Dependency("Plugin.Shared", "[2.0.0,)")),
+                Package("Plugin.Shared", "1.0.0"),
+                Package("Plugin.Shared", "2.0.0"),
+                Package("Plugin.Shared", "3.0.0")
+            ]);
+
+        Assert.Contains(resolved, static package => package.Id == "Plugin.Shared" && package.Version.ToNormalizedString() == "2.0.0");
+        Assert.DoesNotContain(resolved, static package => package.Id == "Plugin.Shared" && package.Version.ToNormalizedString() == "3.0.0");
+    }
+
+    [Fact]
+    public void Resolve_MultipleTopLevelRoots_UnifiesSharedDependencyAcrossAggregateGraph()
+    {
+        var resolved = Resolve(
+            targetIds: ["Plugin.Left", "Plugin.Right"],
+            preferredVersions: [Identity("Plugin.Left", "1.0.0"), Identity("Plugin.Right", "1.0.0")],
+            availablePackages:
+            [
+                Package("Plugin.Left", "1.0.0", Dependency("Plugin.Shared", "[1.0.0,)")),
+                Package("Plugin.Right", "1.0.0", Dependency("Plugin.Shared", "[2.0.0,)")),
+                Package("Plugin.Shared", "1.0.0"),
+                Package("Plugin.Shared", "2.0.0"),
+                Package("Plugin.Shared", "3.0.0")
+            ]);
+
+        Assert.Single(resolved, static package => package.Id == "Plugin.Shared");
+        Assert.Contains(resolved, static package => package.Id == "Plugin.Shared" && package.Version.ToNormalizedString() == "2.0.0");
+    }
+
+    private IReadOnlyList<PackageIdentity> Resolve(
+        IReadOnlyList<string> targetIds,
+        IReadOnlyList<PackageIdentity> preferredVersions,
+        IReadOnlyList<SourcePackageDependencyInfo> availablePackages)
+    {
+        var context = new PackageResolverContext(
+            DependencyBehavior.Lowest,
+            targetIds,
+            requiredPackageIds: targetIds,
+            packagesConfig: [],
+            preferredVersions,
+            availablePackages,
+            [source.PackageSource],
+            NullLogger.Instance);
+
+        return new PackageResolver()
+            .Resolve(context, CancellationToken.None)
+            .OrderBy(static package => package.Id, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(static package => package.Version)
+            .ToArray();
+    }
+
+    private SourcePackageDependencyInfo Package(string id, string version, params PackageDependency[] dependencies) =>
+        new(id, NuGetVersion.Parse(version), dependencies, listed: true, source);
+
+    private static PackageDependency Dependency(string id, string versionRange) =>
+        new(id, VersionRange.Parse(versionRange));
+
+    private static PackageIdentity Identity(string id, string version) =>
+        new(id, NuGetVersion.Parse(version));
+}

--- a/test/Nuplane.Runtime.Tests/Feeds/PackageDependencyGraphResolverTests.cs
+++ b/test/Nuplane.Runtime.Tests/Feeds/PackageDependencyGraphResolverTests.cs
@@ -170,6 +170,25 @@ public sealed class PackageDependencyGraphResolverTests : IDisposable
     }
 
     [Fact]
+    public async Task ResolveAsync_WithNonNormalizedPackageVersion_MapsNuGetSelectedIdentityBackToResolvedPackage()
+    {
+        var root = CreateInstalledPackage("Plugin.Root", "1.0");
+        var resolver = new StubPackageResolver(new Dictionary<string, ResolvedPackage>(StringComparer.OrdinalIgnoreCase));
+        var sut = new PackageDependencyGraphResolver(resolver, new PassthroughRetryPolicy());
+
+        var result = await sut.ResolveAsync(
+            [new PackageRequest("Plugin.Root", "[1.0.0]", "test-feed", PackageUpdatePolicy.Exact, "test-source")],
+            (_, _) => Task.FromResult(root),
+            CancellationToken.None);
+
+        var package = Assert.Single(result.ResolvedPackages);
+        Assert.Equal("Plugin.Root", package.Id);
+        Assert.Equal("1.0", package.Version);
+        var graph = Assert.Single(result.ResolvedGraphs);
+        Assert.Contains(graph.Nodes, static node => node.PackageId == "Plugin.Root" && node.Version == "1.0");
+    }
+
+    [Fact]
     public async Task ResolveAsync_WithMalformedDependencyVersionRange_ThrowsNamedInvalidRangeDiagnostic()
     {
         var root = CreateInstalledPackage("Plugin.Root", "1.0.0", dependencyId: "Plugin.Dependency", dependencyVersionRange: "latest");

--- a/test/Nuplane.Runtime.Tests/Feeds/PackageDependencyGraphResolverTests.cs
+++ b/test/Nuplane.Runtime.Tests/Feeds/PackageDependencyGraphResolverTests.cs
@@ -152,6 +152,45 @@ public sealed class PackageDependencyGraphResolverTests : IDisposable
     }
 
     [Fact]
+    public async Task ResolveAsync_WhenCancelledBeforeNuGetSolve_ThrowsOperationCanceledException()
+    {
+        using var cts = new CancellationTokenSource();
+        var root = CreateInstalledPackage("Plugin.Root", "1.0.0");
+        var resolver = new StubPackageResolver(new Dictionary<string, ResolvedPackage>(StringComparer.OrdinalIgnoreCase));
+        var sut = new PackageDependencyGraphResolver(resolver, new PassthroughRetryPolicy());
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() => sut.ResolveAsync(
+            [new PackageRequest("Plugin.Root", "[1.0.0]", "test-feed", PackageUpdatePolicy.Exact, "test-source")],
+            (_, _) =>
+            {
+                cts.Cancel();
+                return Task.FromResult(root);
+            },
+            cts.Token));
+    }
+
+    [Fact]
+    public async Task ResolveAsync_WithMalformedDependencyVersionRange_ThrowsNamedInvalidRangeDiagnostic()
+    {
+        var root = CreateInstalledPackage("Plugin.Root", "1.0.0", dependencyId: "Plugin.Dependency", dependencyVersionRange: "latest");
+        var dependency = CreateInstalledPackage("Plugin.Dependency", "1.0.0");
+        var resolver = new StubPackageResolver(
+            new Dictionary<string, ResolvedPackage>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["Plugin.Dependency"] = dependency
+            });
+        var sut = new PackageDependencyGraphResolver(resolver, new PassthroughRetryPolicy());
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => sut.ResolveAsync(
+            [new PackageRequest("Plugin.Root", "[1.0.0]", "test-feed", PackageUpdatePolicy.Exact, "test-source")],
+            (_, _) => Task.FromResult(root),
+            CancellationToken.None));
+
+        Assert.Contains("invalid version range 'latest'", exception.Message);
+        Assert.Contains("Plugin.Dependency", exception.Message);
+    }
+
+    [Fact]
     public async Task ResolveAsync_DependencyProvidedByHost_DoesNotAcquireDependencyNode()
     {
         var root = CreateInstalledPackage("Plugin.Root", "1.0.0", dependencyId: "Nuplane.Abstractions", dependencyVersionRange: "[1.0.0]");

--- a/test/Nuplane.Runtime.Tests/Feeds/PackageDependencyGraphResolverTests.cs
+++ b/test/Nuplane.Runtime.Tests/Feeds/PackageDependencyGraphResolverTests.cs
@@ -120,6 +120,38 @@ public sealed class PackageDependencyGraphResolverTests : IDisposable
     }
 
     [Fact]
+    public async Task ResolveAsync_MultipleRoots_UnifiesSharedDependencyWithNuGetLowestApplicableVersion()
+    {
+        var leftRoot = CreateInstalledPackage("Plugin.Left", "1.0.0", dependencyId: "Plugin.Shared", dependencyVersionRange: "1.0.0");
+        var rightRoot = CreateInstalledPackage("Plugin.Right", "1.0.0", dependencyId: "Plugin.Shared", dependencyVersionRange: "2.0.0");
+        var resolver = new VersionRangePackageResolver(
+            new Dictionary<string, IReadOnlyList<ResolvedPackage>>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["Plugin.Shared"] =
+                [
+                    CreateInstalledPackage("Plugin.Shared", "1.0.0"),
+                    CreateInstalledPackage("Plugin.Shared", "2.0.0"),
+                    CreateInstalledPackage("Plugin.Shared", "3.0.0")
+                ]
+            });
+        var sut = new PackageDependencyGraphResolver(resolver, new PassthroughRetryPolicy());
+
+        var result = await sut.ResolveAsync(
+            [
+                new PackageRequest("Plugin.Left", "[1.0.0]", "test-feed", PackageUpdatePolicy.Exact, "test-source"),
+                new PackageRequest("Plugin.Right", "[1.0.0]", "test-feed", PackageUpdatePolicy.Exact, "test-source")
+            ],
+            (request, _) => Task.FromResult(request.Id == "Plugin.Left" ? leftRoot : rightRoot),
+            CancellationToken.None);
+
+        var graph = Assert.Single(result.ResolvedGraphs);
+        Assert.Equal(["Plugin.Left", "Plugin.Right"], graph.Roots.Select(static node => node.PackageId).Order(StringComparer.OrdinalIgnoreCase));
+        Assert.Single(graph.Nodes, static node => node.PackageId == "Plugin.Shared");
+        Assert.Contains(graph.Nodes, static node => node.PackageId == "Plugin.Shared" && node.Version == "2.0.0");
+        Assert.DoesNotContain(graph.Nodes, static node => node.PackageId == "Plugin.Shared" && node.Version == "3.0.0");
+    }
+
+    [Fact]
     public async Task ResolveAsync_DependencyProvidedByHost_DoesNotAcquireDependencyNode()
     {
         var root = CreateInstalledPackage("Plugin.Root", "1.0.0", dependencyId: "Nuplane.Abstractions", dependencyVersionRange: "[1.0.0]");

--- a/test/Nuplane.Runtime.Tests/Feeds/PackageDependencyGraphResolverTests.cs
+++ b/test/Nuplane.Runtime.Tests/Feeds/PackageDependencyGraphResolverTests.cs
@@ -87,6 +87,39 @@ public sealed class PackageDependencyGraphResolverTests : IDisposable
     }
 
     [Fact]
+    public async Task ResolveAsync_WhenHigherDirectDependencySatisfiesTransitiveBaseline_ReusesSelectedDependency()
+    {
+        var root = CreateInstalledPackage(
+            "Plugin.Root",
+            "1.0.0",
+            dependenciesXml: """
+                <dependencies>
+                  <dependency id="Plugin.Direct" version="10.0.3" />
+                  <dependency id="Plugin.Transitive" version="[1.0.0]" />
+                </dependencies>
+                """);
+        var direct = CreateInstalledPackage("Plugin.Direct", "10.0.3");
+        var transitive = CreateInstalledPackage("Plugin.Transitive", "1.0.0", dependencyId: "Plugin.Direct", dependencyVersionRange: "8.0.2");
+        var resolver = new VersionRangePackageResolver(
+            new Dictionary<string, IReadOnlyList<ResolvedPackage>>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["Plugin.Direct"] = [direct],
+                ["Plugin.Transitive"] = [transitive]
+            });
+        var sut = new PackageDependencyGraphResolver(resolver, new PassthroughRetryPolicy());
+
+        var result = await sut.ResolveAsync(
+            [new PackageRequest("Plugin.Root", "[1.0.0]", "test-feed", PackageUpdatePolicy.Exact, "test-source")],
+            (_, _) => Task.FromResult(root),
+            CancellationToken.None);
+
+        var graph = Assert.Single(result.ResolvedGraphs);
+        Assert.Single(graph.Nodes, static node => node.PackageId == "Plugin.Direct");
+        Assert.Equal(2, graph.Edges.Count(static edge => edge.ToPackageId == "Plugin.Direct"));
+        Assert.Single(resolver.Requests, static request => request.Id == "Plugin.Direct");
+    }
+
+    [Fact]
     public async Task ResolveAsync_DependencyProvidedByHost_DoesNotAcquireDependencyNode()
     {
         var root = CreateInstalledPackage("Plugin.Root", "1.0.0", dependencyId: "Nuplane.Abstractions", dependencyVersionRange: "[1.0.0]");

--- a/test/Nuplane.Runtime.Tests/Nuplane.Runtime.Tests.csproj
+++ b/test/Nuplane.Runtime.Tests/Nuplane.Runtime.Tests.csproj
@@ -4,6 +4,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Microsoft.Extensions.Logging" />
+    <PackageReference Include="NuGet.Resolver" />
     <ProjectReference Include="..\..\src\Nuplane.Sources.Directory\Nuplane.Sources.Directory.csproj" />
     <ProjectReference Include="..\..\src\Nuplane\Nuplane.csproj" />
     <ProjectReference Include="..\..\src\Nuplane.Admin\Nuplane.Admin.csproj" />

--- a/test/Nuplane.Runtime.Tests/Reconciliation/PackageApplyExecutorTests.cs
+++ b/test/Nuplane.Runtime.Tests/Reconciliation/PackageApplyExecutorTests.cs
@@ -69,11 +69,9 @@ public sealed class PackageApplyExecutorTests : IDisposable
 
         Assert.Empty(recorder.Records);
         Assert.Contains(result.ResolvedPackages, static package => package.Id == "Shared.Dependency" && package.Version == "10.0.3");
-        Assert.Equal(2, result.ResolvedGraphs.Count);
-        Assert.All(result.ResolvedGraphs, graph =>
-        {
-            Assert.Contains(graph.Nodes, static node => node.PackageId == "Shared.Dependency" && node.Version == "10.0.3");
-        });
+        var graph = Assert.Single(result.ResolvedGraphs);
+        Assert.Equal(["Root.Baseline", "Root.Current"], graph.Roots.Select(static root => root.PackageId).Order(StringComparer.OrdinalIgnoreCase));
+        Assert.Contains(graph.Nodes, static node => node.PackageId == "Shared.Dependency" && node.Version == "10.0.3");
     }
 
     public void Dispose()

--- a/test/Nuplane.Runtime.Tests/TestSupport/VersionRangePackageResolver.cs
+++ b/test/Nuplane.Runtime.Tests/TestSupport/VersionRangePackageResolver.cs
@@ -35,7 +35,7 @@ internal sealed class VersionRangePackageResolver(IReadOnlyDictionary<string, IR
                 Version = NuGetVersion.Parse(package.Version)
             })
             .Where(candidate => range.Satisfies(candidate.Version))
-            .OrderByDescending(candidate => candidate.Version)
+            .OrderBy(candidate => candidate.Version)
             .FirstOrDefault();
 
         return match is null


### PR DESCRIPTION
## Summary

- delegates aggregate dependency graph version selection to NuGet's resolver with lowest-dependency semantics
- preserves isolated root package acquisition failures before solving successful roots together
- adds regression coverage for EF preview avoidance, direct dependency wins, cousin dependency unification, and multi-root aggregate graphs
- documents the feasibility decision and implementation notes under `specs/023-nuget-restore-feasibility`

## Why

Nuplane had been incrementally rediscovering NuGet restore behavior in custom graph code. The active failure mode was dependency ranges such as `[10.0.3,)` floating to an incompatible `11.0.0-preview` package. Letting NuGet select the aggregate package identity set avoids that class of bug while Nuplane continues to own feed trust, acquisition, store activation, graph persistence, and runtime loading.

## Validation

- `dotnet test test/Nuplane.Runtime.Tests/Nuplane.Runtime.Tests.csproj`
- `dotnet test nuplane.sln`
