### PR TITLE
Skip host runtime assemblies during package loading

### DIFF
--- a/src/Nuplane.Loading/PackageLoader.cs
+++ b/src/Nuplane.Loading/PackageLoader.cs
@@ -150,6 +150,16 @@ internal sealed class PackageLoader : IPackageLoader
             try
             {
                 var mainAssemblyPath = ResolveMainAssemblyPath(package.InstallPath, package.Id);
+                if (HostRuntimeAssemblyCatalog.Contains(mainAssemblyPath))
+                {
+                    _logger.LogInformation(
+                        "Skipped package {PackageId}@{Version} because assembly {AssemblyPath} is provided by the host runtime.",
+                        package.Id,
+                        package.Version,
+                        mainAssemblyPath);
+                    continue;
+                }
+
                 var context = new PackageAssemblyLoadContext(mainAssemblyPath, sharedPolicy, _matcher);
                 var assemblyName = AssemblyName.GetAssemblyName(mainAssemblyPath);
                 context.LoadFromAssemblyName(assemblyName);
@@ -373,11 +383,23 @@ internal sealed class PackageLoader : IPackageLoader
         {
             try
             {
+                var mainAssemblyPath = ResolveMainAssemblyPath(package.InstallPath, package.Id);
+                if (HostRuntimeAssemblyCatalog.Contains(mainAssemblyPath))
+                {
+                    skippedPackages.Add(new(package.Id, package.Version, package.InstallPath));
+                    _logger.LogInformation(
+                        "Skipped package {PackageId}@{Version} in graph because assembly {AssemblyPath} is provided by the host runtime.",
+                        package.Id,
+                        package.Version,
+                        mainAssemblyPath);
+                    continue;
+                }
+
                 loadablePackages.Add(new(
                     package.Id,
                     package.Version,
                     package.InstallPath,
-                    ResolveMainAssemblyPath(package.InstallPath, package.Id)));
+                    mainAssemblyPath));
             }
             catch (NoLoadableAssemblyException ex)
             {
@@ -804,6 +826,61 @@ internal sealed class PackageLoader : IPackageLoader
     private sealed record LoadedGraphCacheEntry(
         PackageLoadMode LoadMode,
         IReadOnlyList<string> LoadablePackageKeys);
+
+    private static class HostRuntimeAssemblyCatalog
+    {
+        private static readonly Lazy<IReadOnlySet<string>> AssemblyNames = new(LoadAssemblyNames);
+
+        public static bool Contains(string assemblyPath)
+        {
+            try
+            {
+                var assemblyName = AssemblyName.GetAssemblyName(assemblyPath).Name;
+                return !string.IsNullOrWhiteSpace(assemblyName) &&
+                    IsHostFrameworkAssemblyName(assemblyName) &&
+                    AssemblyNames.Value.Contains(assemblyName);
+            }
+            catch (Exception ex) when (ex is BadImageFormatException or FileNotFoundException or FileLoadException)
+            {
+                return false;
+            }
+        }
+
+        private static bool IsHostFrameworkAssemblyName(string? assemblyName) =>
+            !string.IsNullOrWhiteSpace(assemblyName) &&
+            (assemblyName.StartsWith("System.", StringComparison.OrdinalIgnoreCase) ||
+                assemblyName.StartsWith("Microsoft.Extensions.", StringComparison.OrdinalIgnoreCase) ||
+                assemblyName.Equals("Microsoft.CSharp", StringComparison.OrdinalIgnoreCase) ||
+                assemblyName.Equals("mscorlib", StringComparison.OrdinalIgnoreCase) ||
+                assemblyName.Equals("netstandard", StringComparison.OrdinalIgnoreCase));
+
+        private static IReadOnlySet<string> LoadAssemblyNames()
+        {
+            var assemblyNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var trustedPlatformAssemblies = AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string;
+            if (string.IsNullOrWhiteSpace(trustedPlatformAssemblies))
+            {
+                return assemblyNames;
+            }
+
+            foreach (var path in trustedPlatformAssemblies.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries))
+            {
+                try
+                {
+                    var assemblyName = AssemblyName.GetAssemblyName(path).Name;
+                    if (!string.IsNullOrWhiteSpace(assemblyName))
+                    {
+                        assemblyNames.Add(assemblyName);
+                    }
+                }
+                catch (Exception ex) when (ex is BadImageFormatException or FileNotFoundException or FileLoadException)
+                {
+                }
+            }
+
+            return assemblyNames;
+        }
+    }
 
     private sealed class NoLoadableAssemblyException(string message) : FileNotFoundException(message);
 

--- a/src/Nuplane.Loading/PackageLoader.cs
+++ b/src/Nuplane.Loading/PackageLoader.cs
@@ -232,6 +232,11 @@ internal sealed class PackageLoader : IPackageLoader
 
             if (graphPackages.LoadablePackages.Count == 0)
             {
+                if (graphPackages.SkippedPackages.Count == 0 && graphPackages.HostRuntimePackages.Count > 0)
+                {
+                    return new(loaded, failed);
+                }
+
                 throw new NoLoadableAssemblyException(
                     $"No loadable assembly found in graph '{graphKey}'. Scanned install paths: {FormatQuotedList(graphPackages.SkippedInstallPaths)}.");
             }
@@ -376,6 +381,7 @@ internal sealed class PackageLoader : IPackageLoader
     {
         var loadablePackages = new List<LoadableGraphPackage>(packages.Count);
         var skippedPackages = new List<GraphPackage>();
+        var hostRuntimePackages = new List<GraphPackage>();
         var failedPackages = new List<GraphPackage>();
         Exception? resolutionFailure = null;
 
@@ -386,7 +392,7 @@ internal sealed class PackageLoader : IPackageLoader
                 var mainAssemblyPath = ResolveMainAssemblyPath(package.InstallPath, package.Id);
                 if (HostRuntimeAssemblyCatalog.Contains(mainAssemblyPath))
                 {
-                    skippedPackages.Add(new(package.Id, package.Version, package.InstallPath));
+                    hostRuntimePackages.Add(new(package.Id, package.Version, package.InstallPath));
                     _logger.LogInformation(
                         "Skipped package {PackageId}@{Version} in graph because assembly {AssemblyPath} is provided by the host runtime.",
                         package.Id,
@@ -418,7 +424,7 @@ internal sealed class PackageLoader : IPackageLoader
             }
         }
 
-        return new(loadablePackages, skippedPackages, failedPackages, resolutionFailure);
+        return new(loadablePackages, skippedPackages, hostRuntimePackages, failedPackages, resolutionFailure);
     }
 
     private void UnloadUnreferencedContexts(IEnumerable<AssemblyLoadContext> contexts)
@@ -817,6 +823,7 @@ internal sealed class PackageLoader : IPackageLoader
     private sealed record GraphPackageResolution(
         IReadOnlyList<LoadableGraphPackage> LoadablePackages,
         IReadOnlyList<GraphPackage> SkippedPackages,
+        IReadOnlyList<GraphPackage> HostRuntimePackages,
         IReadOnlyList<GraphPackage> FailedPackages,
         Exception? ResolutionFailure)
     {

--- a/test/Nuplane.Loading.Tests/PackageLoaderGraphRegressionTests.cs
+++ b/test/Nuplane.Loading.Tests/PackageLoaderGraphRegressionTests.cs
@@ -138,6 +138,22 @@ public sealed class PackageLoaderGraphRegressionTests : IDisposable
     }
 
     [Fact]
+    public async Task EnsureGraphLoadedAsync_GraphWithOnlyHostRuntimeAssemblies_DoesNotReportFailures()
+    {
+        var systemMemoryInstall = CreateHostRuntimeAssemblyPackageInstall("System.Memory");
+        var loader = new PackageLoader();
+
+        var result = await loader.EnsureGraphLoadedAsync(
+            [[new ResolvedPackage("System.Memory", "4.5.3", "test-feed", systemMemoryInstall, DateTimeOffset.UtcNow, "test-source")]],
+            [],
+            CancellationToken.None);
+
+        Assert.Empty(result.Loaded);
+        Assert.Empty(result.FailedByPackageId);
+        Assert.Empty(loader.Sessions);
+    }
+
+    [Fact]
     public async Task EnsureGraphLoadedAsync_LoadablePackageWithNoAssemblyDependency_ReusesExistingGraphSession()
     {
         var rootInstall = CreatePackageInstall("Plugin.Root", "Plugin.Root.dll");

--- a/test/Nuplane.Loading.Tests/PackageLoaderGraphRegressionTests.cs
+++ b/test/Nuplane.Loading.Tests/PackageLoaderGraphRegressionTests.cs
@@ -115,6 +115,29 @@ public sealed class PackageLoaderGraphRegressionTests : IDisposable
     }
 
     [Fact]
+    public async Task EnsureGraphLoadedAsync_HostRuntimeAssemblyPackage_SkipsDependencyWithoutLoadingRuntimeFacade()
+    {
+        var rootInstall = CreatePackageInstall("Plugin.Root", "Plugin.Root.dll");
+        var systemMemoryInstall = CreateHostRuntimeAssemblyPackageInstall("System.Memory");
+        var loader = new PackageLoader();
+
+        var result = await loader.EnsureGraphLoadedAsync(
+            [[
+                new ResolvedPackage("Plugin.Root", "1.0.0", "test-feed", rootInstall, DateTimeOffset.UtcNow, "test-source"),
+                new ResolvedPackage("System.Memory", "4.5.3", "test-feed", systemMemoryInstall, DateTimeOffset.UtcNow, "dependency-of:Plugin.Root")
+            ]],
+            [],
+            CancellationToken.None);
+
+        var loaded = Assert.Single(result.Loaded);
+        Assert.Equal("Plugin.Root", loaded.PackageId);
+        Assert.Empty(result.FailedByPackageId);
+        Assert.True(loader.TryGetContext("Plugin.Root", "1.0.0", out _));
+        Assert.False(loader.TryGetContext("System.Memory", "4.5.3", out _));
+        Assert.DoesNotContain("System.Memory@4.5.3", loader.Sessions.Keys, StringComparer.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public async Task EnsureGraphLoadedAsync_LoadablePackageWithNoAssemblyDependency_ReusesExistingGraphSession()
     {
         var rootInstall = CreatePackageInstall("Plugin.Root", "Plugin.Root.dll");
@@ -211,6 +234,31 @@ public sealed class PackageLoaderGraphRegressionTests : IDisposable
         Directory.CreateDirectory(libPath);
         File.Copy(FindFixtureAssembly(assemblyFileName), Path.Combine(libPath, assemblyFileName), overwrite: true);
         return installPath;
+    }
+
+    private string CreatePackageInstall(string packageId, string assemblyFileName, string sourceAssembly)
+    {
+        var installPath = Path.Combine(tempRoot, packageId, "1.0.0");
+        var libPath = Path.Combine(installPath, "lib", "net10.0");
+        Directory.CreateDirectory(libPath);
+        File.Copy(sourceAssembly, Path.Combine(libPath, assemblyFileName), overwrite: true);
+        return installPath;
+    }
+
+    private string CreateHostRuntimeAssemblyPackageInstall(string assemblyName) =>
+        CreatePackageInstall(assemblyName, $"{assemblyName}.dll", FindHostRuntimeAssembly(assemblyName));
+
+    private static string FindHostRuntimeAssembly(string assemblyName)
+    {
+        var trustedPlatformAssemblies = AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string;
+        Assert.False(string.IsNullOrWhiteSpace(trustedPlatformAssemblies));
+
+        var path = trustedPlatformAssemblies
+            .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries)
+            .FirstOrDefault(path => string.Equals(Path.GetFileNameWithoutExtension(path), assemblyName, StringComparison.OrdinalIgnoreCase));
+
+        Assert.False(string.IsNullOrWhiteSpace(path));
+        return path!;
     }
 
     private string CreateFlatPackageInstall(string packageId, string assemblyFileName)


### PR DESCRIPTION
## Summary

- Skip package assemblies that duplicate framework/runtime assemblies already present in the trusted platform assembly set.
- Keep the guard narrow to framework-style assembly names such as `System.*`, `Microsoft.Extensions.*`, `netstandard`, and related runtime assemblies.
- Add a regression proving a graph dependency on `System.Memory` does not load the package copy or create a Nuplane load session.

## Root Cause

A NuGet graph can contain packages like `System.Memory`. Loading those assemblies into a package graph ALC, including a noncollectible host-integrated graph, splits runtime type identity for signatures such as `ReadOnlySpan<T>`. In the SQLitePCLRaw graph this surfaces as a misleading `MissingMethodException` for `ISQLite3Provider.sqlite3_key(... ReadOnlySpan<byte>)` even though the SQLitePCLRaw package versions are aligned.

`PackageLoadModes` controls the ALC used for real package assemblies; it cannot make duplicated framework assemblies safe to load privately. Framework/runtime assemblies must be resolved from the host runtime regardless of package load mode.

## Validation

- `dotnet test test/Nuplane.Loading.Tests/Nuplane.Loading.Tests.csproj --configuration Release --no-restore`
- `dotnet test test/Nuplane.Runtime.Tests/Nuplane.Runtime.Tests.csproj --configuration Release --no-restore`
