### PR TITLE
Fix fixture lookup in release tests

### DIFF
--- a/test/Nuplane.Loading.Tests/PackageLoaderGraphRegressionTests.cs
+++ b/test/Nuplane.Loading.Tests/PackageLoaderGraphRegressionTests.cs
@@ -241,21 +241,7 @@ public sealed class PackageLoaderGraphRegressionTests : IDisposable
     }
 
     private static string FindFixtureAssembly(string assemblyFileName)
-    {
-        var current = new DirectoryInfo(AppContext.BaseDirectory);
-        while (current is not null)
-        {
-            var candidate = Path.Combine(current.FullName, "test", ResolveFixtureProjectDirectory(assemblyFileName), "bin", "Debug", "net10.0", assemblyFileName);
-            if (File.Exists(candidate))
-            {
-                return candidate;
-            }
-
-            current = current.Parent;
-        }
-
-        throw new FileNotFoundException($"Fixture assembly '{assemblyFileName}' was not found.", assemblyFileName);
-    }
+        => TestFixtureAssemblyPaths.FindProjectAssembly(ResolveFixtureProjectDirectory(assemblyFileName), assemblyFileName);
 
     private static string ResolveFixtureProjectDirectory(string assemblyFileName) => assemblyFileName switch
     {

--- a/test/Nuplane.Loading.Tests/PackageTypeScannerTests.cs
+++ b/test/Nuplane.Loading.Tests/PackageTypeScannerTests.cs
@@ -176,7 +176,7 @@ public sealed class PackageTypeScannerTests : IDisposable
     }
 
     private static string GetBuiltFixtureAssemblyPath(string assemblyName) =>
-        Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, $"../../../../{assemblyName}/bin/Debug/net10.0/{assemblyName}.dll"));
+        TestFixtureAssemblyPaths.FindProjectAssembly(assemblyName, $"{assemblyName}.dll");
 
     private string CopyBrokenCandidateAssembly(string subdirectory)
     {

--- a/test/Nuplane.Loading.Tests/TestFixtureAssemblyPaths.cs
+++ b/test/Nuplane.Loading.Tests/TestFixtureAssemblyPaths.cs
@@ -1,0 +1,36 @@
+namespace Nuplane.Loading.Tests;
+
+internal static class TestFixtureAssemblyPaths
+{
+    public static string FindProjectAssembly(string projectDirectoryName, string assemblyFileName)
+    {
+        var searchedPaths = new List<string>();
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        var configurations = GetCandidateConfigurations();
+        while (current is not null)
+        {
+            foreach (var configuration in configurations)
+            {
+                var candidate = Path.Combine(current.FullName, "test", projectDirectoryName, "bin", configuration, "net10.0", assemblyFileName);
+                searchedPaths.Add(candidate);
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+
+            current = current.Parent;
+        }
+
+        throw new FileNotFoundException($"Fixture assembly '{assemblyFileName}' was not found. Searched: {string.Join(", ", searchedPaths)}", assemblyFileName);
+    }
+
+    private static IReadOnlyList<string> GetCandidateConfigurations()
+    {
+        var currentConfiguration = new DirectoryInfo(AppContext.BaseDirectory).Parent?.Name;
+        return new[] { currentConfiguration, "Debug", "Release" }
+            .Where(static configuration => !string.IsNullOrWhiteSpace(configuration))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray()!;
+    }
+}


### PR DESCRIPTION
## What changed

- Adds a shared fixture assembly path helper for loading test fixtures.
- Fixture lookup now checks the current test configuration first, then falls back to Debug and Release.
- Updates scanner and graph loader tests to use the shared helper instead of hard-coded `bin/Debug` paths.

## Why

CI runs `dotnet test --configuration Release --no-restore --no-build`. Some tests still assumed fixture assemblies live under `bin/Debug`, which caused Release CI runs to fail when copying fixture assemblies.

## Validation

- `dotnet build nuplane.sln --configuration Release --no-restore`
- `dotnet test nuplane.sln --configuration Release --no-restore --no-build`
