### PR TITLE
Fix stale active graph metadata

### DIFF
--- a/src/Nuplane/Operational/ActivePackageCatalogMapper.cs
+++ b/src/Nuplane/Operational/ActivePackageCatalogMapper.cs
@@ -174,8 +174,11 @@ internal static class ActivePackageCatalogMapper
         string.Equals(existing.GraphGenerationId, next.GraphGenerationId, StringComparison.OrdinalIgnoreCase) &&
         existing.PackageRole == next.PackageRole &&
         existing.Discoverable == next.Discoverable &&
-        existing.RootPackageIds.SequenceEqual(next.RootPackageIds, StringComparer.OrdinalIgnoreCase) &&
-        existing.DependencyOfPackageIds.SequenceEqual(next.DependencyOfPackageIds, StringComparer.OrdinalIgnoreCase);
+        SetEquals(existing.RootPackageIds, next.RootPackageIds) &&
+        SetEquals(existing.DependencyOfPackageIds, next.DependencyOfPackageIds);
+
+    private static bool SetEquals(IEnumerable<string> left, IEnumerable<string> right) =>
+        left.ToHashSet(StringComparer.OrdinalIgnoreCase).SetEquals(right);
 
     public static ActivePackagesSnapshot MapSnapshot(StoreStateRecord state, string correlationId)
     {

--- a/src/Nuplane/Operational/ActivePackageCatalogMapper.cs
+++ b/src/Nuplane/Operational/ActivePackageCatalogMapper.cs
@@ -45,15 +45,7 @@ internal static class ActivePackageCatalogMapper
                 continue;
             }
 
-            if (!changedPackageIds.Contains(package.Id) &&
-                descriptors.TryGetValue(package.Id, out var existing) &&
-                string.Equals(existing.Version, package.Version, StringComparison.OrdinalIgnoreCase) &&
-                string.Equals(existing.InstallPath, package.InstallPath, StringComparison.Ordinal))
-            {
-                continue;
-            }
-
-            descriptors[package.Id] = CreateDescriptor(
+            var nextDescriptor = CreateDescriptor(
                 package.Id,
                 package.Version,
                 Sanitize(package.FeedName),
@@ -62,6 +54,15 @@ internal static class ActivePackageCatalogMapper
                 activatedAtUtc,
                 correlationId,
                 graphNodesByPackageId);
+
+            if (!changedPackageIds.Contains(package.Id) &&
+                descriptors.TryGetValue(package.Id, out var existing) &&
+                HasSameActivationShape(existing, nextDescriptor))
+            {
+                continue;
+            }
+
+            descriptors[package.Id] = nextDescriptor;
         }
 
         foreach (var packageId in nextActiveVersions.Keys)
@@ -108,11 +109,17 @@ internal static class ActivePackageCatalogMapper
             currentState.ActiveGraphsByIdNormalized,
             StringComparer.OrdinalIgnoreCase);
 
+        var activatedGraphIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var activatedRootKeys = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
         foreach (var graph in resolvedGraphs)
         {
             if (graph.Nodes.All(node => nextActiveVersions.TryGetValue(node.PackageId, out var version)
                     && string.Equals(version, node.Version, StringComparison.OrdinalIgnoreCase)))
             {
+                activatedGraphIds.Add(graph.GraphId);
+                activatedRootKeys.Add(BuildRootSetKey(graph.Roots.Select(static node => node.PackageId)));
+
                 records[graph.GraphId] = new GraphActivationRecord(
                     graph.GraphId,
                     graph.GenerationId,
@@ -127,7 +134,11 @@ internal static class ActivePackageCatalogMapper
 
         foreach (var graphId in records.Keys.ToArray())
         {
-            if (!IsGraphStillActive(records[graphId], nextActiveVersions))
+            var record = records[graphId];
+            var supersededByResolvedGraph = activatedRootKeys.Contains(BuildRootSetKey(record.RootPackageIds)) &&
+                !activatedGraphIds.Contains(record.GraphId);
+
+            if (supersededByResolvedGraph || !IsGraphStillActive(record, nextActiveVersions))
             {
                 records.Remove(graphId);
             }
@@ -149,6 +160,22 @@ internal static class ActivePackageCatalogMapper
             graph.NodeVersionsByPackageId.All(node => nextActiveVersions.TryGetValue(node.Key, out var activeVersion)
                 && string.Equals(activeVersion, node.Value, StringComparison.OrdinalIgnoreCase));
     }
+
+    private static string BuildRootSetKey(IEnumerable<string> rootPackageIds) =>
+        string.Join('\u001f', rootPackageIds
+            .OrderBy(static id => id, StringComparer.OrdinalIgnoreCase));
+
+    private static bool HasSameActivationShape(ActivePackageDescriptor existing, ActivePackageDescriptor next) =>
+        string.Equals(existing.Version, next.Version, StringComparison.OrdinalIgnoreCase) &&
+        string.Equals(existing.FeedName, next.FeedName, StringComparison.Ordinal) &&
+        string.Equals(existing.SourceName, next.SourceName, StringComparison.Ordinal) &&
+        string.Equals(existing.InstallPath, next.InstallPath, StringComparison.Ordinal) &&
+        string.Equals(existing.GraphId, next.GraphId, StringComparison.OrdinalIgnoreCase) &&
+        string.Equals(existing.GraphGenerationId, next.GraphGenerationId, StringComparison.OrdinalIgnoreCase) &&
+        existing.PackageRole == next.PackageRole &&
+        existing.Discoverable == next.Discoverable &&
+        existing.RootPackageIds.SequenceEqual(next.RootPackageIds, StringComparer.OrdinalIgnoreCase) &&
+        existing.DependencyOfPackageIds.SequenceEqual(next.DependencyOfPackageIds, StringComparer.OrdinalIgnoreCase);
 
     public static ActivePackagesSnapshot MapSnapshot(StoreStateRecord state, string correlationId)
     {
@@ -207,7 +234,7 @@ internal static class ActivePackageCatalogMapper
             graphNode.Role,
             graphNode.RootPackageIds,
             graphNode.DependencyOfPackageIds,
-            Discoverable: true);
+            Discoverable: graphNode.Role is not ActivePackageRole.Dependency);
     }
 
     private static IReadOnlyDictionary<string, GraphNodeProjection> BuildGraphNodesByPackageId(IReadOnlyList<ResolvedPackageGraph> graphs)

--- a/src/Nuplane/Operational/ActivePackageCatalogMapper.cs
+++ b/src/Nuplane/Operational/ActivePackageCatalogMapper.cs
@@ -171,11 +171,21 @@ internal static class ActivePackageCatalogMapper
         string.Equals(existing.SourceName, next.SourceName, StringComparison.Ordinal) &&
         string.Equals(existing.InstallPath, next.InstallPath, StringComparison.Ordinal) &&
         string.Equals(existing.GraphId, next.GraphId, StringComparison.OrdinalIgnoreCase) &&
-        string.Equals(existing.GraphGenerationId, next.GraphGenerationId, StringComparison.OrdinalIgnoreCase) &&
+        HasSameGraphGeneration(existing, next) &&
         existing.PackageRole == next.PackageRole &&
         existing.Discoverable == next.Discoverable &&
         SetEquals(existing.RootPackageIds, next.RootPackageIds) &&
         SetEquals(existing.DependencyOfPackageIds, next.DependencyOfPackageIds);
+
+    private static bool HasSameGraphGeneration(ActivePackageDescriptor existing, ActivePackageDescriptor next) =>
+        IsLegacyRootDescriptor(existing) && IsLegacyRootDescriptor(next) ||
+        string.Equals(existing.GraphGenerationId, next.GraphGenerationId, StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsLegacyRootDescriptor(ActivePackageDescriptor descriptor) =>
+        string.Equals(descriptor.GraphId, descriptor.PackageId, StringComparison.OrdinalIgnoreCase) &&
+        descriptor.PackageRole == ActivePackageRole.Root &&
+        SetEquals(descriptor.RootPackageIds, [descriptor.PackageId]) &&
+        !descriptor.DependencyOfPackageIds.Any();
 
     private static bool SetEquals(IEnumerable<string> left, IEnumerable<string> right) =>
         left.ToHashSet(StringComparer.OrdinalIgnoreCase).SetEquals(right);

--- a/test/Nuplane.Runtime.Tests/Operational/ActivePackageGraphMetadataTests.cs
+++ b/test/Nuplane.Runtime.Tests/Operational/ActivePackageGraphMetadataTests.cs
@@ -75,7 +75,7 @@ public sealed class ActivePackageGraphMetadataTests
     }
 
     [Fact]
-    public void BuildNextDescriptors_WithDependencyGraph_KeepsDependencyNodesDiscoverable()
+    public void BuildNextDescriptors_WithDependencyGraph_MarksDependencyNodesSupportOnly()
     {
         var activatedAtUtc = DateTimeOffset.Parse("2026-05-05T10:00:00Z");
         var state = new StoreStateRecord(
@@ -114,7 +114,59 @@ public sealed class ActivePackageGraphMetadataTests
 
         var dependencyDescriptor = descriptors["Plugin.Dependency"];
         Assert.Equal(ActivePackageRole.Dependency, dependencyDescriptor.PackageRole);
-        Assert.True(dependencyDescriptor.Discoverable);
+        Assert.False(dependencyDescriptor.Discoverable);
+    }
+
+    [Fact]
+    public void BuildNextDescriptors_WhenExistingDescriptorHasStaleDiscoverability_UpdatesGraphMetadata()
+    {
+        var activatedAtUtc = DateTimeOffset.Parse("2026-05-05T10:00:00Z");
+        var root = new ResolvedPackage("Plugin.Root", "1.0.0", "feed-a", "/packages/root", activatedAtUtc, "source-a");
+        var dependency = new ResolvedPackage("Plugin.Dependency", "1.0.0", "feed-a", "/packages/dependency", activatedAtUtc, "dependency-of:Plugin.Root");
+        var currentState = StoreStateRecord.Empty() with
+        {
+            ActivePackageDescriptorsById = new(StringComparer.OrdinalIgnoreCase)
+            {
+                [dependency.Id] = new(
+                    dependency.Id,
+                    dependency.Version,
+                    "feed-a",
+                    "dependency-of:Plugin.Root",
+                    dependency.InstallPath,
+                    activatedAtUtc,
+                    "corr-old",
+                    "graph-old",
+                    "generation-old",
+                    ActivePackageRole.Dependency,
+                    [root.Id],
+                    [root.Id],
+                    Discoverable: true)
+            }
+        };
+        var graph = Graph(
+            "graph-new",
+            "generation-new",
+            root,
+            dependency,
+            Node(dependency, PackageNodeRole.Dependency));
+
+        var descriptors = ActivePackageCatalogMapper.BuildNextDescriptors(
+            currentState,
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                [root.Id] = root.Version,
+                [dependency.Id] = dependency.Version
+            },
+            [root, dependency],
+            new PackageChangeSet([], [], [], "corr-new", activatedAtUtc),
+            "corr-new",
+            activatedAtUtc,
+            [graph]);
+
+        var descriptor = descriptors[dependency.Id];
+        Assert.Equal("graph-new", descriptor.GraphId);
+        Assert.Equal("generation-new", descriptor.GraphGenerationId);
+        Assert.False(descriptor.Discoverable);
     }
 
     [Fact]
@@ -197,6 +249,60 @@ public sealed class ActivePackageGraphMetadataTests
         Assert.Equal("2.0.0", record.NodeVersionsByPackageId!["Plugin.Dependency"]);
     }
 
+    [Fact]
+    public void BuildActiveGraphRecords_WhenSameRootSetResolvesExpandedGraph_ReplacesStaleGraphRecord()
+    {
+        var activatedAtUtc = DateTimeOffset.Parse("2026-05-05T10:00:00Z");
+        var root = new ResolvedPackage("Plugin.Root", "1.0.0", "feed-a", "/packages/root", activatedAtUtc, "source-a");
+        var dependency = new ResolvedPackage("Plugin.Dependency", "1.0.0", "feed-a", "/packages/dependency", activatedAtUtc, "source-a");
+        var support = new ResolvedPackage("Plugin.Support", "1.0.0", "feed-a", "/packages/support", activatedAtUtc, "source-a");
+        var oldGraph = Graph("graph-old", "generation-old", root, [dependency]);
+        var newGraph = Graph("graph-new", "generation-new", root, [dependency, support]);
+        var currentState = StateWithActiveGraph(oldGraph, activatedAtUtc);
+
+        var records = ActivePackageCatalogMapper.BuildActiveGraphRecords(
+            currentState,
+            [newGraph],
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                [root.Id] = root.Version,
+                [dependency.Id] = dependency.Version,
+                [support.Id] = support.Version
+            },
+            "corr-new",
+            activatedAtUtc);
+
+        var record = Assert.Single(records).Value;
+        Assert.Equal("graph-new", record.GraphId);
+        Assert.Equal([root.Id, dependency.Id, support.Id], record.NodePackageIds);
+    }
+
+    [Fact]
+    public void BuildActiveGraphRecords_WhenSameRootSetResolvedGraphIsNotActive_PreservesLastKnownGoodGraphRecord()
+    {
+        var activatedAtUtc = DateTimeOffset.Parse("2026-05-05T10:00:00Z");
+        var root = new ResolvedPackage("Plugin.Root", "1.0.0", "feed-a", "/packages/root", activatedAtUtc, "source-a");
+        var dependency = new ResolvedPackage("Plugin.Dependency", "1.0.0", "feed-a", "/packages/dependency", activatedAtUtc, "source-a");
+        var support = new ResolvedPackage("Plugin.Support", "1.0.0", "feed-a", "/packages/support", activatedAtUtc, "source-a");
+        var oldGraph = Graph("graph-old", "generation-old", root, [dependency]);
+        var newGraph = Graph("graph-new", "generation-new", root, [dependency, support]);
+        var currentState = StateWithActiveGraph(oldGraph, activatedAtUtc);
+
+        var records = ActivePackageCatalogMapper.BuildActiveGraphRecords(
+            currentState,
+            [newGraph],
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                [root.Id] = root.Version,
+                [dependency.Id] = dependency.Version
+            },
+            "corr-new",
+            activatedAtUtc);
+
+        var record = Assert.Single(records).Value;
+        Assert.Equal("graph-old", record.GraphId);
+    }
+
     private static ResolvedPackageNode Node(ResolvedPackage package, PackageNodeRole role) =>
         new(
             package.Id,
@@ -228,4 +334,53 @@ public sealed class ActivePackageGraphMetadataTests
             [],
             DateTimeOffset.Parse("2026-05-05T10:00:00Z"));
     }
+
+    private static ResolvedPackageGraph Graph(
+        string graphId,
+        string generationId,
+        ResolvedPackage root,
+        IReadOnlyList<ResolvedPackage> dependencies)
+    {
+        var rootNode = Node(root, PackageNodeRole.Root);
+        var dependencyNodes = dependencies
+            .Select(static package => Node(package, PackageNodeRole.Dependency))
+            .ToArray();
+        var nodes = new[] { rootNode }
+            .Concat(dependencyNodes)
+            .ToArray();
+        var edges = dependencies
+            .Select((dependency, index) =>
+            {
+                var parent = index == 0 ? root : dependencies[index - 1];
+                return new DependencyEdge(parent.Id, parent.Version, dependency.Id, "[1.0.0, )", dependency.Version, "net10.0", Optional: false);
+            })
+            .ToArray();
+
+        return new(
+            graphId,
+            generationId,
+            "net10.0",
+            [rootNode],
+            nodes,
+            edges,
+            [],
+            DateTimeOffset.Parse("2026-05-05T10:00:00Z"));
+    }
+
+    private static StoreStateRecord StateWithActiveGraph(ResolvedPackageGraph graph, DateTimeOffset activatedAtUtc) =>
+        StoreStateRecord.Empty() with
+        {
+            ActiveGraphsById = new(StringComparer.OrdinalIgnoreCase)
+            {
+                [graph.GraphId] = new(
+                    graph.GraphId,
+                    graph.GenerationId,
+                    graph.Roots.Select(static node => node.PackageId).ToArray(),
+                    graph.Nodes.Select(static node => node.PackageId).ToArray(),
+                    activatedAtUtc,
+                    "corr-old",
+                    GraphActivationStatus.Active,
+                    NodeVersionsByPackageId: graph.Nodes.ToDictionary(static node => node.PackageId, static node => node.Version, StringComparer.OrdinalIgnoreCase))
+            }
+        };
 }

--- a/test/Nuplane.Runtime.Tests/Operational/ActivePackageGraphMetadataTests.cs
+++ b/test/Nuplane.Runtime.Tests/Operational/ActivePackageGraphMetadataTests.cs
@@ -47,6 +47,49 @@ public sealed class ActivePackageGraphMetadataTests
     }
 
     [Fact]
+    public void BuildNextDescriptors_WhenLegacyRootPackageIsUnchanged_PreservesExistingActivation()
+    {
+        var activatedAtUtc = DateTimeOffset.Parse("2026-05-05T10:00:00Z");
+        var resolvedPackage = new ResolvedPackage(
+            "Plugin.Root",
+            "1.0.0",
+            "feed-a",
+            "/packages/root",
+            activatedAtUtc,
+            "source-a");
+        var currentState = StoreStateRecord.Empty() with
+        {
+            ActivePackageDescriptorsById = new(StringComparer.OrdinalIgnoreCase)
+            {
+                [resolvedPackage.Id] = new(
+                    resolvedPackage.Id,
+                    resolvedPackage.Version,
+                    resolvedPackage.FeedName,
+                    resolvedPackage.SourceName,
+                    resolvedPackage.InstallPath,
+                    activatedAtUtc,
+                    "corr-old")
+            }
+        };
+
+        var descriptors = ActivePackageCatalogMapper.BuildNextDescriptors(
+            currentState,
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                [resolvedPackage.Id] = resolvedPackage.Version
+            },
+            [resolvedPackage],
+            new PackageChangeSet([], [], [], "corr-new", activatedAtUtc.AddMinutes(1)),
+            "corr-new",
+            activatedAtUtc.AddMinutes(1));
+
+        var descriptor = Assert.Single(descriptors).Value;
+        Assert.Equal("corr-old", descriptor.ActivationCorrelationId);
+        Assert.Equal("corr-old", descriptor.GraphGenerationId);
+        Assert.Equal(activatedAtUtc, descriptor.ActivatedAtUtc);
+    }
+
+    [Fact]
     public void ToActivePackage_WithDependencyDescriptor_PreservesGraphMetadata()
     {
         var descriptor = new ActivePackageDescriptor(

--- a/test/Nuplane.Runtime.Tests/Operational/ActivePackageGraphMetadataTests.cs
+++ b/test/Nuplane.Runtime.Tests/Operational/ActivePackageGraphMetadataTests.cs
@@ -170,6 +170,56 @@ public sealed class ActivePackageGraphMetadataTests
     }
 
     [Fact]
+    public void BuildNextDescriptors_WhenExistingDescriptorHasSameMetadataInDifferentOrder_PreservesExistingActivation()
+    {
+        var activatedAtUtc = DateTimeOffset.Parse("2026-05-05T10:00:00Z");
+        var rootA = new ResolvedPackage("Plugin.RootA", "1.0.0", "feed-a", "/packages/root-a", activatedAtUtc, "source-a");
+        var rootB = new ResolvedPackage("Plugin.RootB", "1.0.0", "feed-a", "/packages/root-b", activatedAtUtc, "source-a");
+        var dependency = new ResolvedPackage("Plugin.Dependency", "1.0.0", "feed-a", "/packages/dependency", activatedAtUtc, "source-a");
+        var dependencyNode = Node(dependency, PackageNodeRole.Dependency);
+        var graphA = Graph("graph-a", "generation-a", rootA, dependency, dependencyNode);
+        var graphB = Graph("graph-b", "generation-b", rootB, dependency, dependencyNode);
+        var currentState = StoreStateRecord.Empty() with
+        {
+            ActivePackageDescriptorsById = new(StringComparer.OrdinalIgnoreCase)
+            {
+                [dependency.Id] = new(
+                    dependency.Id,
+                    dependency.Version,
+                    "feed-a",
+                    "source-a",
+                    dependency.InstallPath,
+                    activatedAtUtc,
+                    "corr-old",
+                    "graph-a",
+                    "generation-a",
+                    ActivePackageRole.Dependency,
+                    [rootB.Id, rootA.Id],
+                    [rootB.Id, rootA.Id],
+                    Discoverable: false)
+            }
+        };
+
+        var descriptors = ActivePackageCatalogMapper.BuildNextDescriptors(
+            currentState,
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                [rootA.Id] = rootA.Version,
+                [rootB.Id] = rootB.Version,
+                [dependency.Id] = dependency.Version
+            },
+            [rootA, rootB, dependency],
+            new PackageChangeSet([], [], [], "corr-new", activatedAtUtc.AddMinutes(1)),
+            "corr-new",
+            activatedAtUtc.AddMinutes(1),
+            [graphA, graphB]);
+
+        var descriptor = descriptors[dependency.Id];
+        Assert.Equal("corr-old", descriptor.ActivationCorrelationId);
+        Assert.Equal(activatedAtUtc, descriptor.ActivatedAtUtc);
+    }
+
+    [Fact]
     public void BuildNextDescriptors_WithSharedDependency_PreservesFirstGraphAndMergesParents()
     {
         var activatedAtUtc = DateTimeOffset.Parse("2026-05-05T10:00:00Z");


### PR DESCRIPTION
## Summary

- Replace stale active graph records when a newly publishable graph has the same desired root set.
- Refresh active package descriptors when graph metadata or discoverability changes, even if package version/path stayed the same.
- Mark dependency-only graph nodes as support-only for discovery again, matching the dependency closure spec.

## Root Cause

Nuplane retained older active graph records as long as their node package IDs and versions still existed in the next active set. After resolver behavior changed, a stale graph with an incomplete dependency closure could survive beside the newly resolved graph for the same root package set. Active descriptors could also keep stale discoverability metadata because unchanged package version/path skipped descriptor replacement.

## Validation

- `dotnet test test/Nuplane.Runtime.Tests/Nuplane.Runtime.Tests.csproj --configuration Release`
- `dotnet test test/Nuplane.Loading.Tests/Nuplane.Loading.Tests.csproj --configuration Release --no-restore`
