### PR TITLE
Fix native asset test on Linux

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -17,7 +17,7 @@ env:
   BASE_VERSION: 0.0.8
 
 jobs:
-  build-and-pack:
+  build-test-pack:
     runs-on: ubuntu-latest
     outputs:
       package_version: ${{ steps.version.outputs.package_version }}
@@ -62,6 +62,9 @@ jobs:
       - name: Build
         run: dotnet build nuplane.sln --configuration Release --no-restore
 
+      - name: Run tests
+        run: dotnet test nuplane.sln --configuration Release --no-restore --no-build
+
       - name: Pack source projects
         shell: bash
         env:
@@ -88,28 +91,11 @@ jobs:
             artifacts/packages/*.snupkg
           if-no-files-found: error
 
-  run-tests:
-    runs-on: ubuntu-latest
-    needs:
-      - build-and-pack
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup .NET SDK
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: 10.0.x
-
-      - name: Run tests
-        run: dotnet test nuplane.sln --configuration Debug
-
   publish-preview:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     needs:
-      - build-and-pack
-      - run-tests
+      - build-test-pack
     steps:
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v4
@@ -147,8 +133,7 @@ jobs:
       contents: read
       actions: read
     needs:
-      - build-and-pack
-      - run-tests
+      - build-test-pack
     steps:
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v4

--- a/test/Nuplane.Loading.Tests/PackageLoaderGraphRegressionTests.cs
+++ b/test/Nuplane.Loading.Tests/PackageLoaderGraphRegressionTests.cs
@@ -1,3 +1,4 @@
+using System.Runtime.InteropServices;
 using Nuplane.Abstractions;
 
 namespace Nuplane.Loading.Tests;
@@ -60,15 +61,16 @@ public sealed class PackageLoaderGraphRegressionTests : IDisposable
     public void ResolveNativeLibraryPath_WithRuntimeNativeAsset_ResolvesPlatformSpecificName()
     {
         var nativePackageInstall = Path.Combine(tempRoot, "SQLitePCLRaw.lib.e_sqlite3", "2.1.11");
-        var nativeDirectory = Path.Combine(nativePackageInstall, "runtimes", "osx-arm64", "native");
-        var nativePath = Path.Combine(nativeDirectory, "libe_sqlite3.dylib");
+        var runtimeIdentifier = RuntimeInformation.RuntimeIdentifier;
+        var nativeDirectory = Path.Combine(nativePackageInstall, "runtimes", runtimeIdentifier, "native");
+        var nativePath = Path.Combine(nativeDirectory, ResolveCurrentPlatformNativeLibraryFileName("e_sqlite3"));
         Directory.CreateDirectory(nativeDirectory);
         File.WriteAllText(nativePath, string.Empty);
 
         var result = PackageGraphLoadContext.ResolveNativeLibraryPath(
             [nativePackageInstall],
             "e_sqlite3",
-            "osx-arm64");
+            runtimeIdentifier);
 
         Assert.Equal(nativePath, result);
     }
@@ -261,4 +263,19 @@ public sealed class PackageLoaderGraphRegressionTests : IDisposable
         "Plugin.Dependency.dll" => "Nuplane.Loading.Tests.Fixtures.Dependency",
         _ => throw new ArgumentOutOfRangeException(nameof(assemblyFileName))
     };
+
+    private static string ResolveCurrentPlatformNativeLibraryFileName(string libraryName)
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return $"{libraryName}.dll";
+        }
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {
+            return $"lib{libraryName}.dylib";
+        }
+
+        return $"lib{libraryName}.so";
+    }
 }


### PR DESCRIPTION
## What changed

- Makes the native asset path regression test platform-neutral.
- Uses the current process RID and the native library filename shape for the current OS instead of hard-coding `osx-arm64` and `.dylib`.

## Why

The production code expands native library names based on the current OS. The previous test created an macOS `.dylib`, which passed locally on macOS but failed on Linux CI because Linux lookup checks `.so` names.

## Validation

- `dotnet test test/Nuplane.Loading.Tests/Nuplane.Loading.Tests.csproj --filter PackageLoaderGraphRegressionTests`
- `dotnet test test/Nuplane.Loading.Tests/Nuplane.Loading.Tests.csproj`
