### PR TITLE
Fix NuGet framework group resolution

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -18,6 +18,7 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="NuGet.Protocol" Version="6.13.1" />
+    <PackageVersion Include="NuGet.Frameworks" Version="6.13.1" />
     <PackageVersion Include="NuGet.Resolver" Version="6.13.1" />
     <PackageVersion Include="NuGet.Versioning" Version="6.13.1" />
     <PackageVersion Include="Polly.Extensions" Version="8.6.5" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -15,6 +15,7 @@
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.3" />
     <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.3" />
     <PackageVersion Include="Microsoft.Extensions.Resilience" Version="10.1.0" />
+    <PackageVersion Include="Microsoft.NETCore.Platforms" Version="7.0.4" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="NuGet.Protocol" Version="6.13.1" />

--- a/src/Nuplane.Loading/HostIntegratedPackageGraphLoadContext.cs
+++ b/src/Nuplane.Loading/HostIntegratedPackageGraphLoadContext.cs
@@ -6,6 +6,7 @@ namespace Nuplane.Loading;
 internal sealed class HostIntegratedPackageGraphLoadContext(
     string graphKey,
     IReadOnlyList<string> mainAssemblyPaths,
+    IReadOnlyList<string> packageInstallPaths,
     IReadOnlyList<SharedAssemblyPolicyEntry> sharedPolicy,
     SharedAssemblyPolicyMatcher matcher)
-    : PackageGraphLoadContext(graphKey, mainAssemblyPaths, sharedPolicy, matcher, isCollectible: false);
+    : PackageGraphLoadContext(graphKey, mainAssemblyPaths, packageInstallPaths, sharedPolicy, matcher, isCollectible: false);

--- a/src/Nuplane.Loading/Nuplane.Loading.csproj
+++ b/src/Nuplane.Loading/Nuplane.Loading.csproj
@@ -17,8 +17,13 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Options" />
+    <PackageReference Include="Microsoft.NETCore.Platforms" GeneratePathProperty="true" PrivateAssets="all" />
     <ProjectReference Include="..\Nuplane.Abstractions\Nuplane.Abstractions.csproj" />
     <ProjectReference Include="..\Nuplane.Loading.Abstractions\Nuplane.Loading.Abstractions.csproj" />
     <ProjectReference Include="..\Nuplane\Nuplane.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="$(PkgMicrosoft_NETCore_Platforms)\runtime.json" LogicalName="Nuplane.Loading.RuntimeIdentifierGraph.json" />
   </ItemGroup>
 </Project>

--- a/src/Nuplane.Loading/PackageGraphLoadContext.cs
+++ b/src/Nuplane.Loading/PackageGraphLoadContext.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Runtime.Loader;
 
 namespace Nuplane.Loading;
@@ -7,21 +8,24 @@ internal class PackageGraphLoadContext : AssemblyLoadContext
 {
     private readonly IReadOnlyDictionary<string, string> assemblyPathsByName;
     private readonly IReadOnlyList<AssemblyDependencyResolver> dependencyResolvers;
+    private readonly IReadOnlyList<string> packageInstallPaths;
     private readonly IReadOnlyList<SharedAssemblyPolicyEntry> sharedPolicy;
     private readonly SharedAssemblyPolicyMatcher matcher;
 
     public PackageGraphLoadContext(
         string contextName,
         IReadOnlyList<string> mainAssemblyPaths,
+        IReadOnlyList<string> packageInstallPaths,
         IReadOnlyList<SharedAssemblyPolicyEntry> sharedPolicy,
         SharedAssemblyPolicyMatcher matcher)
-        : this(contextName, mainAssemblyPaths, sharedPolicy, matcher, isCollectible: true)
+        : this(contextName, mainAssemblyPaths, packageInstallPaths, sharedPolicy, matcher, isCollectible: true)
     {
     }
 
     protected PackageGraphLoadContext(
         string contextName,
         IReadOnlyList<string> mainAssemblyPaths,
+        IReadOnlyList<string> packageInstallPaths,
         IReadOnlyList<SharedAssemblyPolicyEntry> sharedPolicy,
         SharedAssemblyPolicyMatcher matcher,
         bool isCollectible)
@@ -32,6 +36,7 @@ internal class PackageGraphLoadContext : AssemblyLoadContext
 
         this.sharedPolicy = sharedPolicy ?? throw new ArgumentNullException(nameof(sharedPolicy));
         this.matcher = matcher ?? throw new ArgumentNullException(nameof(matcher));
+        this.packageInstallPaths = packageInstallPaths ?? throw new ArgumentNullException(nameof(packageInstallPaths));
         dependencyResolvers = mainAssemblyPaths.Select(static path => new AssemblyDependencyResolver(path)).ToArray();
         assemblyPathsByName = mainAssemblyPaths
             .SelectMany(path => Directory.EnumerateFiles(Path.GetDirectoryName(path)!, "*.dll", SearchOption.AllDirectories))
@@ -74,6 +79,103 @@ internal class PackageGraphLoadContext : AssemblyLoadContext
         }
 
         return null;
+    }
+
+    protected override IntPtr LoadUnmanagedDll(string unmanagedDllName)
+    {
+        foreach (var resolver in dependencyResolvers)
+        {
+            var resolvedPath = resolver.ResolveUnmanagedDllToPath(unmanagedDllName);
+            if (!string.IsNullOrWhiteSpace(resolvedPath))
+            {
+                return LoadUnmanagedDllFromPath(resolvedPath);
+            }
+        }
+
+        var nativePath = ResolveNativeLibraryPath(packageInstallPaths, unmanagedDllName, RuntimeInformation.RuntimeIdentifier);
+        return nativePath is null ? IntPtr.Zero : LoadUnmanagedDllFromPath(nativePath);
+    }
+
+    internal static string? ResolveNativeLibraryPath(
+        IEnumerable<string> packageInstallPaths,
+        string unmanagedDllName,
+        string runtimeIdentifier)
+    {
+        if (string.IsNullOrWhiteSpace(unmanagedDllName) || string.IsNullOrWhiteSpace(runtimeIdentifier))
+        {
+            return null;
+        }
+
+        var fileNames = BuildNativeLibraryFileNames(unmanagedDllName).ToArray();
+        foreach (var directory in packageInstallPaths.SelectMany(path => ResolveNativeSearchDirectories(path, runtimeIdentifier)))
+        {
+            foreach (var fileName in fileNames)
+            {
+                var candidate = Path.Combine(directory, fileName);
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private static IEnumerable<string> ResolveNativeSearchDirectories(string packageInstallPath, string runtimeIdentifier)
+    {
+        if (string.IsNullOrWhiteSpace(packageInstallPath) || !Directory.Exists(packageInstallPath))
+        {
+            yield break;
+        }
+
+        yield return packageInstallPath;
+
+        var nativeDirectory = Path.Combine(packageInstallPath, "runtimes", runtimeIdentifier, "native");
+        if (Directory.Exists(nativeDirectory))
+        {
+            yield return nativeDirectory;
+        }
+    }
+
+    private static IEnumerable<string> BuildNativeLibraryFileNames(string unmanagedDllName)
+    {
+        yield return unmanagedDllName;
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            if (!unmanagedDllName.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
+            {
+                yield return $"{unmanagedDllName}.dll";
+            }
+
+            yield break;
+        }
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {
+            if (!unmanagedDllName.EndsWith(".dylib", StringComparison.OrdinalIgnoreCase))
+            {
+                yield return $"{unmanagedDllName}.dylib";
+            }
+
+            if (!unmanagedDllName.StartsWith("lib", StringComparison.OrdinalIgnoreCase))
+            {
+                yield return $"lib{unmanagedDllName}.dylib";
+            }
+
+            yield break;
+        }
+
+        if (!unmanagedDllName.EndsWith(".so", StringComparison.OrdinalIgnoreCase))
+        {
+            yield return $"{unmanagedDllName}.so";
+        }
+
+        if (!unmanagedDllName.StartsWith("lib", StringComparison.OrdinalIgnoreCase))
+        {
+            yield return $"lib{unmanagedDllName}.so";
+        }
     }
 
     private static string? TryGetManagedAssemblyName(string path)

--- a/src/Nuplane.Loading/PackageGraphLoadContext.cs
+++ b/src/Nuplane.Loading/PackageGraphLoadContext.cs
@@ -1,6 +1,7 @@
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Runtime.Loader;
+using NuGet.RuntimeModel;
 
 namespace Nuplane.Loading;
 
@@ -11,6 +12,7 @@ internal class PackageGraphLoadContext : AssemblyLoadContext
     private readonly IReadOnlyList<string> packageInstallPaths;
     private readonly IReadOnlyList<SharedAssemblyPolicyEntry> sharedPolicy;
     private readonly SharedAssemblyPolicyMatcher matcher;
+    private static readonly Lazy<RuntimeGraph> RuntimeGraphProvider = new(LoadRuntimeGraph);
 
     public PackageGraphLoadContext(
         string contextName,
@@ -107,7 +109,8 @@ internal class PackageGraphLoadContext : AssemblyLoadContext
         }
 
         var fileNames = BuildNativeLibraryFileNames(unmanagedDllName).ToArray();
-        foreach (var directory in packageInstallPaths.SelectMany(path => ResolveNativeSearchDirectories(path, runtimeIdentifier)))
+        var runtimeIdentifiers = ExpandRuntimeIdentifiers(runtimeIdentifier);
+        foreach (var directory in packageInstallPaths.SelectMany(path => ResolveNativeSearchDirectories(path, runtimeIdentifiers)))
         {
             foreach (var fileName in fileNames)
             {
@@ -122,7 +125,20 @@ internal class PackageGraphLoadContext : AssemblyLoadContext
         return null;
     }
 
-    private static IEnumerable<string> ResolveNativeSearchDirectories(string packageInstallPath, string runtimeIdentifier)
+    internal static IReadOnlyList<string> ExpandRuntimeIdentifiers(string runtimeIdentifier) =>
+        RuntimeGraphProvider.Value
+            .ExpandRuntime(runtimeIdentifier)
+            .Prepend(runtimeIdentifier)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+    private static RuntimeGraph LoadRuntimeGraph()
+    {
+        using var stream = typeof(PackageGraphLoadContext).Assembly.GetManifestResourceStream("Nuplane.Loading.RuntimeIdentifierGraph.json");
+        return stream is null ? RuntimeGraph.Empty : JsonRuntimeFormat.ReadRuntimeGraph(stream);
+    }
+
+    private static IEnumerable<string> ResolveNativeSearchDirectories(string packageInstallPath, IReadOnlyList<string> runtimeIdentifiers)
     {
         if (string.IsNullOrWhiteSpace(packageInstallPath) || !Directory.Exists(packageInstallPath))
         {
@@ -131,10 +147,13 @@ internal class PackageGraphLoadContext : AssemblyLoadContext
 
         yield return packageInstallPath;
 
-        var nativeDirectory = Path.Combine(packageInstallPath, "runtimes", runtimeIdentifier, "native");
-        if (Directory.Exists(nativeDirectory))
+        foreach (var runtimeIdentifier in runtimeIdentifiers)
         {
-            yield return nativeDirectory;
+            var nativeDirectory = Path.Combine(packageInstallPath, "runtimes", runtimeIdentifier, "native");
+            if (Directory.Exists(nativeDirectory))
+            {
+                yield return nativeDirectory;
+            }
         }
     }
 

--- a/src/Nuplane.Loading/PackageLoader.cs
+++ b/src/Nuplane.Loading/PackageLoader.cs
@@ -238,8 +238,8 @@ internal sealed class PackageLoader : IPackageLoader
             }
 
             context = graphLoadMode == PackageLoadMode.HostIntegrated
-                ? new HostIntegratedPackageGraphLoadContext(graphKey, mainAssemblyPaths, sharedPolicy, _matcher)
-                : new PackageGraphLoadContext(graphKey, mainAssemblyPaths, sharedPolicy, _matcher);
+                ? new HostIntegratedPackageGraphLoadContext(graphKey, mainAssemblyPaths, packages.Select(static package => package.InstallPath).ToArray(), sharedPolicy, _matcher)
+                : new PackageGraphLoadContext(graphKey, mainAssemblyPaths, packages.Select(static package => package.InstallPath).ToArray(), sharedPolicy, _matcher);
 
             foreach (var mainAssemblyPath in mainAssemblyPaths)
             {

--- a/src/Nuplane/Nuplane.csproj
+++ b/src/Nuplane/Nuplane.csproj
@@ -17,6 +17,7 @@
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Options" />
     <PackageReference Include="Microsoft.Extensions.Resilience" />
+    <PackageReference Include="NuGet.Frameworks" />
     <PackageReference Include="NuGet.Protocol" />
     <PackageReference Include="NuGet.Resolver" />
     <PackageReference Include="NuGet.Versioning" />

--- a/src/Nuplane/Reconciliation/PackageDependencyGraphResolver.cs
+++ b/src/Nuplane/Reconciliation/PackageDependencyGraphResolver.cs
@@ -3,6 +3,7 @@ using System.Text.Json;
 using System.Xml.Linq;
 using NuGet.Common;
 using NuGet.Configuration;
+using NuGet.Frameworks;
 using NuGet.Packaging.Core;
 using NuGet.Protocol.Core.Types;
 using NuGet.Resolver;
@@ -419,79 +420,65 @@ public sealed class PackageDependencyGraphResolver(IPackageResolver packageResol
             return [];
         }
 
-        if (!TryParseFramework(TargetFrameworkMonikerProvider.Current, out var hostTarget))
+        if (!TryParseNuGetFramework(TargetFrameworkMonikerProvider.Current, out var hostTarget))
         {
             return groups.Where(static group => string.IsNullOrWhiteSpace(group.TargetFramework)).ToArray();
         }
 
-        var compatibleGroups = groups
+        var parsedGroups = groups
             .Select(group => new
             {
                 Group = group,
-                Parsed = TryParseFramework(group.TargetFramework, out var target) ? target : null
+                Parsed = TryParseNuGetFramework(group.TargetFramework, out var target) ? target : null
             })
-            .Where(candidate => candidate.Parsed is not null && IsCompatible(hostTarget, candidate.Parsed))
-            .OrderByDescending(candidate => candidate.Parsed!.Kind == hostTarget.Kind ? 1 : 0)
-            .ThenByDescending(candidate => candidate.Parsed!.Version)
-            .Select(candidate => candidate.Group)
+            .Where(static candidate => candidate.Parsed is not null)
             .ToArray();
 
-        if (compatibleGroups.Length > 0)
+        var nearest = new FrameworkReducer().GetNearest(hostTarget, parsedGroups.Select(static candidate => candidate.Parsed!));
+        if (nearest is not null)
         {
-            return [compatibleGroups[0]];
+            return parsedGroups
+                .Where(candidate => NuGetFrameworkFullComparer.Instance.Equals(candidate.Parsed, nearest))
+                .Select(static candidate => candidate.Group)
+                .Take(1)
+                .ToArray();
         }
 
         return groups.Where(static group => string.IsNullOrWhiteSpace(group.TargetFramework)).ToArray();
     }
 
-    private static bool IsCompatible(FrameworkTarget host, FrameworkTarget candidate)
-    {
-        if (candidate.Kind == FrameworkKind.NetStandard)
-        {
-            return candidate.Version <= new Version(2, 1);
-        }
-
-        return candidate.Kind == host.Kind && candidate.Version <= host.Version;
-    }
-
-    private static bool TryParseFramework(string? value, out FrameworkTarget target)
+    private static bool TryParseNuGetFramework(string? value, out NuGetFramework framework)
     {
         if (string.IsNullOrWhiteSpace(value))
         {
-            target = null!;
+            framework = null!;
             return false;
         }
 
         var normalized = value.Trim();
-        if (normalized.StartsWith(".NETCoreApp,Version=v", StringComparison.OrdinalIgnoreCase))
+        if (normalized.Contains(",Version=", StringComparison.OrdinalIgnoreCase))
         {
-            return TryParseVersion(normalized[21..], FrameworkKind.NetCoreApp, out target);
+            framework = NuGetFramework.ParseFrameworkName(normalized, DefaultFrameworkNameProvider.Instance);
+            return !framework.IsUnsupported;
         }
 
-        if (normalized.StartsWith("netstandard", StringComparison.OrdinalIgnoreCase))
-        {
-            return TryParseVersion(normalized[11..], FrameworkKind.NetStandard, out target);
-        }
-
-        if (normalized.StartsWith("net", StringComparison.OrdinalIgnoreCase) && normalized.Contains('.'))
-        {
-            return TryParseVersion(normalized[3..], FrameworkKind.NetCoreApp, out target);
-        }
-
-        target = null!;
-        return false;
+        framework = NuGetFramework.ParseFolder(NormalizeFrameworkFolderName(normalized));
+        return !framework.IsUnsupported;
     }
 
-    private static bool TryParseVersion(string value, FrameworkKind kind, out FrameworkTarget target)
+    private static string NormalizeFrameworkFolderName(string value)
     {
-        if (Version.TryParse(value, out var version))
+        if (value.StartsWith(".NETStandard", StringComparison.OrdinalIgnoreCase))
         {
-            target = new FrameworkTarget(kind, new Version(version.Major, version.Minor));
-            return true;
+            return "netstandard" + value[".NETStandard".Length..];
         }
 
-        target = null!;
-        return false;
+        if (value.StartsWith(".NETCoreApp", StringComparison.OrdinalIgnoreCase))
+        {
+            return "netcoreapp" + value[".NETCoreApp".Length..];
+        }
+
+        return value;
     }
 
     private static string BuildPackageKey(string packageId, string version) => $"{packageId}@{version}";
@@ -608,13 +595,6 @@ public sealed class PackageDependencyGraphResolver(IPackageResolver packageResol
 
     private sealed record PackageDependencyMetadata(string PackageId, string VersionRange, string? TargetFramework);
 
-    private sealed record FrameworkTarget(FrameworkKind Kind, Version Version);
-
-    private enum FrameworkKind
-    {
-        NetCoreApp,
-        NetStandard
-    }
 }
 
 /// <summary>

--- a/test/Nuplane.Loading.Tests/PackageLoaderGraphRegressionTests.cs
+++ b/test/Nuplane.Loading.Tests/PackageLoaderGraphRegressionTests.cs
@@ -74,6 +74,23 @@ public sealed class PackageLoaderGraphRegressionTests : IDisposable
     }
 
     [Fact]
+    public void ResolveNativeLibraryPath_WithRuntimeGraphFallback_ResolvesCompatibleRidAsset()
+    {
+        var nativePackageInstall = Path.Combine(tempRoot, "Native.Package", "1.0.0");
+        var nativeDirectory = Path.Combine(nativePackageInstall, "runtimes", "linux-x64", "native");
+        var nativePath = Path.Combine(nativeDirectory, "e_sqlite3");
+        Directory.CreateDirectory(nativeDirectory);
+        File.WriteAllText(nativePath, string.Empty);
+
+        var result = PackageGraphLoadContext.ResolveNativeLibraryPath(
+            [nativePackageInstall],
+            "e_sqlite3",
+            "linux-musl-x64");
+
+        Assert.Equal(nativePath, result);
+    }
+
+    [Fact]
     public async Task EnsureGraphLoadedAsync_LoadablePackageWithNoAssemblyDependency_SkipsDependencyWithoutFailure()
     {
         var rootInstall = CreatePackageInstall("Plugin.Root", "Plugin.Root.dll");

--- a/test/Nuplane.Loading.Tests/PackageLoaderGraphRegressionTests.cs
+++ b/test/Nuplane.Loading.Tests/PackageLoaderGraphRegressionTests.cs
@@ -57,6 +57,23 @@ public sealed class PackageLoaderGraphRegressionTests : IDisposable
     }
 
     [Fact]
+    public void ResolveNativeLibraryPath_WithRuntimeNativeAsset_ResolvesPlatformSpecificName()
+    {
+        var nativePackageInstall = Path.Combine(tempRoot, "SQLitePCLRaw.lib.e_sqlite3", "2.1.11");
+        var nativeDirectory = Path.Combine(nativePackageInstall, "runtimes", "osx-arm64", "native");
+        var nativePath = Path.Combine(nativeDirectory, "libe_sqlite3.dylib");
+        Directory.CreateDirectory(nativeDirectory);
+        File.WriteAllText(nativePath, string.Empty);
+
+        var result = PackageGraphLoadContext.ResolveNativeLibraryPath(
+            [nativePackageInstall],
+            "e_sqlite3",
+            "osx-arm64");
+
+        Assert.Equal(nativePath, result);
+    }
+
+    [Fact]
     public async Task EnsureGraphLoadedAsync_LoadablePackageWithNoAssemblyDependency_SkipsDependencyWithoutFailure()
     {
         var rootInstall = CreatePackageInstall("Plugin.Root", "Plugin.Root.dll");

--- a/test/Nuplane.Runtime.Tests/Feeds/PackageDependencyGraphResolverTests.cs
+++ b/test/Nuplane.Runtime.Tests/Feeds/PackageDependencyGraphResolverTests.cs
@@ -356,6 +356,44 @@ public sealed class PackageDependencyGraphResolverTests : IDisposable
         Assert.Equal("Plugin.Compatible", edge.ToPackageId);
     }
 
+    [Theory]
+    [InlineData(".NETStandard2.0")]
+    [InlineData(".NETStandard,Version=v2.0")]
+    public async Task ResolveAsync_WithNuspecNetStandardDependencyGroup_SelectsCompatibleGroup(string targetFramework)
+    {
+        var root = CreateInstalledPackage(
+            "SQLitePCLRaw.bundle_e_sqlite3",
+            "2.1.11",
+            dependenciesXml: $$"""
+                <dependencies>
+                  <group targetFramework="{{targetFramework}}">
+                    <dependency id="SQLitePCLRaw.provider.e_sqlite3" version="2.1.11" />
+                    <dependency id="SQLitePCLRaw.lib.e_sqlite3" version="2.1.11" />
+                  </group>
+                </dependencies>
+                """);
+        var provider = CreateInstalledPackage("SQLitePCLRaw.provider.e_sqlite3", "2.1.11");
+        var nativeLibrary = CreateInstalledPackage("SQLitePCLRaw.lib.e_sqlite3", "2.1.11");
+        var resolver = new StubPackageResolver(
+            new Dictionary<string, ResolvedPackage>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["SQLitePCLRaw.provider.e_sqlite3"] = provider,
+                ["SQLitePCLRaw.lib.e_sqlite3"] = nativeLibrary
+            });
+        var sut = new PackageDependencyGraphResolver(resolver, new PassthroughRetryPolicy());
+
+        var result = await sut.ResolveAsync(
+            [new PackageRequest("SQLitePCLRaw.bundle_e_sqlite3", "[2.1.11]", "test-feed", PackageUpdatePolicy.Exact, "test-source")],
+            (_, _) => Task.FromResult(root),
+            CancellationToken.None);
+
+        var graph = Assert.Single(result.ResolvedGraphs);
+        Assert.Contains(graph.Nodes, static node => node.PackageId == "SQLitePCLRaw.provider.e_sqlite3");
+        Assert.Contains(graph.Nodes, static node => node.PackageId == "SQLitePCLRaw.lib.e_sqlite3");
+        Assert.Contains(graph.Edges, static edge => edge.ToPackageId == "SQLitePCLRaw.provider.e_sqlite3");
+        Assert.Contains(graph.Edges, static edge => edge.ToPackageId == "SQLitePCLRaw.lib.e_sqlite3");
+    }
+
     [Fact]
     public async Task ResolveAsync_WithDependencyCycle_ThrowsCycleDiagnostic()
     {


### PR DESCRIPTION
## What changed

- Use NuGet.Frameworks / FrameworkReducer when selecting nuspec dependency groups instead of Nuplane's hand-rolled framework parser.
- Recognize nuspec framework forms such as `.NETStandard2.0` and `.NETStandard,Version=v2.0`, which appear in packages like `SQLitePCLRaw.bundle_e_sqlite3`.
- Add graph load context support for resolving package native assets from `runtimes/{rid}/native`, covering SQLitePCLRaw's `libe_sqlite3` dependency.
- Add regression coverage for the SQLitePCLRaw-shaped dependency group and native asset lookup.

## Why

ElsaProServer with Quartz SQLite was still failing after the NuGet resolver changes because Nuplane skipped the `.NETStandard2.0` dependency group in `SQLitePCLRaw.bundle_e_sqlite3`. That omitted `SQLitePCLRaw.provider.e_sqlite3` and `SQLitePCLRaw.lib.e_sqlite3` from the graph, so `Microsoft.Data.Sqlite` failed at runtime while initializing SQLitePCLRaw.

## Validation

- `dotnet test test/Nuplane.Loading.Tests/Nuplane.Loading.Tests.csproj --filter "PackageLoaderGraphRegressionTests|PackageLoaderHostIntegratedTests"`
- `dotnet test test/Nuplane.Runtime.Tests/Nuplane.Runtime.Tests.csproj --filter PackageDependencyGraphResolverTests`
- `dotnet test nuplane.sln`
