### PR TITLE
Add automatic package load mode selection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,6 +79,8 @@ Run focused tests first for the area changed, then run the full solution when pr
 - C# with SDK-style .NET libraries targeting `net8.0;net9.0;net10.0`; tests target `net10.0`.
 - Microsoft.Extensions.DependencyInjection/Options/Logging/Hosting, NuGet.Protocol, NuGet.Versioning, System.Runtime.Loader, xUnit, and NSubstitute.
 - File-backed Nuplane store state and package install directories under configured state/package roots; no database.
+- C# with SDK-style .NET libraries targeting `net8.0;net9.0;net10.0`; tests target `net10.0` + Microsoft.Extensions.DependencyInjection, Microsoft.Extensions.Options, Microsoft.Extensions.Logging, System.Text.Json, System.Runtime.Loader, existing Nuplane graph/loading abstractions, xUnit, NSubstitute (027-auto-load-mode-selection)
+- Existing file-backed Nuplane package install directories and active package state; metadata is read from extracted package-root `nuplane.json`; no database or durable state format change required for v1 (027-auto-load-mode-selection)
 
 ## Recent Changes
 - 017-dependency-closure-loading: Added C# with SDK-style .NET libraries targeting `net8.0;net9.0;net10.0`; tests target `net10.0` + Microsoft.Extensions.DependencyInjection/Options/Logging/Hosting, NuGet.Protocol and NuGet.Versioning already used by feed version resolution, System.Runtime.Loader, xUnit, NSubstitute

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,9 +78,7 @@ Run focused tests first for the area changed, then run the full solution when pr
 ## Active Technologies
 - C# with SDK-style .NET libraries targeting `net8.0;net9.0;net10.0`; tests target `net10.0`.
 - Microsoft.Extensions.DependencyInjection/Options/Logging/Hosting, NuGet.Protocol, NuGet.Versioning, System.Runtime.Loader, xUnit, and NSubstitute.
-- File-backed Nuplane store state and package install directories under configured state/package roots; no database.
-- C# with SDK-style .NET libraries targeting `net8.0;net9.0;net10.0`; tests target `net10.0` + Microsoft.Extensions.DependencyInjection, Microsoft.Extensions.Options, Microsoft.Extensions.Logging, System.Text.Json, System.Runtime.Loader, existing Nuplane graph/loading abstractions, xUnit, NSubstitute (027-auto-load-mode-selection)
-- Existing file-backed Nuplane package install directories and active package state; metadata is read from extracted package-root `nuplane.json`; no database or durable state format change required for v1 (027-auto-load-mode-selection)
+- File-backed Nuplane store state and package install directories under configured state/package roots; package metadata is read from extracted package-root `nuplane.json`; no database.
 
 ## Recent Changes
 - 017-dependency-closure-loading: Added C# with SDK-style .NET libraries targeting `net8.0;net9.0;net10.0`; tests target `net10.0` + Microsoft.Extensions.DependencyInjection/Options/Logging/Hosting, NuGet.Protocol and NuGet.Versioning already used by feed version resolution, System.Runtime.Loader, xUnit, NSubstitute

--- a/README.md
+++ b/README.md
@@ -148,6 +148,23 @@ Nuplane supports two package load modes:
 Shared assemblies remain a separate policy: they solve contract/type identity by resolving selected abstractions from the host/default context, but they do not by themselves make package assemblies framework-integrated or resolvable by name.
 Nuplane can manage shared contract assemblies, deactivation timeout, unload coordination for collectible packages, and host-integrated assembly-name resolution, but your host still decides what loaded types mean.
 
+Load mode can be selected automatically. Nuplane resolves package graphs first, evaluates load-mode advisors, and promotes a graph to `HostIntegrated` when a package declares a host-integration requirement. Explicit `PackageLoadModes` overrides remain authoritative, and packages without overrides or metadata keep using `DefaultLoadMode`.
+
+Package authors can declare Nuplane loading metadata once in package-root `nuplane.json`:
+
+```json
+{
+  "schemaVersion": 1,
+  "loading": {
+    "loadMode": "HostIntegrated",
+    "scope": "DependencyClosure",
+    "reason": "Uses framework type resolution and runtime scheduler integration."
+  }
+}
+```
+
+Nuplane reads this metadata only from packages that have already been resolved and installed through the configured source and integrity paths. Metadata is trusted only as much as the package itself; it does not bypass source trust, package validation, or host-owned activation decisions.
+
 ### Module registration
 
 Each optional Nuplane module (loading, directory-source) provides its own direct `IServiceCollection` registration extension.
@@ -214,6 +231,7 @@ builder.Services.AddNuplane(nuplaneConfiguration, nuplane =>
     "Loading": {
       "Enabled": true,
       "DefaultLoadMode": "Collectible",
+      "LoadModeSelectionPolicy": "Automatic",
       "PackageLoadModes": [
         {
           "PackageId": "Elsa.Persistence.EFCore.PostgreSql",
@@ -285,6 +303,7 @@ Nuplane has two configuration layers:
   - `DeactivationTimeout`
   - `ActiveStoreRoot`
   - `DefaultLoadMode`
+  - `LoadModeSelectionPolicy`
   - `PackageLoadModes`
   - `SharedAssemblies`
 

--- a/docs/wiki/Concepts-and-Glossary.md
+++ b/docs/wiki/Concepts-and-Glossary.md
@@ -99,8 +99,36 @@ The loading setting that controls package assembly lifetime and framework integr
 `Collectible` keeps the existing unloadable/isolation-oriented behavior, while `HostIntegrated` makes active package assemblies safe for application-lifetime framework integration and by-name resolution.
 
 - **Applicability:** `Optional Module`
-- Applied in: [Usage Guide](Usage-Guide.md)
+- Applied in: [Usage Guide](Usage-Guide.md), [Package Authoring](Package-Authoring.md)
 - Canonical anchors: `README.md`, `src/Nuplane.Loading.Abstractions/PackageLoadMode.cs`
+
+### Automatic load-mode selection
+
+The loading policy that evaluates resolved package graphs through load-mode advisors before falling back to `DefaultLoadMode`.
+Automatic selection keeps effective runtime modes concrete: packages still load as `Collectible` or `HostIntegrated`, never as an `Auto` runtime mode.
+
+- **Applicability:** `Optional Module`
+- Applied in: [Usage Guide](Usage-Guide.md), [Package Authoring](Package-Authoring.md)
+- Canonical anchors: `src/Nuplane.Loading.Abstractions/PackageLoadModeSelectionPolicy.cs`, `src/Nuplane.Loading/PackageLoadModeSelector.cs`
+
+### Package load-mode advisor
+
+An extension point that inspects an already-resolved package graph and returns deterministic, secret-safe load-mode requirements or diagnostics.
+The built-in advisor reads Nuplane package metadata; future advisors can inspect other package or runtime metadata without hard-coding package IDs in core loading logic.
+
+- **Applicability:** `Optional Module`
+- Applied in: [Usage Guide](Usage-Guide.md), [Package Authoring](Package-Authoring.md)
+- Canonical anchors: `src/Nuplane.Loading.Abstractions/IPackageLoadModeAdvisor.cs`
+
+### Nuplane package metadata
+
+Package-authored metadata stored in package-root `nuplane.json`.
+For loading, the v1 schema supports `schemaVersion`, `loading.loadMode`, `loading.scope`, and optional `loading.reason`.
+Metadata is trusted only as much as the package itself and does not bypass source trust, integrity validation, or host-owned activation semantics.
+
+- **Applicability:** `Optional Module`
+- Applied in: [Usage Guide](Usage-Guide.md), [Package Authoring](Package-Authoring.md)
+- Canonical anchors: `README.md`, `specs/027-auto-load-mode-selection/spec.md`
 
 ### Host-integrated assembly
 

--- a/docs/wiki/Package-Authoring.md
+++ b/docs/wiki/Package-Authoring.md
@@ -1,0 +1,58 @@
+# Package Authoring
+
+## Purpose
+
+This page gives package authors the Nuplane-specific metadata shape for packages that need predictable runtime loading behavior.
+
+## Load-mode metadata
+
+Packages that require framework/default assembly load context integration can declare that requirement once in package-root `nuplane.json`:
+
+```json
+{
+  "schemaVersion": 1,
+  "loading": {
+    "loadMode": "HostIntegrated",
+    "scope": "DependencyClosure",
+    "reason": "Uses framework type resolution and runtime scheduler integration."
+  }
+}
+```
+
+Place the file at the root of the NuGet package next to the package contents. Nuplane v1 loading metadata is not discovered from `build/`, `contentFiles/`, or nuspec metadata.
+
+Allowed values:
+
+- `schemaVersion`: `1`
+- `loading.loadMode`: `HostIntegrated` or `Collectible`
+- `loading.scope`: `DependencyClosure` or `PackageOnly`
+- `loading.reason`: optional bounded human-readable explanation
+
+`HostIntegrated` is a requirement. With `DependencyClosure`, Nuplane promotes the loadable graph containing the declaring package so framework services, by-name assembly resolution, provider metadata, schedulers, migrations, and similar long-lived integrations can see the package graph consistently.
+
+`Collectible` is only a preference. It does not force an application down from a `HostIntegrated` default or another package's host-integrated requirement.
+
+## Application overrides
+
+Application authors remain in control. `Loading:PackageLoadModes` overrides win over metadata for the same package, and Nuplane records a suppression diagnostic so operators can see that package metadata was ignored intentionally.
+
+Use metadata for package-owned requirements that every host would otherwise need to rediscover. Use app overrides for deployment-specific policy, temporary migration, or emergency compatibility controls.
+
+## Trust model
+
+Nuplane reads `nuplane.json` only after the package has already been resolved and installed through the configured package source, trust, and integrity paths. Metadata is trusted only as much as the package itself.
+
+Metadata cannot:
+
+- grant additional package source trust;
+- bypass package validation or lock-file policy;
+- mutate package/store state during selection;
+- define host activation semantics;
+- sandbox untrusted package code.
+
+Invalid, unsupported, unreadable, or oversized metadata is ignored for selection and reported through load-mode diagnostics.
+
+## Related pages
+
+- [Usage Guide](Usage-Guide.md)
+- [Concepts and Glossary](Concepts-and-Glossary.md)

--- a/docs/wiki/Usage-Guide.md
+++ b/docs/wiki/Usage-Guide.md
@@ -109,7 +109,24 @@ The sample `Program.cs` is the best concrete repository anchor for this path.
 - Use `Collectible` for isolated plugin discovery, scan-only packages, and scenarios where unloadability matters. It is the default to preserve existing loading behavior.
 - Use `HostIntegrated` for packages that contribute application-lifetime framework types such as DI registrations, endpoints, hosted services, options, validators, or database migrations. Host-integrated package assemblies may remain loaded for the process lifetime.
 - Configure shared assemblies separately from load mode. Shared assemblies preserve contract/type identity; load mode controls package lifetime and whether active package assemblies are made visible to framework by-name resolution.
-- Prefer explicit default and package-specific load mode configuration over auto-detection.
+- Keep `LoadModeSelectionPolicy` at `Automatic` when you want Nuplane to evaluate package-declared metadata before falling back to `DefaultLoadMode`.
+- Use package-specific `PackageLoadModes` overrides when the application must force a package to `HostIntegrated` or `Collectible`; these overrides win over package metadata for the same package.
+- Use `ExplicitOnly` only when you want to ignore package metadata and rely on `DefaultLoadMode` plus explicit package overrides.
+
+Package-authored metadata lives at package-root `nuplane.json`:
+
+```json
+{
+  "schemaVersion": 1,
+  "loading": {
+    "loadMode": "HostIntegrated",
+    "scope": "DependencyClosure",
+    "reason": "Uses framework type resolution and runtime scheduler integration."
+  }
+}
+```
+
+`HostIntegrated` metadata is treated as a requirement and promotes the loadable dependency closure. `Collectible` metadata is only a preference; it never forces a graph down from a host-configured `HostIntegrated` default or another host-integrated requirement.
 
 ## Sample-backed next steps
 

--- a/docs/wiki/_Sidebar.md
+++ b/docs/wiki/_Sidebar.md
@@ -4,6 +4,7 @@
 - [Overview](Overview.md)
 - [Getting Started](Getting-Started.md)
 - [Usage Guide](Usage-Guide.md)
+- [Package Authoring](Package-Authoring.md)
 - [Architecture Guide](Architecture-Guide.md)
 - [Concepts and Glossary](Concepts-and-Glossary.md)
 - [Source References](_Source-References.md)
@@ -12,9 +13,9 @@
 
 - **Evaluator**: [Home](Home.md) → [Overview](Overview.md) → [Getting Started](Getting-Started.md)
 - **Integrator**: [Home](Home.md) → [Overview](Overview.md) → [Getting Started](Getting-Started.md) → [Usage Guide](Usage-Guide.md)
+- **Package author**: [Home](Home.md) → [Usage Guide](Usage-Guide.md) → [Package Authoring](Package-Authoring.md)
 - **Contributor**: [Home](Home.md) → [Overview](Overview.md) → [Architecture Guide](Architecture-Guide.md) → [Concepts and Glossary](Concepts-and-Glossary.md)
 
 ## Governance
 
 - [Source References](_Source-References.md)
-

--- a/specs/027-auto-load-mode-selection/checklists/requirements.md
+++ b/specs/027-auto-load-mode-selection/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Automatic Load Mode Selection
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning  
+**Created**: 2026-05-14  
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details beyond repository-required architectural contract names
+- [x] Focused on user value and business needs
+- [x] Written for maintainers, package authors, app authors, and operators
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic where possible for a runtime library feature
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No speculative implementation work is required by this specification
+
+## Notes
+
+- The spec intentionally names existing Nuplane concepts such as `LoadingOptions`, `PackageLoadModes`, loading catalogs, and dependency-closure promotion because repository Speckit conventions require architecture-facing requirements for implementation planning.
+- Open questions remain for API shape and exact diagnostic surface placement; they are captured in the spec and do not block planning.

--- a/specs/027-auto-load-mode-selection/contracts/automatic-load-mode-selection-contract.md
+++ b/specs/027-auto-load-mode-selection/contracts/automatic-load-mode-selection-contract.md
@@ -1,0 +1,78 @@
+# Contract: Automatic Load Mode Selection
+
+## Scope
+
+This contract defines configuration, advisor, package metadata, selection precedence, loading, diagnostics, and security behavior for automatic package load-mode selection.
+
+## Configuration Contract
+
+1. Loading configuration MUST expose an option-level load-mode selection policy.
+2. The policy MUST support automatic advisor evaluation and explicit-only behavior.
+3. The default policy MUST evaluate advisors and then fall back to `DefaultLoadMode`.
+4. The effective runtime load mode MUST remain `Collectible` or `HostIntegrated`.
+5. `PackageLoadMode.Auto` MUST NOT be introduced as an effective session/catalog mode for this feature.
+6. Existing `DefaultLoadMode` and `PackageLoadModes` settings MUST continue to bind from configuration.
+7. Package-specific `PackageLoadModes` overrides MUST remain highest-precedence per-package inputs.
+8. Invalid policy values MUST fail `LoadingOptions` validation before loading begins.
+
+## Advisor Contract
+
+1. Nuplane MUST expose an `IPackageLoadModeAdvisor` contract from loading abstractions.
+2. Advisors MUST evaluate a resolved package graph context after dependency graph resolution and before package graph loading.
+3. Advisors MUST return bounded, deterministic, secret-safe results.
+4. Advisors MUST NOT mutate package/store state.
+5. Advisors MUST NOT perform network access during load-mode selection.
+6. Advisors MUST NOT bypass source trust, package validation, package identity selection, or desired-state resolution.
+7. The built-in metadata advisor MUST NOT hard-code package IDs or product-specific rules.
+
+## Package Metadata Contract
+
+1. Nuplane v1 package metadata MUST be read only from package-root `nuplane.json`.
+2. Metadata MUST be read only from packages already installed through existing trusted source and integrity paths.
+3. v1 metadata MUST support `schemaVersion`.
+4. v1 metadata MUST support `loading.loadMode`.
+5. v1 metadata MUST support `loading.scope`.
+6. v1 metadata MUST support optional `loading.reason`.
+7. `loading.loadMode` MUST accept `HostIntegrated` and `Collectible`.
+8. `HostIntegrated` metadata MUST be treated as a requirement.
+9. `Collectible` metadata MUST be treated only as a preference and MUST NOT force down from a `HostIntegrated` default or another host-integrated requirement.
+10. `loading.scope` MUST support `DependencyClosure`.
+11. `loading.scope` MAY support `PackageOnly`, but current graph loading MUST still produce one concrete graph mode.
+12. Invalid metadata MUST be ignored for selection and reported as a degraded diagnostic.
+
+## Selection Precedence Contract
+
+1. The selector MUST evaluate package-specific app overrides before advisor results for the same package.
+2. A same-package app override MUST suppress conflicting metadata and record `metadata-suppressed`.
+3. Valid advisor requirements MUST be evaluated before fallback default mode.
+4. If no override or valid advisor requirement applies, the package MUST use `DefaultLoadMode`.
+5. If any effective package decision in a graph is `HostIntegrated`, the loadable dependency closure MUST load as `HostIntegrated`.
+6. Packages promoted only by closure promotion MUST be identifiable with `dependency-closure`.
+7. Metadata conflicts that cannot be represented exactly MUST resolve deterministically to `HostIntegrated` and record `metadata-conflict`.
+8. The same graph packages, options, metadata, and advisors MUST produce the same effective graph mode on repeated runs.
+
+## Loading Contract
+
+1. `Collectible` graphs MUST preserve existing collectible loading behavior.
+2. `HostIntegrated` graphs MUST preserve existing non-collectible, framework-safe host-integrated behavior.
+3. Existing host-integrated assembly conflict validation MUST still run before visibility publication.
+4. Failed host-integrated activation or visibility publication MUST preserve last-known-good visibility when available.
+5. Packages with no loadable assemblies MUST continue to follow existing graph facade/support package behavior.
+
+## Diagnostics Contract
+
+1. `LoadingPackageDescriptor` MUST expose full advisor explanations first.
+2. Runtime load sessions MUST keep only effective mode and minimal loading state.
+3. Advisor explanations MUST include stable reason codes for `default`, `package-override`, `package-metadata`, `dependency-closure`, `metadata-invalid`, `metadata-suppressed`, and `metadata-conflict`.
+4. Advisor explanations MUST identify package ID, package version, graph key or graph ID, requested metadata scope, advisor name, and final effective graph mode when available.
+5. Package assembly catalog metadata MAY project a reduced explanation for assembly consumers.
+6. Structured logs MUST report advisor evaluation, metadata discovery success, metadata parse failure, override suppression, conflict resolution, and final graph mode selection.
+7. Diagnostics MUST not log secrets, feed credentials, full metadata payloads, or full exception stack traces at Information level.
+
+## Documentation Contract
+
+1. Documentation MUST show a complete package-root `nuplane.json` example.
+2. Documentation MUST explain automatic selection policy and explicit-only opt-out.
+3. Documentation MUST explain package override precedence over metadata.
+4. Documentation MUST explain that existing `PackageLoadModes` overrides continue to work and can be removed gradually after package metadata ships.
+5. Documentation MUST state that package metadata is trusted only as much as the package itself and does not bypass source/integrity validation.

--- a/specs/027-auto-load-mode-selection/data-model.md
+++ b/specs/027-auto-load-mode-selection/data-model.md
@@ -1,0 +1,176 @@
+# Data Model: Automatic Load Mode Selection
+
+## PackageLoadModeSelectionPolicy
+
+Represents the option-level policy that controls whether Nuplane evaluates load-mode advisors.
+
+**Fields**:
+- `Automatic`: Evaluate registered advisors, then fall back to `LoadingOptions.DefaultLoadMode`.
+- `ExplicitOnly`: Ignore advisor results and use package-specific overrides plus `LoadingOptions.DefaultLoadMode`.
+
+**Validation rules**:
+- Value must be a supported policy.
+- Missing value defaults to `Automatic`.
+- Policy values are not effective load modes and must never be recorded as package session load modes.
+
+## LoadingOptions
+
+Represents module-level package loading configuration.
+
+**Fields**:
+- `Enabled`: Existing loading enablement flag.
+- `DeactivationTimeout`: Existing collectible-context deactivation timeout.
+- `ActiveStoreRoot`: Existing active store root validation boundary.
+- `DefaultLoadMode`: Existing concrete fallback load mode.
+- `PackageLoadModes`: Existing package-specific load mode overrides.
+- `LoadModeSelectionPolicy`: New option-level policy controlling advisor evaluation.
+- `SharedAssemblies`: Existing shared assembly policy entries.
+
+**Validation rules**:
+- `DefaultLoadMode` must remain `Collectible` or `HostIntegrated`.
+- `LoadModeSelectionPolicy` must be supported.
+- Package override validation remains case-insensitive and duplicate-safe.
+- Options remain data-only and are validated through `IValidateOptions<LoadingOptions>`.
+
+## IPackageLoadModeAdvisor
+
+Represents an extensible policy source that can produce load-mode advice for a resolved package graph.
+
+**Fields / members**:
+- `Name`: Stable advisor name used in diagnostics.
+- `EvaluateAsync(context, cancellationToken)`: Produces zero or more advisor results for the graph.
+
+**Relationships**:
+- Registered in DI by concrete implementation first, then exposed through the interface.
+- Consumed by `PackageLoadModeSelector` when `LoadModeSelectionPolicy` is `Automatic`.
+- The built-in implementation is `PackageMetadataLoadModeAdvisor`.
+
+**Validation rules**:
+- Advisor output must be deterministic for the same graph package identities, install paths, metadata files, and configuration.
+- Advisor diagnostics must be bounded and secret-safe.
+- Advisors must not perform network access or mutate package/store state.
+
+## LoadModeAdvisorContext
+
+Represents the resolved graph context passed to advisors.
+
+**Fields**:
+- `GraphKey`: Deterministic load graph key.
+- `Packages`: Resolved packages in the graph, including identity, version, feed/source name, install path, and source name.
+- `LoadModeSelectionPolicy`: Current policy for diagnostic context.
+- `DefaultLoadMode`: Current fallback concrete mode.
+- `PackageOverrides`: Package-specific app overrides available for suppression diagnostics.
+
+**Validation rules**:
+- Graph key must be non-empty.
+- Packages must be non-null and ordered deterministically before advisor evaluation.
+- Advisors may read package install paths but must not write to them.
+
+## NuplanePackageMetadata
+
+Represents package-authored metadata read from package-root `nuplane.json`.
+
+**Fields**:
+- `SchemaVersion`: Integer schema version; v1 is required for this feature.
+- `Loading`: Optional loading metadata object.
+- `Loading.LoadMode`: `HostIntegrated` or `Collectible`.
+- `Loading.Scope`: `DependencyClosure` or `PackageOnly`.
+- `Loading.Reason`: Optional human-readable explanation.
+
+**Relationships**:
+- Owned by a single installed package identity/version.
+- Read only by `PackageMetadataLoadModeReader`.
+- Converted into `LoadModeAdvisorResult` by `PackageMetadataLoadModeAdvisor`.
+
+**Validation rules**:
+- Metadata is read only from package-root `nuplane.json`.
+- Unsupported schema versions, malformed JSON, unsupported load modes, unsupported scopes, missing required loading fields, and unbounded payloads produce invalid metadata diagnostics.
+- `HostIntegrated` is treated as a requirement.
+- `Collectible` is treated only as a preference.
+- Metadata cannot change package identity, source selection, trust validation, or desired state.
+
+## LoadModeAdvisorResult
+
+Represents one advisor output for one package.
+
+**Fields**:
+- `AdvisorName`: Stable advisor identifier.
+- `PackageId`: Declaring package ID.
+- `Version`: Declaring package version.
+- `RequestedLoadMode`: Requested or preferred concrete mode.
+- `Scope`: `DependencyClosure` or `PackageOnly`.
+- `ReasonCode`: Stable machine-readable reason such as `package-metadata` or `metadata-invalid`.
+- `Reason`: Optional human-readable reason, bounded and secret-safe.
+- `IsValid`: Whether the result can influence selection.
+- `Diagnostic`: Optional invalid/suppressed/conflict explanation.
+
+**Relationships**:
+- Produced by advisors.
+- Consumed by `PackageLoadModeSelector`.
+- Projected into `LoadingPackageDescriptor` explanations.
+
+**Validation rules**:
+- Invalid results never control effective load mode.
+- Results are ordered by advisor name, package ID, package version, scope, and reason code for deterministic selection.
+- Human-readable reasons are truncated or rejected when over the configured/built-in bound.
+
+## EffectivePackageLoadModeDecision
+
+Represents the selected concrete mode for a package before graph-wide promotion is projected.
+
+**Fields**:
+- `PackageId`
+- `Version`
+- `LoadMode`: `Collectible` or `HostIntegrated`.
+- `ReasonCode`: `default`, `package-override`, `package-metadata`, `metadata-suppressed`, `metadata-invalid`, or `metadata-conflict`.
+- `AdvisorResults`: Advisor inputs considered for this package.
+- `SuppressedResults`: Advisor inputs ignored because an explicit package override won.
+- `GraphKey`
+
+**Relationships**:
+- Built by `PackageLoadModeSelector`.
+- Used to compute `EffectiveGraphLoadModeDecision`.
+
+**Validation rules**:
+- Explicit package override wins for the matching package.
+- Package-authored `Collectible` never forces down from `HostIntegrated`.
+- Invalid metadata is represented in diagnostics and ignored for selection.
+
+## EffectiveGraphLoadModeDecision
+
+Represents the selected concrete load mode for the whole resolved package graph.
+
+**Fields**:
+- `GraphKey`
+- `LoadMode`: `Collectible` or `HostIntegrated`.
+- `PackageDecisions`: Effective package decisions before and after promotion.
+- `PromotedPackages`: Packages promoted because another package required `HostIntegrated`.
+- `ConflictDiagnostics`: Metadata conflicts resolved by deterministic safest-mode behavior.
+
+**Relationships**:
+- Consumed by `PackageLoader` before choosing graph load context type.
+- Projected into each `LoadingPackageDescriptor` for the graph.
+
+**Validation rules**:
+- If any effective package decision is `HostIntegrated`, every loadable package in the graph is promoted to `HostIntegrated`.
+- Conflicts that cannot be represented as requested resolve to `HostIntegrated`.
+- Decision is deterministic for identical graph packages, metadata, options, and advisors.
+
+## LoadModeDecisionDiagnostic
+
+Represents secret-safe explanation data exposed first through `LoadingPackageDescriptor`.
+
+**Fields**:
+- `GraphKey`
+- `EffectiveGraphLoadMode`
+- `EffectivePackageLoadMode`
+- `ReasonCodes`
+- `DeclaringPackageId`
+- `DeclaringPackageVersion`
+- `RequestedScope`
+- `AdvisorName`
+- `Message`
+
+**Validation rules**:
+- Diagnostics must not include secrets, feed credentials, full metadata payloads, or full exception stack traces at Information level.
+- Diagnostics must include enough package identity and reason-code data to explain default fallback, package override, package metadata, closure promotion, invalid metadata, suppressed metadata, and conflict handling.

--- a/specs/027-auto-load-mode-selection/plan.md
+++ b/specs/027-auto-load-mode-selection/plan.md
@@ -1,0 +1,139 @@
+# Implementation Plan: Automatic Load Mode Selection
+
+**Branch**: `027-auto-load-mode-selection` | **Date**: 2026-05-17 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/027-auto-load-mode-selection/spec.md`
+
+## Summary
+
+Add automatic load-mode selection to Nuplane loading so package-authored metadata can promote a resolved package graph to `HostIntegrated` without app-specific package override trivia. The technical approach adds a separate option-level selection policy, a public advisor contract, a built-in package-root `nuplane.json` metadata advisor, deterministic selector precedence over resolved package graphs, and `LoadingPackageDescriptor` diagnostics that explain fallback, explicit overrides, metadata, dependency-closure promotion, invalid metadata, suppressed metadata, and conflicts. Effective load sessions remain concrete `Collectible` or `HostIntegrated`.
+
+## Technical Context
+
+**Language/Version**: C# with SDK-style .NET libraries targeting `net8.0;net9.0;net10.0`; tests target `net10.0`  
+**Primary Dependencies**: Microsoft.Extensions.DependencyInjection, Microsoft.Extensions.Options, Microsoft.Extensions.Logging, System.Text.Json, System.Runtime.Loader, existing Nuplane graph/loading abstractions, xUnit, NSubstitute  
+**Storage**: Existing file-backed Nuplane package install directories and active package state; metadata is read from extracted package-root `nuplane.json`; no database or durable state format change required for v1  
+**Testing**: xUnit via `dotnet test`, focused first on `test/Nuplane.Loading.Tests/Nuplane.Loading.Tests.csproj` and then `dotnet test nuplane.sln` when practical  
+**Target Platform**: .NET host applications supported by current Nuplane multi-targeted libraries  
+**Project Type**: Infrastructure/library modules with public loading abstractions, loading implementation, and documentation  
+**Performance Goals**: Advisor evaluation performs bounded file reads over the already resolved graph once per graph load; no package graph re-resolution or network access during load-mode selection  
+**Constraints**: Preserve explicit package overrides as authoritative; keep effective load modes limited to `Collectible` and `HostIntegrated`; do not hard-code package IDs; keep `Nuplane.Runtime` dependency-lean; public/protected APIs require XML documentation; options validation uses `IValidateOptions<T>` and `ValidateOnStart()`  
+**Scale/Scope**: Active package graph sizes remain bounded by existing reconciliation/loading behavior; metadata files are small package-owned JSON documents and diagnostics are bounded summaries, not full metadata payloads
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- Deterministic reconciliation: PASS — advisor inputs are resolved graph packages, package-root metadata, and loading options; selector precedence is ordered and deterministic.
+- Transactional store safety: PASS — package store publish/LKG behavior remains unchanged; failed host-integrated loading or visibility publication continues to preserve prior active graph behavior.
+- Source integrity: PASS — metadata is read only from packages already resolved and installed through existing trusted source and integrity paths; metadata cannot alter source access or package identity/version resolution.
+- Observability: PASS — design requires structured logs and `LoadingPackageDescriptor` explanations for advisor results, invalid metadata, override suppression, conflicts, closure promotion, and final mode.
+- Test discipline: PASS — plan requires unit and boundary coverage for options validation, metadata parsing, advisor precedence, graph promotion, loading descriptor diagnostics, invalid metadata, and the provider-style regression.
+- Decomposition discipline: PASS — design separates options/policy, advisor contract, metadata reader/advisor, selector aggregation, graph promotion, descriptor projection, observability, docs, and tests into distinct artifacts for task generation.
+- Options validation discipline: PASS — the new policy option remains data-only and is validated by `IValidateOptions<LoadingOptions>` with startup fail-fast registration.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/027-auto-load-mode-selection/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── automatic-load-mode-selection-contract.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+src/
+├── Nuplane.Loading.Abstractions/
+│   ├── IPackageLoadModeAdvisor.cs
+│   ├── LoadModeAdvisorContext.cs
+│   ├── LoadModeAdvisorResult.cs
+│   ├── LoadModeDecisionDiagnostic.cs
+│   ├── LoadingPackageDescriptor.cs
+│   └── PackageLoadMode.cs
+├── Nuplane.Loading/
+│   ├── LoadingOptions.cs
+│   ├── LoadingOptionsValidator.cs
+│   ├── PackageLoadModeSelectionPolicy.cs
+│   ├── PackageLoadModeSelector.cs
+│   ├── PackageLoadModeSelection.cs
+│   ├── PackageLoadModeDecision.cs
+│   ├── PackageMetadataLoadModeAdvisor.cs
+│   ├── PackageMetadataLoadModeReader.cs
+│   ├── PackageLoader.cs
+│   ├── LoadingCatalog.cs
+│   └── Registration/LoadingRegistrationServices.cs
+├── Nuplane.Loading/Builder/
+│   └── NuplaneLoadingBuilder.cs
+
+test/
+├── Nuplane.Loading.Tests/
+│   ├── LoadingOptionsValidatorTests.cs
+│   ├── PackageMetadataLoadModeReaderTests.cs
+│   ├── PackageMetadataLoadModeAdvisorTests.cs
+│   ├── PackageLoadModeSelectorTests.cs
+│   ├── PackageLoaderHostIntegratedTests.cs
+│   ├── LoadingCatalogTests.cs
+│   └── LoadingRegistrationDeterminismTests.cs
+└── Nuplane.Loading.Tests.Fixtures/
+    └── package graph fixtures as needed
+
+docs/
+├── wiki/Usage-Guide.md
+└── wiki/Concepts-and-Glossary.md
+
+README.md
+```
+
+**Structure Decision**: Implement the feature in `Nuplane.Loading` and `Nuplane.Loading.Abstractions` because load-mode policy, advisor extensibility, package loading, and loading catalog diagnostics are owned by the optional loading module. The built-in metadata advisor reads from resolved package install paths passed to loading and does not require changes to feed resolution, package acquisition, or core runtime source trust behavior.
+
+## Complexity Tracking
+
+No constitution violations or complexity exceptions are required.
+
+## Phase 0: Research
+
+Research is complete in [research.md](./research.md). Key decisions:
+
+- Automatic selection is a separate `LoadingOptions` policy, not a `PackageLoadMode.Auto` enum value.
+- Effective sessions, assembly catalogs, and loading descriptors keep concrete `Collectible` or `HostIntegrated` modes.
+- Package-root `nuplane.json` is the only v1 metadata location.
+- A public `IPackageLoadModeAdvisor` contract enables future advisors and host-specific policy without hard-coded package IDs.
+- Explicit package overrides suppress advisor results on the same package; graph closure promotion may still promote other graph members when another effective requirement requires host integration.
+- Package-authored `Collectible` is preference-only and cannot force a graph down from `HostIntegrated`.
+- Invalid metadata is ignored for selection and reported as degraded diagnostics, not reconciliation-fatal.
+- Full advisor explanations are exposed first through `LoadingPackageDescriptor`.
+
+## Phase 1: Design & Contracts
+
+Design artifacts are complete:
+
+- Data model: [data-model.md](./data-model.md)
+- Contract: [contracts/automatic-load-mode-selection-contract.md](./contracts/automatic-load-mode-selection-contract.md)
+- Quickstart validation: [quickstart.md](./quickstart.md)
+
+### Design Summary
+
+- `LoadingOptions` gains a separate automatic load-mode selection policy, defaulting to metadata-aware automatic selection with explicit-only opt-out.
+- `IPackageLoadModeAdvisor` evaluates resolved package graph context and returns bounded advisor results with stable reason codes.
+- `PackageMetadataLoadModeAdvisor` reads package-root `nuplane.json` through a dedicated reader, validates schema v1, and returns either valid advisory results or invalid metadata diagnostics.
+- `PackageLoadModeSelector` aggregates explicit overrides, advisor results, fallback default, conflict handling, and dependency-closure promotion into concrete package and graph decisions.
+- `PackageLoader` consumes graph decisions before choosing collectible or host-integrated graph loading, preserving existing host-integrated closure promotion and conflict handling.
+- `LoadingCatalog` projects full advisor explanations onto `LoadingPackageDescriptor`; lower-level load sessions keep only effective mode and minimal loading state.
+- Documentation explains metadata authoring, app override precedence, migration from `PackageLoadModes`, security/trust boundaries, and collectible versus host-integrated tradeoffs.
+
+## Post-Design Constitution Check
+
+- Deterministic reconciliation: PASS — data model defines deterministic advisor result ordering, override precedence, conflict handling, and graph promotion.
+- Transactional store safety: PASS — contract leaves package activation and LKG behavior unchanged; failed host-integrated visibility publication keeps prior active visibility.
+- Source integrity: PASS — metadata contract states package metadata is read only after existing source/integrity validation and cannot alter source or package identity decisions.
+- Observability: PASS — contract and data model define `LoadingPackageDescriptor` explanations, stable reason codes, logs, and degraded metadata diagnostics.
+- Test discipline: PASS — quickstart and contract identify required focused tests plus the generic provider-style regression for metadata-driven host-integrated closure loading.
+- Decomposition discipline: PASS — planned artifacts map to discrete option, advisor, reader, selector, loader, catalog projection, registration, documentation, and test concerns.
+- Options validation discipline: PASS — selection policy validation remains in `IValidateOptions<LoadingOptions>` and `ValidateOnStart()` registration.

--- a/specs/027-auto-load-mode-selection/quickstart.md
+++ b/specs/027-auto-load-mode-selection/quickstart.md
@@ -1,0 +1,127 @@
+# Quickstart: Automatic Load Mode Selection
+
+## Purpose
+
+Use this quickstart to validate automatic load-mode selection during implementation. It focuses on observable behavior and regression coverage, not internal implementation details.
+
+## Scenario 1: No Metadata And No Override
+
+1. Configure Nuplane loading as enabled.
+2. Set `DefaultLoadMode` to `Collectible`.
+3. Ensure no package-specific override exists for the test graph.
+4. Install or fixture a resolved graph with no package-root `nuplane.json`.
+5. Run loading for the graph.
+6. Verify the effective graph mode is `Collectible`.
+7. Verify `LoadingPackageDescriptor` explains the mode with `default`.
+8. Verify no host-integrated assembly resolution entries are published for the graph.
+
+## Scenario 2: Explicit Package Override Still Wins
+
+1. Configure `DefaultLoadMode` as `Collectible`.
+2. Configure one package-specific `PackageLoadModes` override to `HostIntegrated`.
+3. Load a graph containing that package and at least one dependency.
+4. Verify the loadable dependency closure is `HostIntegrated`.
+5. Verify descriptors distinguish the explicit package with `package-override` and promoted graph members with `dependency-closure`.
+
+## Scenario 3: Package Metadata Promotes The Graph
+
+1. Configure `DefaultLoadMode` as `Collectible`.
+2. Do not configure package-specific overrides.
+3. Add package-root `nuplane.json` to the root package:
+
+   ```json
+   {
+     "schemaVersion": 1,
+     "loading": {
+       "loadMode": "HostIntegrated",
+       "scope": "DependencyClosure",
+       "reason": "Uses framework type resolution and runtime scheduler integration."
+     }
+   }
+   ```
+
+4. Load the resolved graph.
+5. Verify the effective graph mode is `HostIntegrated`.
+6. Verify descriptors include `package-metadata` for the declaring package and `dependency-closure` for promoted packages.
+7. Verify the graph works without app-specific package override configuration.
+
+## Scenario 4: Explicit Override Suppresses Metadata
+
+1. Configure `DefaultLoadMode` as `Collectible`.
+2. Add package metadata requesting `HostIntegrated`.
+3. Configure a package-specific override for the same package to `Collectible`.
+4. Load the graph with no other host-integrated requirement.
+5. Verify the graph remains `Collectible`.
+6. Verify descriptors include `metadata-suppressed` identifying the package metadata that was ignored.
+
+## Scenario 5: Invalid Metadata Is Degraded
+
+1. Configure automatic selection.
+2. Add malformed or unsupported package-root `nuplane.json` to a package.
+3. Load the graph.
+4. Verify reconciliation/loading does not crash solely because of the invalid metadata.
+5. Verify selection falls back to explicit override or default behavior.
+6. Verify descriptors and logs include `metadata-invalid` with the affected package identity.
+
+## Scenario 6: Metadata Conflict Uses Deterministic Safe Mode
+
+1. Create a graph where one package requests `HostIntegrated` and another package declares `Collectible`.
+2. Load the graph under automatic selection.
+3. Verify the effective graph mode is `HostIntegrated`.
+4. Verify diagnostics include `metadata-conflict` or explain the preference/requirement conflict deterministically.
+5. Repeat the same load and verify the effective mode and reason codes are identical.
+
+## Scenario 7: Automatic Selection Disabled
+
+1. Set load-mode selection policy to explicit-only.
+2. Add package metadata requesting `HostIntegrated`.
+3. Do not configure package-specific overrides.
+4. Load the graph with `DefaultLoadMode=Collectible`.
+5. Verify metadata does not influence the effective mode.
+6. Verify descriptors explain that advisor selection was disabled or that default behavior was used.
+
+## Scenario 8: Generic Provider-Style Regression
+
+1. Build or fixture a generic package graph with a root package and provider/runtime dependencies.
+2. Add package-root metadata to the root declaring `HostIntegrated` with `DependencyClosure`.
+3. Configure `DefaultLoadMode=Collectible` and no package-specific overrides.
+4. Load the graph.
+5. Verify the effective graph mode is `HostIntegrated`.
+6. Verify a framework/default-context style assembly-qualified type resolution scenario can be satisfied by the host-integrated graph.
+
+## Required Validation Commands
+
+Run focused tests first, then broader validation when practical:
+
+```bash
+dotnet test test/Nuplane.Loading.Tests/Nuplane.Loading.Tests.csproj
+dotnet test nuplane.sln
+```
+
+## Documentation Validation
+
+Update README or wiki loading guidance to explain:
+
+- Package-root `nuplane.json` authoring.
+- Automatic selection policy and explicit-only opt-out.
+- Existing `PackageLoadModes` migration path.
+- Override precedence.
+- `Collectible` metadata as preference-only.
+- Package metadata trust boundaries.
+
+## Validation Notes
+
+- Focused loading tests were run with:
+
+  ```bash
+  dotnet test test/Nuplane.Loading.Tests/Nuplane.Loading.Tests.csproj --no-restore --filter "FullyQualifiedName~PackageMetadataLoadMode|FullyQualifiedName~PackageLoadModeSelector|FullyQualifiedName~PackageLoaderHostIntegrated|FullyQualifiedName~LoadingCatalog|FullyQualifiedName~LoadingOptionsValidator|FullyQualifiedName~LoadingRegistrationDeterminism|FullyQualifiedName~LoadingOwnershipContract"
+  ```
+
+- Covered scenarios include package-root metadata parsing, invalid metadata diagnostics, automatic advisor results, explicit override precedence, dependency-closure promotion, collectible fallback, explicit-only policy, metadata conflict resolution, descriptor diagnostics, and load-mode selection logs.
+- Full solution validation was run with:
+
+  ```bash
+  dotnet test nuplane.sln
+  ```
+
+- The full solution test run passed after the loading-focused validation.

--- a/specs/027-auto-load-mode-selection/research.md
+++ b/specs/027-auto-load-mode-selection/research.md
@@ -1,0 +1,82 @@
+# Research: Automatic Load Mode Selection
+
+## Decision: Use An Option-Level Automatic Selection Policy
+
+**Decision**: Add a separate `LoadingOptions` policy for automatic load-mode selection instead of adding `PackageLoadMode.Auto`.
+
+**Rationale**: Existing sessions, catalogs, and loaders already treat `PackageLoadMode` as the concrete runtime mode. Keeping `PackageLoadMode` limited to `Collectible` and `HostIntegrated` avoids ambiguous effective states and lowers migration risk for existing switch logic, validators, and catalog consumers.
+
+**Alternatives considered**:
+- Add `PackageLoadMode.Auto`: rejected because it could leak into effective load-state contracts and force every consumer to handle a non-runtime mode.
+- Always evaluate advisors with no policy option: rejected because app authors need an explicit opt-out for diagnostics, migration, and compatibility testing.
+
+## Decision: Default To Metadata-Aware Automatic Selection
+
+**Decision**: The policy defaults to evaluating advisors, then falling back to `DefaultLoadMode` when no advisor requires host integration.
+
+**Rationale**: Package-authored metadata is opt-in by the package author and solves the observed app-by-app configuration problem only if hosts benefit without adding a second opt-in. Packages without metadata keep the existing fallback behavior.
+
+**Alternatives considered**:
+- Default to explicit-only behavior: rejected because it would make package-authored metadata inert until every app opts in.
+- Remove `DefaultLoadMode`: rejected because hosts still need a fallback for packages with no metadata.
+
+## Decision: Package-Root `nuplane.json` Is The Only V1 Metadata Location
+
+**Decision**: Probe only package-root `nuplane.json` for v1.
+
+**Rationale**: The metadata is package-owned runtime policy that Nuplane can read from the extracted install path. Avoiding `build/` and `contentFiles/` keeps discovery deterministic and avoids importing build-time or content-file conventions into loading.
+
+**Alternatives considered**:
+- Probe `build/nuplane.json`: deferred as future compatibility work because `build/` carries NuGet build asset semantics that are not needed for runtime loading.
+- Probe `contentFiles/any/any/nuplane.json`: rejected for v1 because content files imply consumer project behavior, not Nuplane runtime policy.
+
+## Decision: Expose A Public Advisor Contract
+
+**Decision**: Add a public `IPackageLoadModeAdvisor` contract in loading abstractions and register built-in advisors through the loading module.
+
+**Rationale**: The spec explicitly forbids package-specific hard-coding while preferring an advisor model. A public contract lets hosts or future Nuplane modules add policy sources without changing core selector code. The built-in metadata advisor remains the only required v1 advisor.
+
+**Alternatives considered**:
+- Keep advisors internal: rejected because it would make future advisor extension require changes inside Nuplane loading.
+- Use configuration-only metadata rules: rejected because the feature goal is package-authored declaration, not another host-maintained package list.
+
+## Decision: Explicit Package Overrides Suppress Same-Package Advisor Results
+
+**Decision**: Existing `PackageLoadModes` overrides have highest precedence for the matching package. Suppressed metadata is recorded as a diagnostic.
+
+**Rationale**: App authors must remain authoritative for compatibility, rollback, and emergency mitigation. Diagnostics keep the suppression visible so package metadata problems can be fixed rather than hidden.
+
+**Alternatives considered**:
+- Let package metadata override app configuration: rejected because package-authored metadata must not remove host control over runtime lifetime and integration.
+- Treat conflicts as fatal: rejected because explicit overrides are the established escape hatch and should remain operationally useful.
+
+## Decision: `HostIntegrated` Metadata Is A Requirement; `Collectible` Metadata Is Preference-Only
+
+**Decision**: Package-authored `HostIntegrated` metadata can require host integration. Package-authored `Collectible` metadata only expresses a lower-priority preference and never forces a graph down from a `HostIntegrated` default or another host-integrated requirement.
+
+**Rationale**: Host integration is often required to avoid framework/default-context failures. A package author can safely declare that stronger requirement. Forcing collectible behavior would weaken a host's chosen integration policy and could reintroduce runtime resolution failures.
+
+**Alternatives considered**:
+- Allow `Collectible` metadata to force down from `HostIntegrated`: rejected because it lets package metadata reduce the host-selected integration level.
+- Remove `Collectible` from v1 metadata: rejected because preference diagnostics can help explain that a package is isolation-friendly when the host fallback is collectible.
+
+## Decision: Invalid Metadata Is Degraded And Ignored For Selection
+
+**Decision**: Malformed, unsupported, unreadable, or oversized metadata does not crash reconciliation or loading. The advisor returns an invalid result that is ignored for selection and projected into diagnostics.
+
+**Rationale**: Metadata quality should not make package reconciliation brittle. Existing fallback and explicit override behavior can continue while operators receive actionable diagnostics.
+
+**Alternatives considered**:
+- Fail graph loading on invalid metadata: rejected because a metadata typo should not make otherwise valid packages unavailable unless the host explicitly chooses fail-closed behavior in a future policy.
+- Silently ignore invalid metadata: rejected because package authors and operators need to see why automatic selection did not apply.
+
+## Decision: Expose Full Explanations Through `LoadingPackageDescriptor`
+
+**Decision**: `LoadingPackageDescriptor` is the first public surface for full advisor explanations. Runtime sessions keep effective mode and minimal loading state.
+
+**Rationale**: Loading descriptors already carry loading status, diagnostics, effective mode, context key, and scan guidance. They are the right operator-facing surface for "why" data without putting policy history into lower-level runtime session state.
+
+**Alternatives considered**:
+- Store explanations directly on `PackageLoadSession`: rejected because sessions are lower-level process state and should stay compact.
+- Expose explanations only through package assembly catalog metadata: rejected because assembly consumers may not need full policy history.
+- Add a separate query surface: deferred until there is evidence that loading descriptors cannot carry the explanation cleanly.

--- a/specs/027-auto-load-mode-selection/spec.md
+++ b/specs/027-auto-load-mode-selection/spec.md
@@ -1,0 +1,205 @@
+# Feature Specification: Automatic Load Mode Selection
+
+**Feature Branch**: `027-auto-load-mode-selection`  
+**Created**: 2026-05-14  
+**Status**: Draft  
+**Input**: User description: "Create a Speckit specification for smarter automatic package load-mode selection using package-declared Nuplane metadata, advisor precedence, explicit user overrides, dependency-closure promotion, diagnostics, backwards compatibility, failure handling, trust considerations, migration guidance, and regression coverage for the Quartz SQLite provider metadata scenario."
+
+## Problem
+
+Nuplane supports `Collectible` and `HostIntegrated` package load modes. `Collectible` is the default isolated/unloadable path. `HostIntegrated` is required when packages participate in framework/default assembly load context behavior, assembly-qualified type resolution, application-lifetime services, schedulers, data providers, migrations, endpoints, or similar host-integrated patterns.
+
+Today app authors must know which package roots require `HostIntegrated` and configure `Loading:PackageLoadModes` manually. Once any package in a resolved graph is configured as `HostIntegrated`, Nuplane promotes the whole dependency closure, which is correct. The brittle part is that every application must rediscover the package-specific load-mode requirement.
+
+An observed Quartz SQLite graph failed under `DefaultLoadMode=Collectible` when provider metadata later tried to resolve an assembly-qualified type name for `Microsoft.Data.Sqlite.SqliteConnection, Microsoft.Data.Sqlite`. The same graph worked when relevant roots were explicitly configured as `HostIntegrated`, because closure promotion made the framework-visible graph available. Nuplane should let packages declare this requirement once, then make load mode a deterministic policy decision during graph loading.
+
+## Clarifications
+
+### Session 2026-05-17
+
+- Q: Should automatic selection be exposed as a new public `PackageLoadMode.Auto` value or as a separate policy while effective load modes remain concrete? → A: Use a separate option-level automatic selection policy; effective `PackageLoadMode` values remain limited to `Collectible` and `HostIntegrated`.
+- Q: Where should v1 package-authored Nuplane metadata live inside the package? → A: Probe only package-root `nuplane.json` in v1.
+- Q: Which public diagnostic surface should carry full advisor explanations first? → A: Expose full advisor explanations first through `LoadingPackageDescriptor`; runtime sessions keep only effective mode and minimal state.
+- Q: Should package-authored `Collectible` metadata be able to force a graph down from a host-configured `HostIntegrated` default? → A: No. `Collectible` metadata is only a preference; it never forces a graph down from a `HostIntegrated` default or another host-integrated requirement.
+
+## Goals
+
+- Let package authors declare Nuplane load-mode requirements once in package metadata.
+- Let app authors get correct load-mode behavior automatically without hard-coding package IDs into Nuplane core or each host application.
+- Preserve explicit app overrides as authoritative inputs.
+- Preserve isolated/collectible loading for graphs that do not require host integration.
+- Promote a dependency closure to `HostIntegrated` when any effective advisor result requires graph-wide host integration.
+- Expose secret-safe diagnostics that explain the selected effective graph mode and the reasons that contributed to it.
+- Keep the feature extensible for future advisors while the first advisor focuses on package-declared metadata.
+
+## Non-Goals
+
+- Hard-coding Elsa, Quartz, EF Core, SQLite, provider package IDs, or any other package-specific knowledge into Nuplane core.
+- Inferring every possible framework integration pattern from package contents in the first implementation.
+- Replacing existing source trust, package validation, dependency graph resolution, or host-integrated assembly resolution behavior.
+- Allowing package-authored metadata to bypass explicit app configuration, source policy, integrity validation, or package trust decisions.
+- Introducing side-by-side graph loading semantics beyond the dependency-closure behavior already supported by Nuplane.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Package Authors Declare Load Requirements Once (Priority: P1)
+
+As a package author, I want my Nuplane-compatible package to declare that it requires host-integrated dependency-closure loading, so every Nuplane host can select the correct load mode without duplicating package-specific app configuration.
+
+**Why this priority**: This removes the repeated app-by-app trivia that caused the observed failure while keeping package knowledge with the package that owns the runtime integration requirement.
+
+**Independent Test**: Build a synthetic package graph where the root package contains valid Nuplane metadata declaring `HostIntegrated` with dependency-closure scope. Configure loading with no package-specific overrides, reconcile and load the graph, and verify every loadable package in the graph is loaded as `HostIntegrated` with a diagnostic reason pointing to package metadata.
+
+**Acceptance Scenarios**:
+
+1. **Given** a resolved package graph whose root package declares `HostIntegrated` with dependency-closure scope in Nuplane metadata, **When** Nuplane evaluates load mode for the graph, **Then** the effective graph load mode is `HostIntegrated` without app-specific package override configuration.
+2. **Given** a resolved package graph whose packages have no Nuplane metadata and no package-specific overrides, **When** Nuplane evaluates load mode, **Then** the graph uses the configured default/fallback behavior.
+3. **Given** a generic provider-style package graph where a root package declares a host-integrated dependency-closure requirement, **When** the graph is loaded with automatic selection enabled, **Then** the effective graph mode is `HostIntegrated` and framework/default-context resolution scenarios can be satisfied.
+
+---
+
+### User Story 2 - App Authors Override Explicitly (Priority: P1)
+
+As an app author, I want explicit load-mode configuration to remain authoritative so I can force host integration, force isolation where acceptable, or work around a package metadata problem without waiting for a package update.
+
+**Why this priority**: Automatic policy must not remove the host operator's control over runtime lifetime and integration tradeoffs.
+
+**Independent Test**: Configure package-specific load-mode overrides that conflict with package metadata and verify the explicit override is the selected package decision before graph promotion is computed.
+
+**Acceptance Scenarios**:
+
+1. **Given** a package has no Nuplane metadata and app configuration explicitly sets that package to `HostIntegrated`, **When** Nuplane evaluates the graph, **Then** the dependency closure loads as `HostIntegrated`, matching today's behavior.
+2. **Given** package metadata recommends or requests `Collectible` but app configuration explicitly sets the package to `HostIntegrated`, **When** Nuplane evaluates the graph, **Then** the explicit app override wins and the graph loads as `HostIntegrated`.
+3. **Given** package metadata requests `HostIntegrated` for a package but app configuration explicitly sets that same package to `Collectible`, **When** no other graph member requires host integration, **Then** the package-specific app override wins and Nuplane records a diagnostic that package metadata was suppressed by explicit configuration.
+4. **Given** one graph member is explicitly set to `Collectible` but another graph member effectively requires `HostIntegrated`, **When** Nuplane evaluates graph promotion, **Then** the graph loads as `HostIntegrated` and diagnostics identify both the explicit collectible input and the dependency-closure promotion reason.
+
+---
+
+### User Story 3 - Keep Collectible Loading As The Safe Default Path (Priority: P2)
+
+As an app author running isolated plugins or scan-only packages, I want packages with no host-integration requirement to remain collectible so unloadability and isolation are not weakened unnecessarily.
+
+**Why this priority**: Nuplane must preserve existing isolated plugin scenarios and avoid silently making all packages application-lifetime packages.
+
+**Independent Test**: Reconcile and load a graph with no package metadata and no explicit override under the existing collectible fallback configuration; verify the graph remains `Collectible` and no host-integrated resolution entries are published.
+
+**Acceptance Scenarios**:
+
+1. **Given** a graph has no explicit override and no advisor requires host integration, **When** load mode selection completes, **Then** the graph uses the configured fallback load mode, with `Collectible` preserving existing default behavior.
+2. **Given** a graph remains `Collectible`, **When** loading succeeds, **Then** Nuplane does not publish host-integrated assembly resolution entries for that graph.
+3. **Given** an app opts out of automatic advisor selection through configuration, **When** packages include Nuplane metadata, **Then** Nuplane ignores advisor decisions and uses explicit package overrides plus fallback behavior while recording that automatic selection is disabled.
+
+---
+
+### User Story 4 - Explain Load Mode Decisions (Priority: P2)
+
+As an operator, I want the active/loading catalog and logs to explain why a graph was loaded as `HostIntegrated` or `Collectible`, so I can diagnose package metadata, explicit overrides, dependency-closure promotion, conflicts, and invalid metadata without inspecting loader internals.
+
+**Why this priority**: Automatic policy increases convenience only if the resulting decisions are transparent and deterministic.
+
+**Independent Test**: Load graphs covering default fallback, package override, package metadata, dependency-closure promotion, invalid metadata, and conflicting metadata; verify queryable loading state and logs expose stable reason codes and package identities.
+
+**Acceptance Scenarios**:
+
+1. **Given** graph mode is selected because of package metadata, **When** loading catalog data is queried, **Then** the descriptor or diagnostic explains `package-metadata`, the declaring package, the requested scope, and the resulting effective graph mode.
+2. **Given** graph mode is selected because one package caused dependency-closure promotion, **When** loading state is queried, **Then** each promoted package can be distinguished from the package that originally required `HostIntegrated`.
+3. **Given** invalid metadata is encountered, **When** reconciliation and loading continue, **Then** diagnostics include the invalid metadata reason without crashing reconciliation.
+4. **Given** conflicting metadata appears in one graph, **When** load mode selection completes, **Then** Nuplane chooses a deterministic result and emits a clear conflict diagnostic.
+
+### Edge Cases
+
+- A package metadata file is missing, empty, malformed JSON, too large, or encoded in an unsupported way.
+- A metadata file contains an unsupported schema version, unknown load mode, unknown scope, missing required fields, or conflicting duplicated declarations.
+- Multiple packages in one graph declare conflicting requirements, such as one requiring `HostIntegrated` and another recommending `Collectible`.
+- A package-specific app override conflicts with package metadata on the same package.
+- A package-specific app override on one graph member conflicts with graph-wide promotion caused by another graph member.
+- A package declares dependency-closure host integration but has no loadable assemblies itself while another package in the graph is loadable.
+- A package declares metadata from a source that has not yet passed existing source trust, integrity, or lock policy validation.
+- A graph is replaced by a later generation whose metadata changes the effective load mode.
+- Automatic selection is disabled or unavailable while package metadata exists.
+- Package metadata declares `HostIntegrated` but host-integrated assembly visibility validation fails because of an assembly conflict.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: `LoadingOptions` MUST expose a separate automatic load-mode selection policy that can be enabled or disabled by app configuration; the default policy SHOULD evaluate package-declared metadata and fall back to the configured default load mode when no advisor requires another mode.
+- **FR-002**: The automatic selection policy MUST preserve the existing package-specific `PackageLoadModes` override collection as the highest-precedence per-package input.
+- **FR-003**: The effective runtime load mode recorded for sessions, assembly catalogs, and loading catalogs MUST remain concrete: `Collectible` or `HostIntegrated`; `PackageLoadMode.Auto` MUST NOT be introduced as a final effective load mode for this feature.
+- **FR-004**: Nuplane MUST introduce a load-mode advisor model that evaluates a resolved package graph after dependency graph resolution and before package graph loading.
+- **FR-005**: The first built-in advisor MUST read explicit Nuplane package metadata from installed/resolved package contents and MUST NOT hard-code package IDs or product-specific rules.
+- **FR-006**: Nuplane package metadata v1 MUST use a package-root `nuplane.json` file as the only probed metadata location, because it is package-owned runtime metadata that Nuplane can discover from the extracted package without invoking build or content-file conventions.
+- **FR-007**: The v1 metadata schema MUST support at least `loading.loadMode`, `loading.scope`, and `loading.reason`.
+- **FR-008**: The v1 metadata schema MUST support `loadMode` values of `HostIntegrated` and `Collectible`, with `HostIntegrated` treated as a requirement and `Collectible` treated only as a lower-priority preference that never forces a graph down from a `HostIntegrated` default or another host-integrated requirement unless made explicit by app configuration.
+- **FR-009**: The v1 metadata schema MUST support a `DependencyClosure` scope that applies a load-mode requirement to every loadable package in the resolved graph containing the declaring package.
+- **FR-010**: The v1 metadata schema MAY support a `PackageOnly` scope for package-local recommendations, but graph loading MUST still use a single effective graph mode when the current loader cannot mix modes inside one graph.
+- **FR-011**: The load-mode selector MUST evaluate inputs in deterministic precedence order: package-specific app override for the declaring package, advisor requirements, default/fallback load mode, then dependency-closure promotion.
+- **FR-012**: If any effective package decision in a resolved graph is `HostIntegrated`, the loader MUST promote the whole loadable dependency closure to `HostIntegrated`, preserving the graph promotion semantics already used for explicit overrides.
+- **FR-013**: If metadata conflicts cannot be represented as requested in one graph, Nuplane MUST prefer the deterministic mode least likely to cause runtime framework resolution failure, which is `HostIntegrated`, and MUST emit a conflict diagnostic naming all conflicting declarations.
+- **FR-014**: If a package-specific app override suppresses metadata on the same package, Nuplane MUST use the app override and record a diagnostic that identifies the suppressed metadata requirement.
+- **FR-015**: Invalid or unreadable package metadata MUST NOT crash reconciliation or package loading; Nuplane MUST ignore the invalid advisor result for selection purposes and record a degraded diagnostic tied to the affected package.
+- **FR-016**: Package metadata MUST be evaluated only after the package has been resolved and installed through existing trusted source and integrity paths.
+- **FR-017**: Package metadata MUST NOT be allowed to expand source access, bypass package trust, alter desired package identity/version selection, or grant additional host permissions beyond influencing load-mode selection.
+- **FR-018**: `LoadingPackageDescriptor` MUST expose the effective load mode and full advisor explanation first, including stable reason codes such as `default`, `package-override`, `package-metadata`, `dependency-closure`, `metadata-invalid`, `metadata-suppressed`, and `metadata-conflict`; package assembly catalog metadata MAY project a reduced explanation when useful for assembly consumers.
+- **FR-019**: The `LoadingPackageDescriptor` advisor explanation MUST identify the declaring package ID/version, requested metadata scope, selected graph key or graph ID, and final effective graph mode when those values are available.
+- **FR-020**: Structured logs MUST be emitted for advisor evaluation, metadata discovery success, metadata parse failure, override suppression, conflict resolution, and final graph mode selection without logging secrets, feed credentials, or unbounded metadata payloads.
+- **FR-021**: The feature MUST include migration guidance explaining that existing `PackageLoadModes` overrides continue to work and can be removed gradually once packages ship trusted Nuplane metadata.
+- **FR-022**: Documentation MUST include authoring guidance for package metadata, including the canonical `nuplane.json` location, schema examples, allowed values, dependency-closure scope, and the security/trust model.
+- **FR-023**: The implementation MUST include regression coverage modeling the Quartz SQLite class of failure as a generic package graph whose root declares `HostIntegrated` dependency-closure metadata; the test MUST assert the effective graph mode becomes `HostIntegrated` without app-specific package overrides.
+- **FR-024**: Tests MUST cover no metadata/no override fallback, explicit `HostIntegrated` override, package metadata host-integration promotion, explicit app override winning over metadata, conflicting metadata, invalid metadata, automatic selection disabled, and observability reason codes.
+
+### Operational & Safety Requirements *(mandatory)*
+
+- **OSR-001**: Reconciliation and loading flows MUST remain deterministic and idempotent for repeated identical package graphs, package metadata, and app configuration.
+- **OSR-002**: Load-mode selection changes MUST preserve existing transactional and last-known-good behavior; a failed load or failed host-integrated visibility publication MUST leave the previous active graph available when one exists.
+- **OSR-003**: Source trust and package validation MUST remain unchanged; package-authored metadata is trusted only to the same degree as the package that contains it and only after the package passes existing validation.
+- **OSR-004**: Observability MUST include structured diagnostics and catalog-visible explanations for advisor results, override precedence, dependency-closure promotion, metadata invalidity, metadata conflicts, and final graph mode.
+- **OSR-005**: Automated tests MUST include unit coverage for advisor parsing/precedence, selector conflict handling, graph promotion, diagnostics, and integration-style loader coverage for metadata-driven `HostIntegrated` graph loading.
+
+### Key Entities *(include if feature involves data)*
+
+- **Automatic Load Mode Selection Policy**: App configuration that decides whether Nuplane evaluates advisors before falling back to the configured default load mode.
+- **Package Load Mode Advisor**: A deterministic source of load-mode recommendations for packages or graphs. The first built-in advisor reads package-declared Nuplane metadata.
+- **Nuplane Package Metadata**: Package-authored metadata stored in package-root `nuplane.json` that can declare loading requirements, scope, and a human-readable reason.
+- **Load Mode Advisor Result**: A structured result containing package identity, requested load mode, scope, source, reason code, optional human reason, and validity status.
+- **Effective Package Load Mode Decision**: The selected concrete mode for one package after applying explicit app override, valid advisor results, and fallback behavior.
+- **Effective Graph Load Mode Decision**: The selected concrete mode for the whole resolved graph after dependency-closure promotion.
+- **Load Mode Decision Diagnostic**: Secret-safe diagnostic data exposed first through `LoadingPackageDescriptor` that explains inputs, precedence, conflicts, invalid metadata, suppressed metadata, and final selection while runtime sessions keep only effective mode and minimal loading state.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: In acceptance tests, 100% of graphs with no metadata and no package-specific override use the configured default/fallback load mode.
+- **SC-002**: In acceptance tests, an explicit package override to `HostIntegrated` promotes the whole dependency closure exactly as current behavior does.
+- **SC-003**: In acceptance tests, a package-root `nuplane.json` declaring `HostIntegrated` with dependency-closure scope causes the graph to load as `HostIntegrated` without app-specific package override configuration.
+- **SC-004**: In acceptance tests, explicit app overrides win over conflicting metadata on the same package, and the suppressed metadata is visible in diagnostics.
+- **SC-005**: In conflict tests, multiple incompatible metadata declarations in one graph produce the same deterministic effective mode and the same stable reason codes on every run.
+- **SC-006**: In invalid-metadata tests, reconciliation and loading do not crash, the invalid metadata does not control selection, and a clear diagnostic identifies the affected package.
+- **SC-007**: The generic Quartz SQLite regression model loads the dependency closure as `HostIntegrated` when the root declares host-integrated dependency-closure metadata.
+- **SC-008**: Loading catalog descriptors can explain for every loaded package whether its effective mode came from fallback, package override, package metadata, dependency-closure promotion, or conflict handling.
+- **SC-009**: Existing tests for collectible loading, explicit host-integrated overrides, no-assembly facade dependencies, and host-integrated assembly conflict handling continue to pass.
+- **SC-010**: Documentation gives package authors a complete metadata example and gives app authors a migration path from `PackageLoadModes` overrides to package-declared metadata.
+
+## Assumptions
+
+- The automatic policy is intended to be available by default for metadata-aware packages, with `Collectible` remaining the fallback when no advisor requires host integration.
+- Automatic selection is an option-level policy, not a third public effective load mode.
+- Explicit package-specific overrides are the strongest per-package input, but graph-level closure promotion may still make other graph members host-integrated when another effective requirement in the graph requires it.
+- Package metadata is advisory policy input, not a security boundary or permission grant.
+- Package-authored `Collectible` metadata expresses preference only; app authors use explicit package overrides when they want to force collectible behavior.
+- Nuplane reads package-root `nuplane.json` metadata from already installed/extracted packages; it does not require NuGet restore or build-time asset processing for this feature.
+- `HostIntegrated` is considered the safest deterministic conflict result when the alternative could cause framework/default-context resolution failures, even though it has weaker unloadability than `Collectible`.
+
+## Recommended Metadata Shape
+
+```json
+{
+  "schemaVersion": 1,
+  "loading": {
+    "loadMode": "HostIntegrated",
+    "scope": "DependencyClosure",
+    "reason": "Uses framework type resolution and runtime scheduler integration."
+  }
+}
+```

--- a/specs/027-auto-load-mode-selection/tasks.md
+++ b/specs/027-auto-load-mode-selection/tasks.md
@@ -1,0 +1,233 @@
+# Tasks: Automatic Load Mode Selection
+
+**Input**: Design documents from `/specs/027-auto-load-mode-selection/`  
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/automatic-load-mode-selection-contract.md, quickstart.md
+
+**Tests**: Required by the specification and constitution for changed loading behavior, public contracts, options validation, advisor parsing/precedence, graph promotion, diagnostics, and the provider-style regression.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel with other tasks in the same phase when files do not overlap
+- **[Story]**: User story label for story phases only
+- All task descriptions include exact file paths
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Prepare shared test support and public contract expectations without changing runtime behavior.
+
+- [X] T001 [P] Add metadata package fixture helpers for package-root `nuplane.json` in test/Nuplane.Loading.Tests/PackageMetadataTestSupport.cs
+- [X] T002 [P] Add public contract tests for automatic load-mode API shape in test/Nuplane.Loading.Tests/LoadingOwnershipContractTests.cs
+- [X] T003 [P] Add provider-style graph fixture helpers for metadata-driven host-integrated loading in test/Nuplane.Loading.Tests/PackageLoaderGraphRegressionTests.cs
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Define shared policy, advisor, decision, and diagnostic contracts required before any user story can be implemented.
+
+**CRITICAL**: No user story work can begin until this phase is complete.
+
+- [X] T004 Create public PackageLoadModeSelectionPolicy enum with XML documentation in src/Nuplane.Loading.Abstractions/PackageLoadModeSelectionPolicy.cs
+- [X] T005 Extend LoadingOptions with LoadModeSelectionPolicy in src/Nuplane.Loading/LoadingOptions.cs
+- [X] T006 [P] Add load-mode selection policy validation tests in test/Nuplane.Loading.Tests/LoadingOptionsValidatorTests.cs
+- [X] T007 Update LoadingOptionsValidator to validate LoadModeSelectionPolicy in src/Nuplane.Loading/LoadingOptionsValidator.cs
+- [X] T008 [P] Add fluent builder policy configuration tests in test/Nuplane.Loading.Tests/LoadingRegistrationDeterminismTests.cs
+- [X] T009 Add fluent builder method for load-mode selection policy in src/Nuplane.Loading/Builder/NuplaneLoadingBuilder.cs
+- [X] T010 Add public IPackageLoadModeAdvisor contract with XML documentation in src/Nuplane.Loading.Abstractions/IPackageLoadModeAdvisor.cs
+- [X] T011 [P] Add public LoadModeAdvisorContext model with XML documentation in src/Nuplane.Loading.Abstractions/LoadModeAdvisorContext.cs
+- [X] T012 [P] Add public LoadModeAdvisorResult model with XML documentation in src/Nuplane.Loading.Abstractions/LoadModeAdvisorResult.cs
+- [X] T013 [P] Add public LoadModeDecisionDiagnostic model with XML documentation in src/Nuplane.Loading.Abstractions/LoadModeDecisionDiagnostic.cs
+- [X] T014 Add internal PackageLoadModeDecision model in src/Nuplane.Loading/PackageLoadModeDecision.cs
+- [X] T015 Add internal PackageGraphLoadModeDecision model in src/Nuplane.Loading/PackageGraphLoadModeDecision.cs
+- [X] T016 Register PackageLoadModeSelector dependencies and advisor collection plumbing in src/Nuplane.Loading/Registration/LoadingRegistrationServices.cs
+
+**Checkpoint**: Foundational contracts, options, and registrations are ready for story work.
+
+---
+
+## Phase 3: User Story 1 - Package Authors Declare Load Requirements Once (Priority: P1) MVP
+
+**Goal**: A package can declare `HostIntegrated` dependency-closure loading in package-root `nuplane.json`, and Nuplane loads the graph as `HostIntegrated` without app-specific package overrides.
+
+**Independent Test**: Build a synthetic graph whose root package has valid metadata, configure loading with no package-specific overrides, load the graph, and verify all loadable packages are `HostIntegrated` with `package-metadata` and `dependency-closure` explanations.
+
+### Tests for User Story 1
+
+> NOTE: Write these tests first and ensure they fail before implementation.
+
+- [X] T017 [P] [US1] Add metadata reader tests for valid package-root `nuplane.json` in test/Nuplane.Loading.Tests/PackageMetadataLoadModeReaderTests.cs
+- [X] T018 [P] [US1] Add metadata advisor tests for `HostIntegrated` dependency-closure results in test/Nuplane.Loading.Tests/PackageMetadataLoadModeAdvisorTests.cs
+- [X] T019 [P] [US1] Add selector tests for metadata-driven graph promotion and no-metadata fallback in test/Nuplane.Loading.Tests/PackageLoadModeSelectorTests.cs
+- [X] T020 [P] [US1] Add loader regression test for generic provider-style metadata-driven HostIntegrated closure in test/Nuplane.Loading.Tests/PackageLoaderHostIntegratedTests.cs
+
+### Implementation for User Story 1
+
+- [X] T021 [US1] Add internal NuplanePackageMetadata model in src/Nuplane.Loading/NuplanePackageMetadata.cs
+- [X] T022 [US1] Implement package-root metadata reader in src/Nuplane.Loading/PackageMetadataLoadModeReader.cs
+- [X] T023 [US1] Implement built-in metadata advisor in src/Nuplane.Loading/PackageMetadataLoadModeAdvisor.cs
+- [X] T024 [US1] Update PackageLoadModeSelector to evaluate advisor results before fallback default in src/Nuplane.Loading/PackageLoadModeSelector.cs
+- [X] T025 [US1] Update PackageLoader to consume graph load-mode decisions before choosing collectible or host-integrated graph contexts in src/Nuplane.Loading/PackageLoader.cs
+- [X] T026 [US1] Register built-in metadata advisor in src/Nuplane.Loading/Registration/LoadingRegistrationServices.cs
+
+**Checkpoint**: User Story 1 is functional and testable independently as the MVP.
+
+---
+
+## Phase 4: User Story 2 - App Authors Override Explicitly (Priority: P1)
+
+**Goal**: Existing explicit `PackageLoadModes` configuration remains authoritative, including suppressing same-package metadata while preserving graph promotion caused by other effective host-integrated requirements.
+
+**Independent Test**: Configure package-specific overrides that conflict with package metadata and verify the explicit override wins for the matching package while diagnostics record suppression and closure promotion remains deterministic.
+
+### Tests for User Story 2
+
+- [X] T027 [P] [US2] Add selector tests for explicit HostIntegrated override winning over Collectible metadata in test/Nuplane.Loading.Tests/PackageLoadModeSelectorTests.cs
+- [X] T028 [P] [US2] Add selector tests for explicit Collectible override suppressing HostIntegrated metadata on the same package in test/Nuplane.Loading.Tests/PackageLoadModeSelectorOverrideTests.cs
+- [X] T029 [P] [US2] Add loader tests for explicit override closure promotion matching existing behavior in test/Nuplane.Loading.Tests/PackageLoaderHostIntegratedTests.cs
+
+### Implementation for User Story 2
+
+- [X] T030 [US2] Update PackageLoadModeSelector to apply package overrides before same-package advisor results in src/Nuplane.Loading/PackageLoadModeSelector.cs
+- [X] T031 [US2] Update PackageLoadModeSelector to emit metadata-suppressed diagnostics for ignored same-package advisor results in src/Nuplane.Loading/PackageLoadModeSelector.cs
+- [X] T032 [US2] Update PackageLoader graph promotion to preserve dependency-closure reason codes for packages promoted by another package in src/Nuplane.Loading/PackageLoader.cs
+
+**Checkpoint**: User Story 2 works independently and preserves app-author control over load mode.
+
+---
+
+## Phase 5: User Story 3 - Keep Collectible Loading As The Safe Default Path (Priority: P2)
+
+**Goal**: Graphs without a host-integration requirement remain collectible by fallback, and hosts can disable automatic advisor evaluation through explicit-only policy.
+
+**Independent Test**: Load graphs with no metadata, with Collectible preference metadata, and with automatic selection disabled; verify the effective mode remains `Collectible` when appropriate and no host-integrated resolution entries are published.
+
+### Tests for User Story 3
+
+- [X] T033 [P] [US3] Add selector tests for Collectible metadata preference not forcing down from HostIntegrated in test/Nuplane.Loading.Tests/PackageLoadModeSelectorPolicyTests.cs
+- [X] T034 [P] [US3] Add selector tests for ExplicitOnly policy ignoring metadata in test/Nuplane.Loading.Tests/PackageLoadModeSelectorPolicyTests.cs
+- [X] T035 [P] [US3] Add collectible fallback loader regression tests in test/Nuplane.Loading.Tests/PackageLoaderTests.cs
+- [X] T036 [P] [US3] Add host-integrated resolution catalog absence tests for collectible fallback graphs in test/Nuplane.Loading.Tests/PackageLoaderHostIntegratedTests.cs
+
+### Implementation for User Story 3
+
+- [X] T037 [US3] Update PackageLoadModeSelector to skip advisor evaluation when policy is ExplicitOnly in src/Nuplane.Loading/PackageLoadModeSelector.cs
+- [X] T038 [US3] Update PackageLoadModeSelector to treat package-authored Collectible as preference-only in src/Nuplane.Loading/PackageLoadModeSelector.cs
+- [X] T039 [US3] Update PackageLoader to avoid host-integrated visibility publication for collectible fallback graphs in src/Nuplane.Loading/PackageLoader.cs
+- [X] T040 [US3] Update NuplaneBuilderLoadingExtensions XML documentation for automatic selection policy behavior in src/Nuplane.Loading/Builder/NuplaneBuilderLoadingExtensions.cs
+
+**Checkpoint**: User Story 3 works independently and protects existing collectible/isolation scenarios.
+
+---
+
+## Phase 6: User Story 4 - Explain Load Mode Decisions (Priority: P2)
+
+**Goal**: Operators can query loading state and read logs to understand default fallback, package override, package metadata, dependency-closure promotion, invalid metadata, suppressed metadata, and conflict decisions.
+
+**Independent Test**: Load graphs covering all reason codes and verify `LoadingPackageDescriptor` plus structured logs expose stable, secret-safe explanations.
+
+### Tests for User Story 4
+
+- [X] T041 [P] [US4] Add metadata reader tests for malformed JSON, unsupported schema, unsupported load mode, unsupported scope, missing fields, and oversized metadata in test/Nuplane.Loading.Tests/PackageMetadataLoadModeReaderTests.cs
+- [X] T042 [P] [US4] Add selector tests for metadata conflicts resolving deterministically to HostIntegrated in test/Nuplane.Loading.Tests/PackageLoadModeSelectorConflictTests.cs
+- [X] T043 [P] [US4] Add loading catalog descriptor explanation tests for all reason codes in test/Nuplane.Loading.Tests/LoadingCatalogTests.cs
+- [X] T044 [P] [US4] Add observability tests for advisor evaluation and metadata diagnostics in test/Nuplane.Loading.Tests/LoadingCatalogObservabilityTests.cs
+
+### Implementation for User Story 4
+
+- [X] T045 [US4] Update PackageMetadataLoadModeReader to return metadata-invalid diagnostics for malformed or unsupported metadata in src/Nuplane.Loading/PackageMetadataLoadModeReader.cs
+- [X] T046 [US4] Update PackageLoadModeSelector to resolve metadata conflicts with HostIntegrated and metadata-conflict diagnostics in src/Nuplane.Loading/PackageLoadModeSelector.cs
+- [X] T047 [US4] Extend LoadingPackageDescriptor with load-mode decision diagnostics in src/Nuplane.Loading.Abstractions/LoadingPackageDescriptor.cs
+- [X] T048 [US4] Update LoadingCatalog to project load-mode decision diagnostics onto descriptors in src/Nuplane.Loading/LoadingCatalog.cs
+- [X] T049 [US4] Add structured load-mode advisor logging methods in src/Nuplane.Loading/LoadingLogger.cs
+- [X] T050 [US4] Wire advisor, metadata, override-suppression, conflict, and final graph-mode logs in src/Nuplane.Loading/PackageLoadModeSelector.cs
+
+**Checkpoint**: User Story 4 works independently with deterministic operator-facing explanations.
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+**Purpose**: Documentation, contract alignment, and validation across all stories.
+
+- [X] T051 [P] Update README loading guidance for automatic selection and package-root metadata in README.md
+- [X] T052 [P] Update wiki usage guidance for automatic load-mode selection in docs/wiki/Usage-Guide.md
+- [X] T053 [P] Update glossary with automatic selection, advisor, and Nuplane package metadata terms in docs/wiki/Concepts-and-Glossary.md
+- [X] T054 [P] Update package authoring metadata guidance in docs/wiki/Package-Authoring.md
+- [X] T055 Run quickstart validation scenarios and record notes in specs/027-auto-load-mode-selection/quickstart.md
+- [X] T056 Run focused loading tests with `dotnet test test/Nuplane.Loading.Tests/Nuplane.Loading.Tests.csproj`
+- [X] T057 Run full solution tests with `dotnet test nuplane.sln`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1**: No dependencies; can start immediately.
+- **Phase 2**: Depends on Phase 1 setup; blocks all user story work.
+- **Phase 3 (US1)**: Depends on Phase 2; delivers MVP metadata-driven host-integrated graph selection.
+- **Phase 4 (US2)**: Depends on Phase 2; can proceed after selector contracts are stable and complements US1 behavior.
+- **Phase 5 (US3)**: Depends on Phase 2; can proceed after policy and selector contracts are stable.
+- **Phase 6 (US4)**: Depends on US1-US3 reason-code production paths.
+- **Phase 7**: Depends on completed story behavior.
+
+### User Story Dependencies
+
+- **US1**: Requires foundational advisor, policy, and decision contracts.
+- **US2**: Requires foundational advisor and selector contracts; validates explicit override precedence.
+- **US3**: Requires foundational policy and selector contracts; validates default/disabled behavior.
+- **US4**: Requires decision data produced by US1-US3 and projects it to descriptors/logs.
+
+### Parallel Opportunities
+
+- T001, T002, and T003 can run in parallel.
+- T006, T008, and T011-T013 can run in parallel after T004-T005 are sketched.
+- T017-T020 can run in parallel because they target separate test files.
+- T027-T029 can run in parallel because they cover distinct override behavior.
+- T033-T036 can run in parallel because they cover policy and loader fallback behavior in separate tests.
+- T041-T044 can run in parallel because they cover reader, selector, catalog, and observability surfaces.
+- T051-T054 can run in parallel during documentation polish.
+
+## Parallel Example: User Story 1
+
+```text
+Task: "Add metadata reader tests for valid package-root `nuplane.json` in test/Nuplane.Loading.Tests/PackageMetadataLoadModeReaderTests.cs"
+Task: "Add metadata advisor tests for `HostIntegrated` dependency-closure results in test/Nuplane.Loading.Tests/PackageMetadataLoadModeAdvisorTests.cs"
+Task: "Add selector tests for metadata-driven graph promotion and no-metadata fallback in test/Nuplane.Loading.Tests/PackageLoadModeSelectorTests.cs"
+Task: "Add loader regression test for generic provider-style metadata-driven HostIntegrated closure in test/Nuplane.Loading.Tests/PackageLoaderHostIntegratedTests.cs"
+```
+
+## Parallel Example: User Story 4
+
+```text
+Task: "Add metadata reader tests for malformed JSON, unsupported schema, unsupported load mode, unsupported scope, missing fields, and oversized metadata in test/Nuplane.Loading.Tests/PackageMetadataLoadModeReaderTests.cs"
+Task: "Add selector tests for metadata conflicts resolving deterministically to HostIntegrated in test/Nuplane.Loading.Tests/PackageLoadModeSelectorConflictTests.cs"
+Task: "Add loading catalog descriptor explanation tests for all reason codes in test/Nuplane.Loading.Tests/LoadingCatalogTests.cs"
+Task: "Add observability tests for advisor evaluation and metadata diagnostics in test/Nuplane.Loading.Tests/LoadingCatalogObservabilityTests.cs"
+```
+
+## Implementation Strategy
+
+### MVP First (US1 Only)
+
+1. Complete Phase 1 setup.
+2. Complete Phase 2 foundations.
+3. Complete Phase 3 metadata reader, metadata advisor, selector, and loader integration.
+4. Run `dotnet test test/Nuplane.Loading.Tests/Nuplane.Loading.Tests.csproj --filter "FullyQualifiedName~PackageMetadataLoadMode|FullyQualifiedName~PackageLoadModeSelector|FullyQualifiedName~PackageLoaderHostIntegrated"`.
+
+### Incremental Delivery
+
+1. Deliver US1 to prove package-authored metadata can promote a graph to `HostIntegrated`.
+2. Deliver US2 to lock explicit app override precedence and suppression diagnostics.
+3. Deliver US3 to preserve collectible fallback and explicit-only policy.
+4. Deliver US4 to expose complete decision explanations.
+5. Complete documentation and full validation.
+
+### Validation Gates
+
+- Every changed public/protected API has XML documentation.
+- New options remain data-only and are validated through `IValidateOptions<LoadingOptions>`.
+- `LoadingPackageDescriptor` can explain every required reason code.
+- Existing explicit host-integrated override tests and collectible loading tests still pass.

--- a/src/Nuplane.Loading.Abstractions/IPackageLoadModeAdvisor.cs
+++ b/src/Nuplane.Loading.Abstractions/IPackageLoadModeAdvisor.cs
@@ -1,0 +1,22 @@
+namespace Nuplane.Loading;
+
+/// <summary>
+/// Provides load-mode advice for a resolved package graph before Nuplane creates loading contexts.
+/// </summary>
+public interface IPackageLoadModeAdvisor
+{
+    /// <summary>
+    /// Gets the stable advisor name used in diagnostics.
+    /// </summary>
+    string Name { get; }
+
+    /// <summary>
+    /// Evaluates load-mode advice for the supplied graph context.
+    /// </summary>
+    /// <param name="context">The graph context being evaluated.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>Advisor results for the graph.</returns>
+    ValueTask<IReadOnlyList<LoadModeAdvisorResult>> EvaluateAsync(
+        LoadModeAdvisorContext context,
+        CancellationToken cancellationToken);
+}

--- a/src/Nuplane.Loading.Abstractions/LoadModeAdvisorContext.cs
+++ b/src/Nuplane.Loading.Abstractions/LoadModeAdvisorContext.cs
@@ -1,0 +1,18 @@
+using Nuplane.Abstractions;
+
+namespace Nuplane.Loading;
+
+/// <summary>
+/// Provides deterministic graph and configuration context to package load-mode advisors.
+/// </summary>
+/// <param name="GraphKey">The deterministic loading graph key.</param>
+/// <param name="Packages">The resolved packages in the graph.</param>
+/// <param name="SelectionPolicy">The active load-mode selection policy.</param>
+/// <param name="DefaultLoadMode">The configured fallback load mode.</param>
+/// <param name="PackageOverrides">The configured package-specific load mode overrides keyed by package ID.</param>
+public sealed record LoadModeAdvisorContext(
+    string GraphKey,
+    IReadOnlyList<ResolvedPackage> Packages,
+    PackageLoadModeSelectionPolicy SelectionPolicy,
+    PackageLoadMode DefaultLoadMode,
+    IReadOnlyDictionary<string, PackageLoadMode> PackageOverrides);

--- a/src/Nuplane.Loading.Abstractions/LoadModeAdvisorResult.cs
+++ b/src/Nuplane.Loading.Abstractions/LoadModeAdvisorResult.cs
@@ -1,0 +1,24 @@
+namespace Nuplane.Loading;
+
+/// <summary>
+/// Represents one package load-mode advisor result.
+/// </summary>
+/// <param name="AdvisorName">The stable advisor name.</param>
+/// <param name="PackageId">The package that declared or produced the result.</param>
+/// <param name="Version">The package version.</param>
+/// <param name="RequestedLoadMode">The requested or preferred load mode.</param>
+/// <param name="Scope">The requested scope, such as <c>DependencyClosure</c> or <c>PackageOnly</c>.</param>
+/// <param name="ReasonCode">The stable machine-readable reason code.</param>
+/// <param name="Reason">The optional human-readable reason.</param>
+/// <param name="IsValid">Whether this result can influence effective mode selection.</param>
+/// <param name="Diagnostic">The optional diagnostic for invalid or degraded advisor results.</param>
+public sealed record LoadModeAdvisorResult(
+    string AdvisorName,
+    string PackageId,
+    string Version,
+    PackageLoadMode RequestedLoadMode,
+    string Scope,
+    string ReasonCode,
+    string? Reason,
+    bool IsValid = true,
+    string? Diagnostic = null);

--- a/src/Nuplane.Loading.Abstractions/LoadModeDecisionDiagnostic.cs
+++ b/src/Nuplane.Loading.Abstractions/LoadModeDecisionDiagnostic.cs
@@ -1,0 +1,24 @@
+namespace Nuplane.Loading;
+
+/// <summary>
+/// Explains why Nuplane selected an effective package or graph load mode.
+/// </summary>
+/// <param name="GraphKey">The deterministic loading graph key.</param>
+/// <param name="EffectiveGraphLoadMode">The final graph load mode.</param>
+/// <param name="EffectivePackageLoadMode">The final package load mode.</param>
+/// <param name="ReasonCode">The stable machine-readable reason code.</param>
+/// <param name="DeclaringPackageId">The package that declared the requirement, when available.</param>
+/// <param name="DeclaringPackageVersion">The declaring package version, when available.</param>
+/// <param name="RequestedScope">The requested metadata/advisor scope, when available.</param>
+/// <param name="AdvisorName">The advisor that produced the decision input, when available.</param>
+/// <param name="Message">A bounded, secret-safe message.</param>
+public sealed record LoadModeDecisionDiagnostic(
+    string GraphKey,
+    PackageLoadMode EffectiveGraphLoadMode,
+    PackageLoadMode EffectivePackageLoadMode,
+    string ReasonCode,
+    string? DeclaringPackageId = null,
+    string? DeclaringPackageVersion = null,
+    string? RequestedScope = null,
+    string? AdvisorName = null,
+    string? Message = null);

--- a/src/Nuplane.Loading.Abstractions/LoadingPackageDescriptor.cs
+++ b/src/Nuplane.Loading.Abstractions/LoadingPackageDescriptor.cs
@@ -13,6 +13,7 @@ namespace Nuplane.Loading;
 /// <param name="ContextKey">The current load-context key, when one exists.</param>
 /// <param name="LoadMode">The effective load mode used for the package.</param>
 /// <param name="FrameworkIntegrationSafe">Whether the loaded package assemblies are safe for framework integration.</param>
+/// <param name="LoadModeDiagnostics">Secret-safe diagnostics explaining the effective load mode.</param>
 internal sealed record LoadingPackageDescriptor(
     string PackageId,
     string Version,
@@ -23,4 +24,5 @@ internal sealed record LoadingPackageDescriptor(
     IReadOnlyList<AssemblyScanCandidate> ScanCandidates,
     string? ContextKey,
     PackageLoadMode LoadMode = PackageLoadMode.Collectible,
-    bool FrameworkIntegrationSafe = false);
+    bool FrameworkIntegrationSafe = false,
+    IReadOnlyList<LoadModeDecisionDiagnostic>? LoadModeDiagnostics = null);

--- a/src/Nuplane.Loading.Abstractions/PackageLoadModeSelectionPolicy.cs
+++ b/src/Nuplane.Loading.Abstractions/PackageLoadModeSelectionPolicy.cs
@@ -1,0 +1,17 @@
+namespace Nuplane.Loading;
+
+/// <summary>
+/// Controls whether Nuplane evaluates load-mode advisors before applying fallback load-mode configuration.
+/// </summary>
+public enum PackageLoadModeSelectionPolicy
+{
+    /// <summary>
+    /// Evaluates registered advisors, then falls back to configured defaults and package overrides.
+    /// </summary>
+    Automatic = 0,
+
+    /// <summary>
+    /// Ignores advisor results and uses only explicit package overrides plus the configured default load mode.
+    /// </summary>
+    ExplicitOnly = 1
+}

--- a/src/Nuplane.Loading.Abstractions/PackageLoadSession.cs
+++ b/src/Nuplane.Loading.Abstractions/PackageLoadSession.cs
@@ -13,6 +13,7 @@ namespace Nuplane.Loading;
 /// <param name="LastError">The error message from the last failed load attempt, if any.</param>
 /// <param name="LoadMode">The effective load mode used for the package.</param>
 /// <param name="FrameworkIntegrationSafe">Whether the loaded package assemblies are safe for framework integration.</param>
+/// <param name="LoadModeDiagnostics">Secret-safe diagnostics explaining the effective load mode.</param>
 internal sealed record PackageLoadSession(
     string PackageId,
     string Version,
@@ -22,4 +23,5 @@ internal sealed record PackageLoadSession(
     bool IsLoaded,
     string? LastError,
     PackageLoadMode LoadMode = PackageLoadMode.Collectible,
-    bool FrameworkIntegrationSafe = false);
+    bool FrameworkIntegrationSafe = false,
+    IReadOnlyList<LoadModeDecisionDiagnostic>? LoadModeDiagnostics = null);

--- a/src/Nuplane.Loading.Abstractions/PackageLoadState.cs
+++ b/src/Nuplane.Loading.Abstractions/PackageLoadState.cs
@@ -13,7 +13,6 @@ namespace Nuplane.Loading;
 /// <param name="Discoverable">Whether this loaded package should be exposed by default discovery surfaces.</param>
 /// <param name="LoadMode">The effective load mode used for the package.</param>
 /// <param name="FrameworkIntegrationSafe">Whether the loaded package assemblies are safe for framework integration.</param>
-/// <param name="LoadModeDiagnostics">Secret-safe diagnostics explaining the effective load mode.</param>
 public sealed record PackageLoadState(
     string PackageId,
     string Version,
@@ -24,9 +23,13 @@ public sealed record PackageLoadState(
     IReadOnlyList<PackageAssemblyReference> AssemblyReferences,
     bool Discoverable = true,
     PackageLoadMode LoadMode = PackageLoadMode.Collectible,
-    bool FrameworkIntegrationSafe = false,
-    IReadOnlyList<LoadModeDecisionDiagnostic>? LoadModeDiagnostics = null)
+    bool FrameworkIntegrationSafe = false)
 {
+    /// <summary>
+    /// Gets secret-safe diagnostics explaining the effective load mode.
+    /// </summary>
+    public IReadOnlyList<LoadModeDecisionDiagnostic>? LoadModeDiagnostics { get; init; }
+
     /// <summary>
     /// Creates a canonical package load-state record from the legacy loading descriptor model.
     /// </summary>
@@ -51,7 +54,9 @@ public sealed record PackageLoadState(
             descriptor.ScanCandidates.Select(static candidate => PackageAssemblyReference.FromCandidate(candidate)).ToArray(),
             Discoverable: true,
             descriptor.LoadMode,
-            descriptor.FrameworkIntegrationSafe,
-            descriptor.LoadModeDiagnostics);
+            descriptor.FrameworkIntegrationSafe)
+        {
+            LoadModeDiagnostics = descriptor.LoadModeDiagnostics
+        };
     }
 }

--- a/src/Nuplane.Loading.Abstractions/PackageLoadState.cs
+++ b/src/Nuplane.Loading.Abstractions/PackageLoadState.cs
@@ -13,6 +13,7 @@ namespace Nuplane.Loading;
 /// <param name="Discoverable">Whether this loaded package should be exposed by default discovery surfaces.</param>
 /// <param name="LoadMode">The effective load mode used for the package.</param>
 /// <param name="FrameworkIntegrationSafe">Whether the loaded package assemblies are safe for framework integration.</param>
+/// <param name="LoadModeDiagnostics">Secret-safe diagnostics explaining the effective load mode.</param>
 public sealed record PackageLoadState(
     string PackageId,
     string Version,
@@ -23,7 +24,8 @@ public sealed record PackageLoadState(
     IReadOnlyList<PackageAssemblyReference> AssemblyReferences,
     bool Discoverable = true,
     PackageLoadMode LoadMode = PackageLoadMode.Collectible,
-    bool FrameworkIntegrationSafe = false)
+    bool FrameworkIntegrationSafe = false,
+    IReadOnlyList<LoadModeDecisionDiagnostic>? LoadModeDiagnostics = null)
 {
     /// <summary>
     /// Creates a canonical package load-state record from the legacy loading descriptor model.
@@ -49,6 +51,7 @@ public sealed record PackageLoadState(
             descriptor.ScanCandidates.Select(static candidate => PackageAssemblyReference.FromCandidate(candidate)).ToArray(),
             Discoverable: true,
             descriptor.LoadMode,
-            descriptor.FrameworkIntegrationSafe);
+            descriptor.FrameworkIntegrationSafe,
+            descriptor.LoadModeDiagnostics);
     }
 }

--- a/src/Nuplane.Loading/Builder/NuplaneBuilderLoadingExtensions.cs
+++ b/src/Nuplane.Loading/Builder/NuplaneBuilderLoadingExtensions.cs
@@ -19,6 +19,8 @@ public static class NuplaneBuilderLoadingExtensions
     /// Installs the Nuplane assembly loading subsystem from configuration or the <c>Loading</c>
     /// subsection itself, then applies any additional builder customization.
     /// Configuration binds first; the optional builder callback runs afterward and can override it.
+    /// Load-mode selection uses package metadata advisors by default and can be changed through
+    /// <see cref="NuplaneLoadingBuilder.WithLoadModeSelectionPolicy(PackageLoadModeSelectionPolicy)"/>.
     /// </summary>
     /// <param name="builder">The Nuplane builder to extend.</param>
     /// <param name="configuration">The application configuration.</param>
@@ -41,7 +43,9 @@ public static class NuplaneBuilderLoadingExtensions
 
     /// <summary>
     /// Installs the Nuplane assembly loading subsystem, including its canonical public query services
-    /// and the internal auto-loading bridge that keeps load state current.
+    /// and the internal auto-loading bridge that keeps load state current. Automatic load-mode
+    /// selection is enabled by default and falls back to the configured default load mode when no
+    /// package metadata or explicit override applies.
     /// </summary>
     /// <param name="builder">The Nuplane builder to extend.</param>
     /// <param name="configure">An optional callback to configure loading options.</param>

--- a/src/Nuplane.Loading/Builder/NuplaneLoadingBuilder.cs
+++ b/src/Nuplane.Loading/Builder/NuplaneLoadingBuilder.cs
@@ -66,6 +66,20 @@ public sealed class NuplaneLoadingBuilder
     }
 
     /// <summary>
+    /// Sets the package load-mode selection policy used before falling back to the default load mode.
+    /// </summary>
+    /// <param name="selectionPolicy">The selection policy to apply.</param>
+    public NuplaneLoadingBuilder WithLoadModeSelectionPolicy(PackageLoadModeSelectionPolicy selectionPolicy)
+    {
+        Services.Configure<LoadingOptions>(options =>
+        {
+            options.LoadModeSelectionPolicy = selectionPolicy;
+        });
+
+        return this;
+    }
+
+    /// <summary>
     /// Sets a package-specific load mode override.
     /// </summary>
     /// <param name="packageId">The package identifier to override.</param>

--- a/src/Nuplane.Loading/LoadModeReasonCodes.cs
+++ b/src/Nuplane.Loading/LoadModeReasonCodes.cs
@@ -8,6 +8,7 @@ internal static class LoadModeReasonCodes
     public const string DependencyClosure = "dependency-closure";
     public const string MetadataInvalid = "metadata-invalid";
     public const string MetadataSuppressed = "metadata-suppressed";
+    public const string AdvisorSuppressed = "advisor-suppressed";
     public const string MetadataConflict = "metadata-conflict";
     public const string AdvisorsDisabled = "advisors-disabled";
 }

--- a/src/Nuplane.Loading/LoadModeReasonCodes.cs
+++ b/src/Nuplane.Loading/LoadModeReasonCodes.cs
@@ -1,0 +1,19 @@
+namespace Nuplane.Loading;
+
+internal static class LoadModeReasonCodes
+{
+    public const string Default = "default";
+    public const string PackageOverride = "package-override";
+    public const string PackageMetadata = "package-metadata";
+    public const string DependencyClosure = "dependency-closure";
+    public const string MetadataInvalid = "metadata-invalid";
+    public const string MetadataSuppressed = "metadata-suppressed";
+    public const string MetadataConflict = "metadata-conflict";
+    public const string AdvisorsDisabled = "advisors-disabled";
+}
+
+internal static class LoadModeScopes
+{
+    public const string DependencyClosure = "DependencyClosure";
+    public const string PackageOnly = "PackageOnly";
+}

--- a/src/Nuplane.Loading/LoadingCatalog.cs
+++ b/src/Nuplane.Loading/LoadingCatalog.cs
@@ -143,7 +143,8 @@ internal sealed class LoadingCatalog(
                 package.AssemblyReferences.Select(static reference => reference.ToCandidate()).ToArray(),
                 null,
                 package.LoadMode,
-                package.FrameworkIntegrationSafe)).ToArray(),
+                package.FrameworkIntegrationSafe,
+                package.LoadModeDiagnostics)).ToArray(),
             snapshot.Reason,
             snapshot.CorrelationId);
     }
@@ -165,7 +166,8 @@ internal sealed class LoadingCatalog(
             assemblyReferences.ToArray(),
             package.Discoverable,
             session?.LoadMode ?? PackageLoadMode.Collectible,
-            session?.FrameworkIntegrationSafe ?? false);
+            session?.FrameworkIntegrationSafe ?? false,
+            session?.LoadModeDiagnostics ?? []);
 
     private static IReadOnlyList<string> BuildDiagnostics(string? message)
     {

--- a/src/Nuplane.Loading/LoadingCatalog.cs
+++ b/src/Nuplane.Loading/LoadingCatalog.cs
@@ -156,7 +156,7 @@ internal sealed class LoadingCatalog(
         IReadOnlyList<string> diagnostics,
         IReadOnlyList<PackageAssemblyReference> assemblyReferences,
         PackageLoadSession? session = null) =>
-        new(
+        new PackageLoadState(
             package.PackageId,
             package.Version,
             status,
@@ -166,8 +166,10 @@ internal sealed class LoadingCatalog(
             assemblyReferences.ToArray(),
             package.Discoverable,
             session?.LoadMode ?? PackageLoadMode.Collectible,
-            session?.FrameworkIntegrationSafe ?? false,
-            session?.LoadModeDiagnostics ?? []);
+            session?.FrameworkIntegrationSafe ?? false)
+        {
+            LoadModeDiagnostics = session?.LoadModeDiagnostics ?? []
+        };
 
     private static IReadOnlyList<string> BuildDiagnostics(string? message)
     {

--- a/src/Nuplane.Loading/LoadingLogger.cs
+++ b/src/Nuplane.Loading/LoadingLogger.cs
@@ -52,4 +52,16 @@ internal static partial class LoadingLogger
         this ILogger logger,
         string graphKey,
         PackageLoadMode loadMode);
+
+    [LoggerMessage(
+        EventId = 2106,
+        Level = LogLevel.Information,
+        Message = "Discovered package load metadata for {PackageId}@{Version} in graph {GraphKey}: LoadMode={LoadMode}, Scope={Scope}.")]
+    public static partial void PackageLoadMetadataDiscovered(
+        this ILogger logger,
+        string packageId,
+        string version,
+        string graphKey,
+        PackageLoadMode loadMode,
+        string scope);
 }

--- a/src/Nuplane.Loading/LoadingLogger.cs
+++ b/src/Nuplane.Loading/LoadingLogger.cs
@@ -17,8 +17,8 @@ internal static partial class LoadingLogger
     [LoggerMessage(
         EventId = 2102,
         Level = LogLevel.Warning,
-        Message = "Ignored invalid package load metadata for {PackageId}@{Version} in graph {GraphKey}: {Diagnostic}")]
-    public static partial void InvalidPackageLoadMetadata(
+        Message = "Ignored invalid package load-mode advisor result for {PackageId}@{Version} in graph {GraphKey}: {Diagnostic}")]
+    public static partial void InvalidPackageLoadModeAdvisorResult(
         this ILogger logger,
         string packageId,
         string version,
@@ -28,8 +28,8 @@ internal static partial class LoadingLogger
     [LoggerMessage(
         EventId = 2103,
         Level = LogLevel.Information,
-        Message = "Suppressed package load metadata for {PackageId}@{Version} in graph {GraphKey} because an explicit package override was configured.")]
-    public static partial void PackageLoadMetadataSuppressed(
+        Message = "Suppressed package load-mode advisor result for {PackageId}@{Version} in graph {GraphKey} because a higher-precedence load-mode policy was configured.")]
+    public static partial void PackageLoadModeAdvisorResultSuppressed(
         this ILogger logger,
         string packageId,
         string version,

--- a/src/Nuplane.Loading/LoadingLogger.cs
+++ b/src/Nuplane.Loading/LoadingLogger.cs
@@ -1,0 +1,55 @@
+using Microsoft.Extensions.Logging;
+
+namespace Nuplane.Loading;
+
+internal static partial class LoadingLogger
+{
+    [LoggerMessage(
+        EventId = 2101,
+        Level = LogLevel.Information,
+        Message = "Evaluated load mode advisor {AdvisorName} for graph {GraphKey} with ResultCount={ResultCount}.")]
+    public static partial void LoadModeAdvisorEvaluated(
+        this ILogger logger,
+        string advisorName,
+        string graphKey,
+        int resultCount);
+
+    [LoggerMessage(
+        EventId = 2102,
+        Level = LogLevel.Warning,
+        Message = "Ignored invalid package load metadata for {PackageId}@{Version} in graph {GraphKey}: {Diagnostic}")]
+    public static partial void InvalidPackageLoadMetadata(
+        this ILogger logger,
+        string packageId,
+        string version,
+        string graphKey,
+        string diagnostic);
+
+    [LoggerMessage(
+        EventId = 2103,
+        Level = LogLevel.Information,
+        Message = "Suppressed package load metadata for {PackageId}@{Version} in graph {GraphKey} because an explicit package override was configured.")]
+    public static partial void PackageLoadMetadataSuppressed(
+        this ILogger logger,
+        string packageId,
+        string version,
+        string graphKey);
+
+    [LoggerMessage(
+        EventId = 2104,
+        Level = LogLevel.Warning,
+        Message = "Resolved package load metadata conflict in graph {GraphKey} by selecting {LoadMode}.")]
+    public static partial void PackageLoadMetadataConflict(
+        this ILogger logger,
+        string graphKey,
+        PackageLoadMode loadMode);
+
+    [LoggerMessage(
+        EventId = 2105,
+        Level = LogLevel.Information,
+        Message = "Selected graph load mode {LoadMode} for graph {GraphKey}.")]
+    public static partial void GraphLoadModeSelected(
+        this ILogger logger,
+        string graphKey,
+        PackageLoadMode loadMode);
+}

--- a/src/Nuplane.Loading/LoadingOptions.cs
+++ b/src/Nuplane.Loading/LoadingOptions.cs
@@ -27,6 +27,11 @@ public sealed class LoadingOptions
     public PackageLoadMode DefaultLoadMode { get; set; } = PackageLoadMode.Collectible;
 
     /// <summary>
+    /// Gets or sets how Nuplane selects package load modes before applying the default load mode.
+    /// </summary>
+    public PackageLoadModeSelectionPolicy LoadModeSelectionPolicy { get; set; } = PackageLoadModeSelectionPolicy.Automatic;
+
+    /// <summary>
     /// Gets the collection of package-specific load mode overrides.
     /// </summary>
     public ICollection<PackageLoadModeOverrideOptions> PackageLoadModes { get; } = new List<PackageLoadModeOverrideOptions>();

--- a/src/Nuplane.Loading/LoadingOptionsValidator.cs
+++ b/src/Nuplane.Loading/LoadingOptionsValidator.cs
@@ -31,6 +31,11 @@ public sealed class LoadingOptionsValidator
             errors.Add($"Loading default load mode '{options.DefaultLoadMode}' is not supported.");
         }
 
+        if (!Enum.IsDefined(options.LoadModeSelectionPolicy))
+        {
+            errors.Add($"Loading load mode selection policy '{options.LoadModeSelectionPolicy}' is not supported.");
+        }
+
         var seenPackageOverrides = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         foreach (var packageOverride in options.PackageLoadModes)
         {

--- a/src/Nuplane.Loading/NuplanePackageMetadata.cs
+++ b/src/Nuplane.Loading/NuplanePackageMetadata.cs
@@ -1,0 +1,26 @@
+namespace Nuplane.Loading;
+
+internal sealed record NuplanePackageMetadata(
+    int SchemaVersion,
+    NuplanePackageLoadingMetadata? Loading);
+
+internal sealed record NuplanePackageLoadingMetadata(
+    PackageLoadMode LoadMode,
+    string Scope,
+    string? Reason);
+
+internal sealed record PackageMetadataLoadModeReadResult(
+    bool MetadataFound,
+    bool IsValid,
+    NuplanePackageMetadata? Metadata,
+    string? Diagnostic)
+{
+    public static PackageMetadataLoadModeReadResult Missing { get; } =
+        new(MetadataFound: false, IsValid: false, Metadata: null, Diagnostic: null);
+
+    public static PackageMetadataLoadModeReadResult Invalid(string diagnostic) =>
+        new(MetadataFound: true, IsValid: false, Metadata: null, Diagnostic: diagnostic);
+
+    public static PackageMetadataLoadModeReadResult Valid(NuplanePackageMetadata metadata) =>
+        new(MetadataFound: true, IsValid: true, Metadata: metadata, Diagnostic: null);
+}

--- a/src/Nuplane.Loading/PackageGraphLoadModeDecision.cs
+++ b/src/Nuplane.Loading/PackageGraphLoadModeDecision.cs
@@ -1,0 +1,7 @@
+namespace Nuplane.Loading;
+
+internal sealed record PackageGraphLoadModeDecision(
+    string GraphKey,
+    PackageLoadMode LoadMode,
+    IReadOnlyList<PackageLoadModeSelection> Selections,
+    IReadOnlyDictionary<string, IReadOnlyList<LoadModeDecisionDiagnostic>> DiagnosticsByPackageKey);

--- a/src/Nuplane.Loading/PackageLoadModeDecision.cs
+++ b/src/Nuplane.Loading/PackageLoadModeDecision.cs
@@ -1,0 +1,5 @@
+namespace Nuplane.Loading;
+
+internal sealed record PackageLoadModeDecision(
+    PackageLoadModeSelection Selection,
+    IReadOnlyList<LoadModeDecisionDiagnostic> Diagnostics);

--- a/src/Nuplane.Loading/PackageLoadModeSelector.cs
+++ b/src/Nuplane.Loading/PackageLoadModeSelector.cs
@@ -110,8 +110,18 @@ internal sealed class PackageLoadModeSelector
             logger.PackageLoadMetadataConflict(graphKey, graphLoadMode);
         }
 
+        IReadOnlySet<string> conflictingMetadataKeys = metadataConflict
+            ? decisions
+                .Where(static decision => decision.Diagnostics.Any(static diagnostic =>
+                    diagnostic.ReasonCode == LoadModeReasonCodes.PackageMetadata
+                    && (diagnostic.EffectivePackageLoadMode == PackageLoadMode.HostIntegrated
+                        || diagnostic.EffectivePackageLoadMode == PackageLoadMode.Collectible)))
+                .Select(static decision => BuildKey(decision.Selection.PackageId, decision.Selection.Version))
+                .ToHashSet(StringComparer.OrdinalIgnoreCase)
+            : [];
+
         var promotedDecisions = decisions
-            .Select(decision => PromoteDecision(decision, graphKey, graphLoadMode, metadataConflict))
+            .Select(decision => PromoteDecision(decision, graphKey, graphLoadMode, conflictingMetadataKeys))
             .ToArray();
 
         logger.GraphLoadModeSelected(graphKey, graphLoadMode);
@@ -239,7 +249,7 @@ internal sealed class PackageLoadModeSelector
         PackageLoadModeDecision decision,
         string graphKey,
         PackageLoadMode graphLoadMode,
-        bool metadataConflict)
+        IReadOnlySet<string> conflictingMetadataKeys)
     {
         var diagnostics = decision.Diagnostics.ToList();
         var selection = decision.Selection;
@@ -261,7 +271,7 @@ internal sealed class PackageLoadModeSelector
                 Message: "Package was promoted because another package in the graph required host-integrated loading."));
         }
 
-        if (metadataConflict)
+        if (conflictingMetadataKeys.Contains(BuildKey(selection.PackageId, selection.Version)))
         {
             diagnostics.Add(new(
                 graphKey,

--- a/src/Nuplane.Loading/PackageLoadModeSelector.cs
+++ b/src/Nuplane.Loading/PackageLoadModeSelector.cs
@@ -149,21 +149,17 @@ internal sealed class PackageLoadModeSelector
             if (!result.IsValid)
             {
                 diagnostics.Add(CreateAdvisorDiagnostic(graphKey, loadMode, loadMode, result));
-                logger.InvalidPackageLoadMetadata(package.Id, package.Version, graphKey, result.Diagnostic ?? "Package metadata is invalid.");
+                logger.InvalidPackageLoadModeAdvisorResult(package.Id, package.Version, graphKey, result.Diagnostic ?? "Package load-mode advisor result is invalid.");
                 continue;
             }
 
-            diagnostics.Add(new(
+            diagnostics.Add(CreateSuppressedAdvisorDiagnostic(
                 graphKey,
                 loadMode,
                 loadMode,
-                LoadModeReasonCodes.MetadataSuppressed,
-                result.PackageId,
-                result.Version,
-                result.Scope,
-                result.AdvisorName,
-                "Package metadata was suppressed by an explicit package load mode override."));
-            logger.PackageLoadMetadataSuppressed(package.Id, package.Version, graphKey);
+                result,
+                "Package load-mode advisor result was suppressed by an explicit package load mode override."));
+            logger.PackageLoadModeAdvisorResultSuppressed(package.Id, package.Version, graphKey);
         }
 
         return new(new(package.Id, package.Version, loadMode, LoadModeReasonCodes.PackageOverride, graphKey), diagnostics);
@@ -179,7 +175,7 @@ internal sealed class PackageLoadModeSelector
         foreach (var invalidResult in packageResults.Where(static result => !result.IsValid))
         {
             diagnostics.Add(CreateAdvisorDiagnostic(graphKey, options.DefaultLoadMode, options.DefaultLoadMode, invalidResult));
-            logger.InvalidPackageLoadMetadata(package.Id, package.Version, graphKey, invalidResult.Diagnostic ?? "Package metadata is invalid.");
+            logger.InvalidPackageLoadModeAdvisorResult(package.Id, package.Version, graphKey, invalidResult.Diagnostic ?? "Package load-mode advisor result is invalid.");
         }
 
         var validResults = packageResults
@@ -212,17 +208,13 @@ internal sealed class PackageLoadModeSelector
                     diagnostics);
             }
 
-            diagnostics.Add(new(
+            diagnostics.Add(CreateSuppressedAdvisorDiagnostic(
                 graphKey,
                 options.DefaultLoadMode,
                 options.DefaultLoadMode,
-                LoadModeReasonCodes.MetadataSuppressed,
-                collectiblePreference.PackageId,
-                collectiblePreference.Version,
-                collectiblePreference.Scope,
-                collectiblePreference.AdvisorName,
+                collectiblePreference,
                 "Package metadata requested Collectible but the configured default load mode takes precedence."));
-            logger.PackageLoadMetadataSuppressed(package.Id, package.Version, graphKey);
+            logger.PackageLoadModeAdvisorResultSuppressed(package.Id, package.Version, graphKey);
         }
 
         diagnostics.Add(new(
@@ -309,6 +301,27 @@ internal sealed class PackageLoadModeSelector
             result.Scope,
             result.AdvisorName,
             result.Diagnostic ?? result.Reason);
+
+    private static LoadModeDecisionDiagnostic CreateSuppressedAdvisorDiagnostic(
+        string graphKey,
+        PackageLoadMode graphLoadMode,
+        PackageLoadMode packageLoadMode,
+        LoadModeAdvisorResult result,
+        string message) =>
+        new(
+            graphKey,
+            graphLoadMode,
+            packageLoadMode,
+            result.ReasonCode == LoadModeReasonCodes.PackageMetadata
+                ? LoadModeReasonCodes.MetadataSuppressed
+                : LoadModeReasonCodes.AdvisorSuppressed,
+            result.PackageId,
+            result.Version,
+            result.Scope,
+            result.AdvisorName,
+            result.ReasonCode == LoadModeReasonCodes.PackageMetadata
+                ? message
+                : "Package load-mode advisor result was suppressed by a higher-precedence load-mode policy.");
 
     private static string BuildKey(string packageId, string version) => $"{packageId}@{version}";
 }

--- a/src/Nuplane.Loading/PackageLoadModeSelector.cs
+++ b/src/Nuplane.Loading/PackageLoadModeSelector.cs
@@ -90,14 +90,14 @@ internal sealed class PackageLoadModeSelector
                 : SelectFromAdvisorsOrDefault(package, graphKey, options, packageResults));
         }
 
-        var hasHostMetadata = advisorResults.Any(static result =>
-            result.IsValid
-            && result.RequestedLoadMode == PackageLoadMode.HostIntegrated
-            && string.Equals(result.ReasonCode, LoadModeReasonCodes.PackageMetadata, StringComparison.Ordinal));
-        var hasCollectibleMetadata = advisorResults.Any(static result =>
-            result.IsValid
-            && result.RequestedLoadMode == PackageLoadMode.Collectible
-            && string.Equals(result.ReasonCode, LoadModeReasonCodes.PackageMetadata, StringComparison.Ordinal));
+        var hasHostMetadata = decisions.Any(static decision =>
+            decision.Diagnostics.Any(static diagnostic =>
+                diagnostic.ReasonCode == LoadModeReasonCodes.PackageMetadata
+                && diagnostic.EffectivePackageLoadMode == PackageLoadMode.HostIntegrated));
+        var hasCollectibleMetadata = decisions.Any(static decision =>
+            decision.Diagnostics.Any(static diagnostic =>
+                diagnostic.ReasonCode == LoadModeReasonCodes.PackageMetadata
+                && diagnostic.EffectivePackageLoadMode == PackageLoadMode.Collectible));
         var metadataConflict = hasHostMetadata && hasCollectibleMetadata;
 
         var graphLoadMode = decisions.Any(static decision => decision.Selection.LoadMode == PackageLoadMode.HostIntegrated)
@@ -267,6 +267,12 @@ internal sealed class PackageLoadModeSelector
         {
             Selection = selection,
             Diagnostics = diagnostics
+                .Select(diagnostic => diagnostic with
+                {
+                    EffectiveGraphLoadMode = graphLoadMode,
+                    EffectivePackageLoadMode = selection.LoadMode
+                })
+                .ToList()
         };
     }
 

--- a/src/Nuplane.Loading/PackageLoadModeSelector.cs
+++ b/src/Nuplane.Loading/PackageLoadModeSelector.cs
@@ -193,7 +193,7 @@ internal sealed class PackageLoadModeSelector
         {
             diagnostics.Add(CreateAdvisorDiagnostic(graphKey, PackageLoadMode.HostIntegrated, PackageLoadMode.HostIntegrated, hostIntegratedRequirement));
             return new(
-                new(package.Id, package.Version, PackageLoadMode.HostIntegrated, LoadModeReasonCodes.PackageMetadata, graphKey),
+                new(package.Id, package.Version, PackageLoadMode.HostIntegrated, hostIntegratedRequirement.ReasonCode, graphKey),
                 diagnostics);
         }
 
@@ -204,7 +204,7 @@ internal sealed class PackageLoadModeSelector
             {
                 diagnostics.Add(CreateAdvisorDiagnostic(graphKey, PackageLoadMode.Collectible, PackageLoadMode.Collectible, collectiblePreference));
                 return new(
-                    new(package.Id, package.Version, PackageLoadMode.Collectible, LoadModeReasonCodes.PackageMetadata, graphKey),
+                    new(package.Id, package.Version, PackageLoadMode.Collectible, collectiblePreference.ReasonCode, graphKey),
                     diagnostics);
             }
 

--- a/src/Nuplane.Loading/PackageLoadModeSelector.cs
+++ b/src/Nuplane.Loading/PackageLoadModeSelector.cs
@@ -189,6 +189,9 @@ internal sealed class PackageLoadModeSelector
             .ThenBy(static result => result.Scope, StringComparer.OrdinalIgnoreCase)
             .ToArray();
 
+        // Nuplane currently loads a resolved graph in one mode. Scope is preserved in
+        // diagnostics for future policy expansion, while any HostIntegrated metadata
+        // requirement promotes the graph to keep activation deterministic.
         var hostIntegratedRequirement = validResults.FirstOrDefault(static result => result.RequestedLoadMode == PackageLoadMode.HostIntegrated);
         if (hostIntegratedRequirement is not null)
         {
@@ -199,12 +202,27 @@ internal sealed class PackageLoadModeSelector
         }
 
         var collectiblePreference = validResults.FirstOrDefault(static result => result.RequestedLoadMode == PackageLoadMode.Collectible);
-        if (collectiblePreference is not null && options.DefaultLoadMode == PackageLoadMode.Collectible)
+        if (collectiblePreference is not null)
         {
-            diagnostics.Add(CreateAdvisorDiagnostic(graphKey, PackageLoadMode.Collectible, PackageLoadMode.Collectible, collectiblePreference));
-            return new(
-                new(package.Id, package.Version, PackageLoadMode.Collectible, LoadModeReasonCodes.PackageMetadata, graphKey),
-                diagnostics);
+            if (options.DefaultLoadMode == PackageLoadMode.Collectible)
+            {
+                diagnostics.Add(CreateAdvisorDiagnostic(graphKey, PackageLoadMode.Collectible, PackageLoadMode.Collectible, collectiblePreference));
+                return new(
+                    new(package.Id, package.Version, PackageLoadMode.Collectible, LoadModeReasonCodes.PackageMetadata, graphKey),
+                    diagnostics);
+            }
+
+            diagnostics.Add(new(
+                graphKey,
+                options.DefaultLoadMode,
+                options.DefaultLoadMode,
+                LoadModeReasonCodes.MetadataSuppressed,
+                collectiblePreference.PackageId,
+                collectiblePreference.Version,
+                collectiblePreference.Scope,
+                collectiblePreference.AdvisorName,
+                "Package metadata requested Collectible but the configured default load mode takes precedence."));
+            logger.PackageLoadMetadataSuppressed(package.Id, package.Version, graphKey);
         }
 
         diagnostics.Add(new(

--- a/src/Nuplane.Loading/PackageLoadModeSelector.cs
+++ b/src/Nuplane.Loading/PackageLoadModeSelector.cs
@@ -1,3 +1,5 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Nuplane.Abstractions;
 
 namespace Nuplane.Loading;
@@ -7,6 +9,17 @@ namespace Nuplane.Loading;
 /// </summary>
 internal sealed class PackageLoadModeSelector
 {
+    private readonly IReadOnlyList<IPackageLoadModeAdvisor> advisors;
+    private readonly ILogger<PackageLoadModeSelector> logger;
+
+    public PackageLoadModeSelector(
+        IEnumerable<IPackageLoadModeAdvisor>? advisors = null,
+        ILogger<PackageLoadModeSelector>? logger = null)
+    {
+        this.advisors = advisors?.ToArray() ?? [];
+        this.logger = logger ?? NullLogger<PackageLoadModeSelector>.Instance;
+    }
+
     /// <summary>
     /// Selects the effective load mode for the specified package.
     /// </summary>
@@ -23,4 +36,255 @@ internal sealed class PackageLoadModeSelector
             ? new(package.Id, package.Version, options.DefaultLoadMode, "default", graphKey)
             : new(package.Id, package.Version, packageOverride.LoadMode, "package-override", graphKey);
     }
+
+    public async ValueTask<PackageGraphLoadModeDecision> SelectGraphAsync(
+        IReadOnlyList<ResolvedPackage> packages,
+        LoadingOptions options,
+        string graphKey,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(packages);
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentException.ThrowIfNullOrWhiteSpace(graphKey);
+
+        var packageOverrides = options.PackageLoadModes
+            .GroupBy(static packageOverride => packageOverride.PackageId, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(static group => group.Key, static group => group.First().LoadMode, StringComparer.OrdinalIgnoreCase);
+
+        var advisorResults = new List<LoadModeAdvisorResult>();
+        if (options.LoadModeSelectionPolicy == PackageLoadModeSelectionPolicy.Automatic)
+        {
+            var context = new LoadModeAdvisorContext(
+                graphKey,
+                packages
+                    .OrderBy(static package => package.Id, StringComparer.OrdinalIgnoreCase)
+                    .ThenBy(static package => package.Version, StringComparer.OrdinalIgnoreCase)
+                    .ToArray(),
+                options.LoadModeSelectionPolicy,
+                options.DefaultLoadMode,
+                packageOverrides);
+
+            foreach (var advisor in advisors.OrderBy(static advisor => advisor.Name, StringComparer.OrdinalIgnoreCase))
+            {
+                var results = await advisor.EvaluateAsync(context, cancellationToken).ConfigureAwait(false);
+                advisorResults.AddRange(results);
+                logger.LoadModeAdvisorEvaluated(advisor.Name, graphKey, results.Count);
+            }
+        }
+
+        var resultsByPackage = advisorResults
+            .GroupBy(static result => BuildKey(result.PackageId, result.Version), StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(static group => group.Key, static group => group.ToArray(), StringComparer.OrdinalIgnoreCase);
+
+        var decisions = new List<PackageLoadModeDecision>(packages.Count);
+        foreach (var package in packages.OrderBy(static package => package.Id, StringComparer.OrdinalIgnoreCase).ThenBy(static package => package.Version, StringComparer.OrdinalIgnoreCase))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var key = BuildKey(package.Id, package.Version);
+            resultsByPackage.TryGetValue(key, out var packageResults);
+            packageResults ??= [];
+
+            decisions.Add(packageOverrides.TryGetValue(package.Id, out var overrideMode)
+                ? SelectOverride(package, graphKey, overrideMode, packageResults)
+                : SelectFromAdvisorsOrDefault(package, graphKey, options, packageResults));
+        }
+
+        var hasHostMetadata = advisorResults.Any(static result =>
+            result.IsValid
+            && result.RequestedLoadMode == PackageLoadMode.HostIntegrated
+            && string.Equals(result.ReasonCode, LoadModeReasonCodes.PackageMetadata, StringComparison.Ordinal));
+        var hasCollectibleMetadata = advisorResults.Any(static result =>
+            result.IsValid
+            && result.RequestedLoadMode == PackageLoadMode.Collectible
+            && string.Equals(result.ReasonCode, LoadModeReasonCodes.PackageMetadata, StringComparison.Ordinal));
+        var metadataConflict = hasHostMetadata && hasCollectibleMetadata;
+
+        var graphLoadMode = decisions.Any(static decision => decision.Selection.LoadMode == PackageLoadMode.HostIntegrated)
+            ? PackageLoadMode.HostIntegrated
+            : PackageLoadMode.Collectible;
+
+        if (metadataConflict)
+        {
+            graphLoadMode = PackageLoadMode.HostIntegrated;
+            logger.PackageLoadMetadataConflict(graphKey, graphLoadMode);
+        }
+
+        var promotedDecisions = decisions
+            .Select(decision => PromoteDecision(decision, graphKey, graphLoadMode, metadataConflict))
+            .ToArray();
+
+        logger.GraphLoadModeSelected(graphKey, graphLoadMode);
+
+        return new(
+            graphKey,
+            graphLoadMode,
+            promotedDecisions.Select(static decision => decision.Selection).ToArray(),
+            promotedDecisions.ToDictionary(
+                static decision => BuildKey(decision.Selection.PackageId, decision.Selection.Version),
+                static decision => decision.Diagnostics,
+                StringComparer.OrdinalIgnoreCase));
+    }
+
+    private PackageLoadModeDecision SelectOverride(
+        ResolvedPackage package,
+        string graphKey,
+        PackageLoadMode loadMode,
+        IReadOnlyList<LoadModeAdvisorResult> packageResults)
+    {
+        var diagnostics = new List<LoadModeDecisionDiagnostic>
+        {
+            new(
+                graphKey,
+                loadMode,
+                loadMode,
+                LoadModeReasonCodes.PackageOverride,
+                package.Id,
+                package.Version,
+                Message: $"Package '{package.Id}@{package.Version}' uses explicit package load mode override.")
+        };
+
+        foreach (var result in packageResults)
+        {
+            if (!result.IsValid)
+            {
+                diagnostics.Add(CreateAdvisorDiagnostic(graphKey, loadMode, loadMode, result));
+                logger.InvalidPackageLoadMetadata(package.Id, package.Version, graphKey, result.Diagnostic ?? "Package metadata is invalid.");
+                continue;
+            }
+
+            diagnostics.Add(new(
+                graphKey,
+                loadMode,
+                loadMode,
+                LoadModeReasonCodes.MetadataSuppressed,
+                result.PackageId,
+                result.Version,
+                result.Scope,
+                result.AdvisorName,
+                "Package metadata was suppressed by an explicit package load mode override."));
+            logger.PackageLoadMetadataSuppressed(package.Id, package.Version, graphKey);
+        }
+
+        return new(new(package.Id, package.Version, loadMode, LoadModeReasonCodes.PackageOverride, graphKey), diagnostics);
+    }
+
+    private PackageLoadModeDecision SelectFromAdvisorsOrDefault(
+        ResolvedPackage package,
+        string graphKey,
+        LoadingOptions options,
+        IReadOnlyList<LoadModeAdvisorResult> packageResults)
+    {
+        var diagnostics = new List<LoadModeDecisionDiagnostic>();
+        foreach (var invalidResult in packageResults.Where(static result => !result.IsValid))
+        {
+            diagnostics.Add(CreateAdvisorDiagnostic(graphKey, options.DefaultLoadMode, options.DefaultLoadMode, invalidResult));
+            logger.InvalidPackageLoadMetadata(package.Id, package.Version, graphKey, invalidResult.Diagnostic ?? "Package metadata is invalid.");
+        }
+
+        var validResults = packageResults
+            .Where(static result => result.IsValid)
+            .OrderByDescending(static result => result.RequestedLoadMode == PackageLoadMode.HostIntegrated)
+            .ThenBy(static result => result.AdvisorName, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(static result => result.Scope, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        var hostIntegratedRequirement = validResults.FirstOrDefault(static result => result.RequestedLoadMode == PackageLoadMode.HostIntegrated);
+        if (hostIntegratedRequirement is not null)
+        {
+            diagnostics.Add(CreateAdvisorDiagnostic(graphKey, PackageLoadMode.HostIntegrated, PackageLoadMode.HostIntegrated, hostIntegratedRequirement));
+            return new(
+                new(package.Id, package.Version, PackageLoadMode.HostIntegrated, LoadModeReasonCodes.PackageMetadata, graphKey),
+                diagnostics);
+        }
+
+        var collectiblePreference = validResults.FirstOrDefault(static result => result.RequestedLoadMode == PackageLoadMode.Collectible);
+        if (collectiblePreference is not null && options.DefaultLoadMode == PackageLoadMode.Collectible)
+        {
+            diagnostics.Add(CreateAdvisorDiagnostic(graphKey, PackageLoadMode.Collectible, PackageLoadMode.Collectible, collectiblePreference));
+            return new(
+                new(package.Id, package.Version, PackageLoadMode.Collectible, LoadModeReasonCodes.PackageMetadata, graphKey),
+                diagnostics);
+        }
+
+        diagnostics.Add(new(
+            graphKey,
+            options.DefaultLoadMode,
+            options.DefaultLoadMode,
+            options.LoadModeSelectionPolicy == PackageLoadModeSelectionPolicy.ExplicitOnly
+                ? LoadModeReasonCodes.AdvisorsDisabled
+                : LoadModeReasonCodes.Default,
+            package.Id,
+            package.Version,
+            Message: options.LoadModeSelectionPolicy == PackageLoadModeSelectionPolicy.ExplicitOnly
+                ? "Load mode advisors were disabled by policy."
+                : "No advisor or package override selected a load mode."));
+
+        return new(
+            new(package.Id, package.Version, options.DefaultLoadMode, LoadModeReasonCodes.Default, graphKey),
+            diagnostics);
+    }
+
+    private static PackageLoadModeDecision PromoteDecision(
+        PackageLoadModeDecision decision,
+        string graphKey,
+        PackageLoadMode graphLoadMode,
+        bool metadataConflict)
+    {
+        var diagnostics = decision.Diagnostics.ToList();
+        var selection = decision.Selection;
+        if (graphLoadMode == PackageLoadMode.HostIntegrated && selection.LoadMode != PackageLoadMode.HostIntegrated)
+        {
+            selection = selection with
+            {
+                LoadMode = PackageLoadMode.HostIntegrated,
+                SelectionReason = LoadModeReasonCodes.DependencyClosure
+            };
+
+            diagnostics.Add(new(
+                graphKey,
+                graphLoadMode,
+                PackageLoadMode.HostIntegrated,
+                LoadModeReasonCodes.DependencyClosure,
+                selection.PackageId,
+                selection.Version,
+                Message: "Package was promoted because another package in the graph required host-integrated loading."));
+        }
+
+        if (metadataConflict)
+        {
+            diagnostics.Add(new(
+                graphKey,
+                graphLoadMode,
+                selection.LoadMode,
+                LoadModeReasonCodes.MetadataConflict,
+                selection.PackageId,
+                selection.Version,
+                Message: "Conflicting package metadata was resolved by selecting HostIntegrated for the graph."));
+        }
+
+        return decision with
+        {
+            Selection = selection,
+            Diagnostics = diagnostics
+        };
+    }
+
+    private static LoadModeDecisionDiagnostic CreateAdvisorDiagnostic(
+        string graphKey,
+        PackageLoadMode graphLoadMode,
+        PackageLoadMode packageLoadMode,
+        LoadModeAdvisorResult result) =>
+        new(
+            graphKey,
+            graphLoadMode,
+            packageLoadMode,
+            result.ReasonCode,
+            result.PackageId,
+            result.Version,
+            result.Scope,
+            result.AdvisorName,
+            result.Diagnostic ?? result.Reason);
+
+    private static string BuildKey(string packageId, string version) => $"{packageId}@{version}";
 }

--- a/src/Nuplane.Loading/PackageLoader.cs
+++ b/src/Nuplane.Loading/PackageLoader.cs
@@ -33,13 +33,14 @@ internal sealed class PackageLoader : IPackageLoader
         SharedAssemblyPolicyMatcher? matcher = null,
         HostIntegratedAssemblyResolutionCatalog? hostIntegratedResolutionCatalog = null,
         PackageLoadModeSelector? loadModeSelector = null,
+        IEnumerable<IPackageLoadModeAdvisor>? loadModeAdvisors = null,
         IOptions<LoadingOptions>? options = null,
         ILogger<PackageLoader>? logger = null,
         HostIntegratedAssemblyResolver? hostIntegratedAssemblyResolver = null)
     {
         _matcher = matcher ?? new SharedAssemblyPolicyMatcher();
         _hostIntegratedResolutionCatalog = hostIntegratedResolutionCatalog ?? new HostIntegratedAssemblyResolutionCatalog();
-        _loadModeSelector = loadModeSelector ?? new PackageLoadModeSelector();
+        _loadModeSelector = loadModeSelector ?? new PackageLoadModeSelector(loadModeAdvisors);
         _options = options?.Value ?? new LoadingOptions();
         _logger = logger ?? NullLogger<PackageLoader>.Instance;
         _hostIntegratedAssemblyResolver = hostIntegratedAssemblyResolver;
@@ -96,7 +97,7 @@ internal sealed class PackageLoader : IPackageLoader
     }
 
     /// <inheritdoc />
-    public Task<PackageLoadResult> EnsureGraphLoadedAsync(
+    public async Task<PackageLoadResult> EnsureGraphLoadedAsync(
         IReadOnlyList<IReadOnlyList<ResolvedPackage>> packageGraphs,
         IReadOnlyList<SharedAssemblyPolicyEntry> sharedPolicy,
         CancellationToken cancellationToken)
@@ -112,21 +113,19 @@ internal sealed class PackageLoader : IPackageLoader
             cancellationToken.ThrowIfCancellationRequested();
 
             var graphKey = BuildGraphKey(packageGraph);
-            var selectedModes = packageGraph
-                .Select(package => _loadModeSelector.Select(package, _options, graphKey))
-                .ToArray();
-            var selections = PromoteHostIntegratedGraphSelections(selectedModes);
+            var graphDecision = await _loadModeSelector.SelectGraphAsync(packageGraph, _options, graphKey, cancellationToken).ConfigureAwait(false);
+            var selections = graphDecision.Selections;
 
             if (packageGraph.Count <= 1 && selections.All(static selection => selection.LoadMode == PackageLoadMode.Collectible))
             {
-                EnsurePackagesLoaded(packageGraph, sharedPolicy, cancellationToken, loaded, failed);
+                EnsurePackagesLoaded(packageGraph, sharedPolicy, cancellationToken, loaded, failed, graphDecision.DiagnosticsByPackageKey);
                 continue;
             }
 
-            EnsureGraphLoaded(packageGraph, selections, sharedPolicy, loaded, failed);
+            EnsureGraphLoaded(packageGraph, selections, sharedPolicy, loaded, failed, graphDecision.DiagnosticsByPackageKey);
         }
 
-        return Task.FromResult<PackageLoadResult>(new(loaded, failed));
+        return new(loaded, failed);
     }
 
     private void EnsurePackagesLoaded(
@@ -134,7 +133,8 @@ internal sealed class PackageLoader : IPackageLoader
         IReadOnlyList<SharedAssemblyPolicyEntry> sharedPolicy,
         CancellationToken cancellationToken,
         List<PackageLoadSession> loaded,
-        Dictionary<string, string> failed)
+        Dictionary<string, string> failed,
+        IReadOnlyDictionary<string, IReadOnlyList<LoadModeDecisionDiagnostic>>? diagnosticsByPackageKey = null)
     {
         foreach (var package in packages)
         {
@@ -175,7 +175,8 @@ internal sealed class PackageLoader : IPackageLoader
                     IsLoaded: true,
                     LastError: null,
                     PackageLoadMode.Collectible,
-                    FrameworkIntegrationSafe: false);
+                    FrameworkIntegrationSafe: false,
+                    LoadModeDiagnostics: ResolveLoadModeDiagnostics(diagnosticsByPackageKey, key));
 
                 _sessions[key] = session;
                 loaded.Add(session);
@@ -192,7 +193,8 @@ internal sealed class PackageLoader : IPackageLoader
                     IsLoaded: false,
                     LastError: ex.Message,
                     PackageLoadMode.Collectible,
-                    FrameworkIntegrationSafe: false);
+                    FrameworkIntegrationSafe: false,
+                    LoadModeDiagnostics: ResolveLoadModeDiagnostics(diagnosticsByPackageKey, key));
             }
         }
     }
@@ -202,7 +204,8 @@ internal sealed class PackageLoader : IPackageLoader
         IReadOnlyList<PackageLoadModeSelection> selections,
         IReadOnlyList<SharedAssemblyPolicyEntry> sharedPolicy,
         List<PackageLoadSession> loaded,
-        Dictionary<string, string> failed)
+        Dictionary<string, string> failed,
+        IReadOnlyDictionary<string, IReadOnlyList<LoadModeDecisionDiagnostic>> diagnosticsByPackageKey)
     {
         var graphKey = BuildGraphKey(packages);
         var graphLoadMode = selections.Any(static selection => selection.LoadMode == PackageLoadMode.HostIntegrated)
@@ -291,7 +294,8 @@ internal sealed class PackageLoader : IPackageLoader
                     IsLoaded: true,
                     LastError: null,
                     graphLoadMode,
-                    FrameworkIntegrationSafe: graphLoadMode == PackageLoadMode.HostIntegrated);
+                    FrameworkIntegrationSafe: graphLoadMode == PackageLoadMode.HostIntegrated,
+                    LoadModeDiagnostics: ResolveLoadModeDiagnostics(diagnosticsByPackageKey, key));
 
                 _sessions[key] = session;
                 loaded.Add(session);
@@ -345,7 +349,8 @@ internal sealed class PackageLoader : IPackageLoader
                     IsLoaded: false,
                     LastError: ex.Message,
                     graphLoadMode,
-                    FrameworkIntegrationSafe: false);
+                    FrameworkIntegrationSafe: false,
+                    LoadModeDiagnostics: ResolveLoadModeDiagnostics(diagnosticsByPackageKey, key));
             }
         }
 
@@ -506,24 +511,12 @@ internal sealed class PackageLoader : IPackageLoader
             .ThenBy(static package => package.Version, StringComparer.OrdinalIgnoreCase)
             .Select(static package => BuildKey(package.Id, package.Version)));
 
-    private static IReadOnlyList<PackageLoadModeSelection> PromoteHostIntegratedGraphSelections(
-        IReadOnlyList<PackageLoadModeSelection> selections)
-    {
-        if (selections.All(static selection => selection.LoadMode == PackageLoadMode.Collectible))
-        {
-            return selections;
-        }
-
-        return selections
-            .Select(static selection => selection.LoadMode == PackageLoadMode.HostIntegrated
-                ? selection
-                : selection with
-                {
-                    LoadMode = PackageLoadMode.HostIntegrated,
-                    SelectionReason = "dependency-closure"
-                })
-            .ToArray();
-    }
+    private static IReadOnlyList<LoadModeDecisionDiagnostic> ResolveLoadModeDiagnostics(
+        IReadOnlyDictionary<string, IReadOnlyList<LoadModeDecisionDiagnostic>>? diagnosticsByPackageKey,
+        string packageKey) =>
+        diagnosticsByPackageKey is not null && diagnosticsByPackageKey.TryGetValue(packageKey, out var diagnostics)
+            ? diagnostics
+            : [];
 
     private IReadOnlyDictionary<string, IReadOnlyList<Assembly>> MaterializeHostIntegratedAssemblies(
         AssemblyLoadContext context,

--- a/src/Nuplane.Loading/PackageMetadataLoadModeAdvisor.cs
+++ b/src/Nuplane.Loading/PackageMetadataLoadModeAdvisor.cs
@@ -1,0 +1,53 @@
+namespace Nuplane.Loading;
+
+internal sealed class PackageMetadataLoadModeAdvisor(PackageMetadataLoadModeReader reader) : IPackageLoadModeAdvisor
+{
+    public string Name => "package-metadata";
+
+    public ValueTask<IReadOnlyList<LoadModeAdvisorResult>> EvaluateAsync(
+        LoadModeAdvisorContext context,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        var results = new List<LoadModeAdvisorResult>();
+        foreach (var package in context.Packages
+            .OrderBy(static package => package.Id, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(static package => package.Version, StringComparer.OrdinalIgnoreCase))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var result = reader.Read(package.Id, package.Version, package.InstallPath);
+            if (!result.MetadataFound)
+            {
+                continue;
+            }
+
+            if (!result.IsValid || result.Metadata?.Loading is null)
+            {
+                results.Add(new(
+                    Name,
+                    package.Id,
+                    package.Version,
+                    PackageLoadMode.Collectible,
+                    LoadModeScopes.PackageOnly,
+                    LoadModeReasonCodes.MetadataInvalid,
+                    Reason: null,
+                    IsValid: false,
+                    result.Diagnostic ?? "Package metadata is invalid."));
+                continue;
+            }
+
+            results.Add(new(
+                Name,
+                package.Id,
+                package.Version,
+                result.Metadata.Loading.LoadMode,
+                result.Metadata.Loading.Scope,
+                LoadModeReasonCodes.PackageMetadata,
+                result.Metadata.Loading.Reason));
+        }
+
+        return ValueTask.FromResult<IReadOnlyList<LoadModeAdvisorResult>>(results);
+    }
+}

--- a/src/Nuplane.Loading/PackageMetadataLoadModeAdvisor.cs
+++ b/src/Nuplane.Loading/PackageMetadataLoadModeAdvisor.cs
@@ -1,7 +1,23 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
 namespace Nuplane.Loading;
 
-internal sealed class PackageMetadataLoadModeAdvisor(PackageMetadataLoadModeReader reader) : IPackageLoadModeAdvisor
+internal sealed class PackageMetadataLoadModeAdvisor : IPackageLoadModeAdvisor
 {
+    private readonly PackageMetadataLoadModeReader reader;
+    private readonly ILogger<PackageMetadataLoadModeAdvisor> logger;
+
+    public PackageMetadataLoadModeAdvisor(
+        PackageMetadataLoadModeReader reader,
+        ILogger<PackageMetadataLoadModeAdvisor>? logger = null)
+    {
+        ArgumentNullException.ThrowIfNull(reader);
+
+        this.reader = reader;
+        this.logger = logger ?? NullLogger<PackageMetadataLoadModeAdvisor>.Instance;
+    }
+
     public string Name => "package-metadata";
 
     public ValueTask<IReadOnlyList<LoadModeAdvisorResult>> EvaluateAsync(
@@ -38,6 +54,12 @@ internal sealed class PackageMetadataLoadModeAdvisor(PackageMetadataLoadModeRead
                 continue;
             }
 
+            logger.PackageLoadMetadataDiscovered(
+                package.Id,
+                package.Version,
+                context.GraphKey,
+                result.Metadata.Loading.LoadMode,
+                result.Metadata.Loading.Scope);
             results.Add(new(
                 Name,
                 package.Id,

--- a/src/Nuplane.Loading/PackageMetadataLoadModeReader.cs
+++ b/src/Nuplane.Loading/PackageMetadataLoadModeReader.cs
@@ -29,13 +29,12 @@ internal sealed class PackageMetadataLoadModeReader
 
         try
         {
-            var fileInfo = new FileInfo(metadataPath);
-            if (fileInfo.Length > MaxMetadataBytes)
+            using var stream = File.OpenRead(metadataPath);
+            if (stream.Length > MaxMetadataBytes)
             {
                 return PackageMetadataLoadModeReadResult.Invalid($"Package metadata for '{packageId}@{version}' exceeds the {MaxMetadataBytes} byte limit.");
             }
 
-            using var stream = File.OpenRead(metadataPath);
             var document = JsonSerializer.Deserialize<NuplanePackageMetadataDocument>(stream, JsonOptions);
             if (document is null)
             {
@@ -57,8 +56,9 @@ internal sealed class PackageMetadataLoadModeReader
                 return PackageMetadataLoadModeReadResult.Invalid($"Package metadata for '{packageId}@{version}' is missing loading.loadMode.");
             }
 
-            if (!Enum.TryParse<PackageLoadMode>(document.Loading.LoadMode, ignoreCase: true, out var loadMode)
-                || !Enum.IsDefined(loadMode))
+            var loadModeName = document.Loading.LoadMode.Trim();
+            if (!Enum.GetNames<PackageLoadMode>().Any(name => string.Equals(name, loadModeName, StringComparison.OrdinalIgnoreCase))
+                || !Enum.TryParse<PackageLoadMode>(loadModeName, ignoreCase: true, out var loadMode))
             {
                 return PackageMetadataLoadModeReadResult.Invalid($"Package metadata for '{packageId}@{version}' uses unsupported loading.loadMode '{document.Loading.LoadMode}'.");
             }

--- a/src/Nuplane.Loading/PackageMetadataLoadModeReader.cs
+++ b/src/Nuplane.Loading/PackageMetadataLoadModeReader.cs
@@ -1,0 +1,112 @@
+using System.Text.Json;
+
+namespace Nuplane.Loading;
+
+internal sealed class PackageMetadataLoadModeReader
+{
+    internal const string MetadataFileName = "nuplane.json";
+    private const long MaxMetadataBytes = 64 * 1024;
+    private const int MaxReasonLength = 512;
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        ReadCommentHandling = JsonCommentHandling.Skip,
+        AllowTrailingCommas = true
+    };
+
+    public PackageMetadataLoadModeReadResult Read(string packageId, string version, string installPath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(packageId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(version);
+        ArgumentException.ThrowIfNullOrWhiteSpace(installPath);
+
+        var metadataPath = Path.Combine(installPath, MetadataFileName);
+        if (!File.Exists(metadataPath))
+        {
+            return PackageMetadataLoadModeReadResult.Missing;
+        }
+
+        try
+        {
+            var fileInfo = new FileInfo(metadataPath);
+            if (fileInfo.Length > MaxMetadataBytes)
+            {
+                return PackageMetadataLoadModeReadResult.Invalid($"Package metadata for '{packageId}@{version}' exceeds the {MaxMetadataBytes} byte limit.");
+            }
+
+            using var stream = File.OpenRead(metadataPath);
+            var document = JsonSerializer.Deserialize<NuplanePackageMetadataDocument>(stream, JsonOptions);
+            if (document is null)
+            {
+                return PackageMetadataLoadModeReadResult.Invalid($"Package metadata for '{packageId}@{version}' is empty.");
+            }
+
+            if (document.SchemaVersion != 1)
+            {
+                return PackageMetadataLoadModeReadResult.Invalid($"Package metadata for '{packageId}@{version}' uses unsupported schema version '{document.SchemaVersion}'.");
+            }
+
+            if (document.Loading is null)
+            {
+                return PackageMetadataLoadModeReadResult.Invalid($"Package metadata for '{packageId}@{version}' is missing loading metadata.");
+            }
+
+            if (string.IsNullOrWhiteSpace(document.Loading.LoadMode))
+            {
+                return PackageMetadataLoadModeReadResult.Invalid($"Package metadata for '{packageId}@{version}' is missing loading.loadMode.");
+            }
+
+            if (!Enum.TryParse<PackageLoadMode>(document.Loading.LoadMode, ignoreCase: true, out var loadMode)
+                || !Enum.IsDefined(loadMode))
+            {
+                return PackageMetadataLoadModeReadResult.Invalid($"Package metadata for '{packageId}@{version}' uses unsupported loading.loadMode '{document.Loading.LoadMode}'.");
+            }
+
+            if (string.IsNullOrWhiteSpace(document.Loading.Scope))
+            {
+                return PackageMetadataLoadModeReadResult.Invalid($"Package metadata for '{packageId}@{version}' is missing loading.scope.");
+            }
+
+            var scope = document.Loading.Scope.Trim();
+            if (!string.Equals(scope, LoadModeScopes.DependencyClosure, StringComparison.Ordinal)
+                && !string.Equals(scope, LoadModeScopes.PackageOnly, StringComparison.Ordinal))
+            {
+                return PackageMetadataLoadModeReadResult.Invalid($"Package metadata for '{packageId}@{version}' uses unsupported loading.scope '{document.Loading.Scope}'.");
+            }
+
+            var reason = string.IsNullOrWhiteSpace(document.Loading.Reason)
+                ? null
+                : document.Loading.Reason.Trim();
+            if (reason?.Length > MaxReasonLength)
+            {
+                reason = reason[..MaxReasonLength];
+            }
+
+            return PackageMetadataLoadModeReadResult.Valid(new(
+                document.SchemaVersion,
+                new(loadMode, scope, reason)));
+        }
+        catch (JsonException ex)
+        {
+            return PackageMetadataLoadModeReadResult.Invalid($"Package metadata for '{packageId}@{version}' is not valid JSON: {ex.Message}");
+        }
+        catch (IOException ex)
+        {
+            return PackageMetadataLoadModeReadResult.Invalid($"Package metadata for '{packageId}@{version}' could not be read: {ex.Message}");
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            return PackageMetadataLoadModeReadResult.Invalid($"Package metadata for '{packageId}@{version}' could not be accessed: {ex.Message}");
+        }
+    }
+
+    private sealed record NuplanePackageMetadataDocument(
+        int SchemaVersion,
+        NuplanePackageLoadingMetadataDocument? Loading);
+
+    private sealed record NuplanePackageLoadingMetadataDocument(
+        string? LoadMode,
+        string? Scope,
+        string? Reason);
+}

--- a/src/Nuplane.Loading/Registration/LoadingRegistrationServices.cs
+++ b/src/Nuplane.Loading/Registration/LoadingRegistrationServices.cs
@@ -39,7 +39,11 @@ public static class LoadingRegistrationServices
         services.TryAddSingleton<SharedAssemblyPolicyMatcher>();
         services.TryAddSingleton<PackageMetadataLoadModeReader>();
         services.TryAddSingleton<PackageMetadataLoadModeAdvisor>();
-        services.TryAddEnumerable(ServiceDescriptor.Singleton<IPackageLoadModeAdvisor, PackageMetadataLoadModeAdvisor>());
+        if (!services.Any(IsPackageMetadataLoadModeAdvisorRegistration))
+        {
+            services.AddSingleton<IPackageLoadModeAdvisor>(ResolvePackageMetadataLoadModeAdvisor);
+        }
+
         services.TryAddSingleton<PackageLoadModeSelector>();
         services.TryAddSingleton<HostIntegratedAssemblyResolutionCatalog>();
         services.TryAddSingleton<HostIntegratedAssemblyResolver>();
@@ -93,4 +97,11 @@ public static class LoadingRegistrationServices
             services.AddSingleton(implementationFactory);
         }
     }
+
+    private static bool IsPackageMetadataLoadModeAdvisorRegistration(ServiceDescriptor descriptor) =>
+        descriptor.ServiceType == typeof(IPackageLoadModeAdvisor)
+        && descriptor.ImplementationFactory?.Method == ResolvePackageMetadataLoadModeAdvisor.Method;
+
+    private static readonly Func<IServiceProvider, IPackageLoadModeAdvisor> ResolvePackageMetadataLoadModeAdvisor =
+        static sp => sp.GetRequiredService<PackageMetadataLoadModeAdvisor>();
 }

--- a/src/Nuplane.Loading/Registration/LoadingRegistrationServices.cs
+++ b/src/Nuplane.Loading/Registration/LoadingRegistrationServices.cs
@@ -37,6 +37,9 @@ public static class LoadingRegistrationServices
         ReplaceSingleton<LoadingEventDispatcher, LoadingEventDispatcher>(services);
         services.TryAddSingleton<LoadingCatalogRefreshTracker>();
         services.TryAddSingleton<SharedAssemblyPolicyMatcher>();
+        services.TryAddSingleton<PackageMetadataLoadModeReader>();
+        services.TryAddSingleton<PackageMetadataLoadModeAdvisor>();
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IPackageLoadModeAdvisor, PackageMetadataLoadModeAdvisor>());
         services.TryAddSingleton<PackageLoadModeSelector>();
         services.TryAddSingleton<HostIntegratedAssemblyResolutionCatalog>();
         services.TryAddSingleton<HostIntegratedAssemblyResolver>();

--- a/test/Nuplane.Loading.Tests/LoadingCatalogObservabilityTests.cs
+++ b/test/Nuplane.Loading.Tests/LoadingCatalogObservabilityTests.cs
@@ -100,6 +100,60 @@ public sealed class LoadingCatalogObservabilityTests
             && string.Equals(reasonCode, "loading-divergence", StringComparison.Ordinal));
     }
 
+    [Fact]
+    public async Task PackageLoadModeSelector_WhenMetadataIsEvaluated_EmitsDecisionLogs()
+    {
+        var messages = new List<string>();
+        using var loggerFactory = LoggerFactory.Create(builder => builder.AddProvider(new CapturingLoggerProvider(messages)));
+        var result = PackageLoadModeSelectorTests.MetadataResult("pkg-a", PackageLoadMode.HostIntegrated);
+        var sut = new PackageLoadModeSelector(
+            [new StaticPackageLoadModeAdvisor("package-metadata", result)],
+            loggerFactory.CreateLogger<PackageLoadModeSelector>());
+
+        await sut.SelectGraphAsync(
+            [new ResolvedPackage("pkg-a", "1.0.0", "feed-a", "/tmp/pkg", DateTimeOffset.UtcNow, "source-a")],
+            new LoadingOptions(),
+            "graph:pkg-a@1.0.0",
+            CancellationToken.None);
+
+        Assert.Contains(messages, message =>
+            message.Contains("load mode advisor", StringComparison.OrdinalIgnoreCase)
+            && message.Contains("package-metadata", StringComparison.Ordinal));
+        Assert.Contains(messages, message =>
+            message.Contains("Selected graph load mode", StringComparison.Ordinal)
+            && message.Contains("HostIntegrated", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task PackageLoadModeSelector_WhenMetadataIsInvalid_EmitsDiagnosticLog()
+    {
+        var messages = new List<string>();
+        using var loggerFactory = LoggerFactory.Create(builder => builder.AddProvider(new CapturingLoggerProvider(messages)));
+        var result = new LoadModeAdvisorResult(
+            "package-metadata",
+            "pkg-a",
+            "1.0.0",
+            PackageLoadMode.Collectible,
+            LoadModeScopes.PackageOnly,
+            LoadModeReasonCodes.MetadataInvalid,
+            Reason: null,
+            IsValid: false,
+            "metadata was not valid");
+        var sut = new PackageLoadModeSelector(
+            [new StaticPackageLoadModeAdvisor("package-metadata", result)],
+            loggerFactory.CreateLogger<PackageLoadModeSelector>());
+
+        await sut.SelectGraphAsync(
+            [new ResolvedPackage("pkg-a", "1.0.0", "feed-a", "/tmp/pkg", DateTimeOffset.UtcNow, "source-a")],
+            new LoadingOptions(),
+            "graph:pkg-a@1.0.0",
+            CancellationToken.None);
+
+        Assert.Contains(messages, message =>
+            message.Contains("Ignored invalid package load metadata", StringComparison.Ordinal)
+            && message.Contains("metadata was not valid", StringComparison.Ordinal));
+    }
+
     private static ActivePackageCatalogSnapshot CreateSnapshot(string packageId, string installPath, string version = "1.0.0") =>
         new(
             DateTimeOffset.UtcNow,
@@ -183,4 +237,3 @@ public sealed class LoadingCatalogObservabilityTests
 
     private sealed record MeasurementRecord(string InstrumentName, long Value, IReadOnlyDictionary<string, string?> Tags);
 }
-

--- a/test/Nuplane.Loading.Tests/LoadingCatalogObservabilityTests.cs
+++ b/test/Nuplane.Loading.Tests/LoadingCatalogObservabilityTests.cs
@@ -150,7 +150,7 @@ public sealed class LoadingCatalogObservabilityTests
             CancellationToken.None);
 
         Assert.Contains(messages, message =>
-            message.Contains("Ignored invalid package load metadata", StringComparison.Ordinal)
+            message.Contains("Ignored invalid package load-mode advisor result", StringComparison.Ordinal)
             && message.Contains("metadata was not valid", StringComparison.Ordinal));
     }
 

--- a/test/Nuplane.Loading.Tests/LoadingCatalogTests.cs
+++ b/test/Nuplane.Loading.Tests/LoadingCatalogTests.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.Options;
 using Nuplane.Abstractions;
 using Nuplane.Observability;
+using Nuplane.Loading.Tests.Fixtures;
 
 namespace Nuplane.Loading.Tests;
 
@@ -89,6 +90,92 @@ public sealed class LoadingCatalogTests
         Assert.Contains("load-state-divergence:1", contribution.DegradedReasons);
     }
 
+    [Fact]
+    public async Task GetLoadStateAsync_WhenPackageHasLoadModeDiagnostics_ProjectsExplanations()
+    {
+        var refreshTracker = new LoadingCatalogRefreshTracker();
+        var root = CreateResolvedPackage("pkg-root", "1.0.0", typeof(FixtureMarker).Assembly);
+        PackageMetadataTestSupport.WriteMetadata(root.InstallPath);
+        var dependency = CreateResolvedPackage("pkg-dependency", "1.0.0", typeof(LoadingCatalogTests).Assembly);
+        var loader = new PackageLoader(loadModeAdvisors: [new PackageMetadataLoadModeAdvisor(new PackageMetadataLoadModeReader())]);
+        var activeSnapshot = new ActivePackagesSnapshot(
+            DateTimeOffset.UtcNow,
+            DateTimeOffset.UtcNow,
+            [
+                new ActivePackage(root.Id, root.Version, root.FeedName, root.SourceName, root.InstallPath, DateTimeOffset.UtcNow, "corr-root"),
+                new ActivePackage(dependency.Id, dependency.Version, dependency.FeedName, dependency.SourceName, dependency.InstallPath, DateTimeOffset.UtcNow, "corr-dependency")
+            ],
+            "read-load-mode-diagnostics");
+
+        await loader.EnsureGraphLoadedAsync([[root, dependency]], [], CancellationToken.None);
+        refreshTracker.MarkRefreshed("refresh-load-mode-diagnostics");
+        var catalog = CreateCatalog(
+            new LoadingOptions { Enabled = true },
+            activeSnapshot,
+            loader,
+            refreshTracker);
+
+        var snapshot = await catalog.GetLoadStateAsync(CancellationToken.None);
+
+        var rootDescriptor = Assert.Single(snapshot.Packages, package => package.PackageId == "pkg-root");
+        Assert.Contains(rootDescriptor.LoadModeDiagnostics ?? [], diagnostic =>
+            diagnostic.ReasonCode == LoadModeReasonCodes.PackageMetadata
+            && diagnostic.DeclaringPackageId == "pkg-root"
+            && diagnostic.RequestedScope == LoadModeScopes.DependencyClosure);
+
+        var dependencyDescriptor = Assert.Single(snapshot.Packages, package => package.PackageId == "pkg-dependency");
+        Assert.Contains(dependencyDescriptor.LoadModeDiagnostics ?? [], diagnostic =>
+            diagnostic.ReasonCode == LoadModeReasonCodes.DependencyClosure
+            && diagnostic.EffectiveGraphLoadMode == PackageLoadMode.HostIntegrated);
+    }
+
+    [Fact]
+    public async Task GetLoadStateAsync_WhenDecisionReasonVaries_ProjectsStableReasonCodes()
+    {
+        var suppressedPackage = CreateResolvedPackage("pkg-suppressed", "1.0.0");
+        PackageMetadataTestSupport.WriteMetadata(suppressedPackage.InstallPath);
+        var suppressedOptions = new LoadingOptions();
+        suppressedOptions.PackageLoadModes.Add(new() { PackageId = "pkg-suppressed", LoadMode = PackageLoadMode.Collectible });
+
+        var suppressed = await LoadAndReadPackageAsync(suppressedOptions, [suppressedPackage]);
+
+        Assert.Contains(suppressed.LoadModeDiagnostics ?? [], diagnostic => diagnostic.ReasonCode == LoadModeReasonCodes.PackageOverride);
+        Assert.Contains(suppressed.LoadModeDiagnostics ?? [], diagnostic => diagnostic.ReasonCode == LoadModeReasonCodes.MetadataSuppressed);
+
+        var invalidPackage = CreateResolvedPackage("pkg-invalid", "1.0.0");
+        File.WriteAllText(Path.Combine(invalidPackage.InstallPath, PackageMetadataLoadModeReader.MetadataFileName), "{");
+
+        var invalid = await LoadAndReadPackageAsync(new LoadingOptions(), [invalidPackage]);
+
+        Assert.Contains(invalid.LoadModeDiagnostics ?? [], diagnostic => diagnostic.ReasonCode == LoadModeReasonCodes.MetadataInvalid);
+        Assert.Contains(invalid.LoadModeDiagnostics ?? [], diagnostic => diagnostic.ReasonCode == LoadModeReasonCodes.Default);
+
+        var disabledPackage = CreateResolvedPackage("pkg-disabled", "1.0.0");
+        PackageMetadataTestSupport.WriteMetadata(disabledPackage.InstallPath);
+
+        var disabled = await LoadAndReadPackageAsync(
+            new LoadingOptions { LoadModeSelectionPolicy = PackageLoadModeSelectionPolicy.ExplicitOnly },
+            [disabledPackage]);
+
+        Assert.Contains(disabled.LoadModeDiagnostics ?? [], diagnostic => diagnostic.ReasonCode == LoadModeReasonCodes.AdvisorsDisabled);
+
+        var hostPackage = CreateResolvedPackage("pkg-conflict-host", "1.0.0", typeof(FixtureMarker).Assembly);
+        PackageMetadataTestSupport.WriteMetadata(hostPackage.InstallPath, PackageLoadMode.HostIntegrated);
+        var collectiblePackage = CreateResolvedPackage("pkg-conflict-collectible", "1.0.0", typeof(LoadingCatalogTests).Assembly);
+        PackageMetadataTestSupport.WriteMetadata(collectiblePackage.InstallPath, PackageLoadMode.Collectible);
+
+        var conflicted = await LoadAndReadPackageAsync(new LoadingOptions(), [hostPackage, collectiblePackage]);
+
+        Assert.All(conflicted.LoadModeDiagnostics ?? [], diagnostic =>
+            Assert.Contains(diagnostic.ReasonCode, new[]
+            {
+                LoadModeReasonCodes.PackageMetadata,
+                LoadModeReasonCodes.DependencyClosure,
+                LoadModeReasonCodes.MetadataConflict
+            }));
+        Assert.Contains(conflicted.LoadModeDiagnostics ?? [], diagnostic => diagnostic.ReasonCode == LoadModeReasonCodes.MetadataConflict);
+    }
+
     private static LoadingCatalog CreateCatalog(
         LoadingOptions options,
         ActivePackagesSnapshot snapshot,
@@ -105,14 +192,40 @@ public sealed class LoadingCatalogTests
             new ReconciliationMetrics(new ReconciliationTelemetry()));
     }
 
-    private static ResolvedPackage CreateResolvedPackage(string id, string version)
+    private static async Task<PackageLoadState> LoadAndReadPackageAsync(
+        LoadingOptions options,
+        IReadOnlyList<ResolvedPackage> packages)
+    {
+        var loader = new PackageLoader(
+            loadModeAdvisors: [new PackageMetadataLoadModeAdvisor(new PackageMetadataLoadModeReader())],
+            options: Options.Create(options));
+        var refreshTracker = new LoadingCatalogRefreshTracker();
+        var activeSnapshot = new ActivePackagesSnapshot(
+            DateTimeOffset.UtcNow,
+            DateTimeOffset.UtcNow,
+            packages
+                .Select(package => new ActivePackage(package.Id, package.Version, package.FeedName, package.SourceName, package.InstallPath, DateTimeOffset.UtcNow, $"corr-{package.Id}"))
+                .ToArray(),
+            $"read-{Guid.NewGuid():N}");
+
+        await loader.EnsureGraphLoadedAsync([packages], [], CancellationToken.None);
+        refreshTracker.MarkRefreshed($"refresh-{Guid.NewGuid():N}");
+
+        var catalog = CreateCatalog(new LoadingOptions { Enabled = true }, activeSnapshot, loader, refreshTracker);
+        var snapshot = await catalog.GetLoadStateAsync(CancellationToken.None);
+        return snapshot.Packages[0];
+    }
+
+    private static ResolvedPackage CreateResolvedPackage(string id, string version) =>
+        CreateResolvedPackage(id, version, typeof(PackageLoader).Assembly);
+
+    private static ResolvedPackage CreateResolvedPackage(string id, string version, System.Reflection.Assembly sourceAssembly)
     {
         var root = Path.Combine(Path.GetTempPath(), "nuplane-loading-catalog-tests", Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(root);
 
-        var sourceAssembly = typeof(PackageLoader).Assembly.Location;
-        var targetAssembly = Path.Combine(root, Path.GetFileName(sourceAssembly));
-        File.Copy(sourceAssembly, targetAssembly, overwrite: true);
+        var targetAssembly = Path.Combine(root, $"{id}.dll");
+        File.Copy(sourceAssembly.Location, targetAssembly, overwrite: true);
 
         return new ResolvedPackage(id, version, "feed-a", root, DateTimeOffset.UtcNow, "source-a");
     }
@@ -122,4 +235,3 @@ public sealed class LoadingCatalogTests
         public Task<ActivePackagesSnapshot> GetActivePackagesAsync(CancellationToken cancellationToken) => Task.FromResult(snapshot);
     }
 }
-

--- a/test/Nuplane.Loading.Tests/LoadingOptionsValidatorTests.cs
+++ b/test/Nuplane.Loading.Tests/LoadingOptionsValidatorTests.cs
@@ -27,6 +27,20 @@ public sealed class LoadingOptionsValidatorTests
     }
 
     [Fact]
+    public void Validate_InvalidLoadModeSelectionPolicy_ReturnsError()
+    {
+        var sut = new LoadingOptionsValidator();
+        var options = new LoadingOptions
+        {
+            LoadModeSelectionPolicy = (PackageLoadModeSelectionPolicy)42
+        };
+
+        var errors = sut.Validate(options);
+
+        Assert.Contains(errors, error => error.Contains("selection policy", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
     public void Validate_DuplicatePackageLoadModeOverrides_ReturnsError()
     {
         var sut = new LoadingOptionsValidator();

--- a/test/Nuplane.Loading.Tests/LoadingOwnershipContractTests.cs
+++ b/test/Nuplane.Loading.Tests/LoadingOwnershipContractTests.cs
@@ -29,6 +29,11 @@ public sealed class LoadingOwnershipContractTests
         Assert.Contains(nameof(PackageLoadState), exportedTypeNames);
         Assert.Contains(nameof(PackageAssemblyReference), exportedTypeNames);
         Assert.Contains(nameof(PackageAssemblies), exportedTypeNames);
+        Assert.Contains(nameof(IPackageLoadModeAdvisor), exportedTypeNames);
+        Assert.Contains(nameof(LoadModeAdvisorContext), exportedTypeNames);
+        Assert.Contains(nameof(LoadModeAdvisorResult), exportedTypeNames);
+        Assert.Contains(nameof(LoadModeDecisionDiagnostic), exportedTypeNames);
+        Assert.Contains(nameof(PackageLoadModeSelectionPolicy), exportedTypeNames);
 
         Assert.DoesNotContain(nameof(IPackageLoader), exportedTypeNames);
         Assert.DoesNotContain(nameof(IPackageAssemblyProvider), exportedTypeNames);

--- a/test/Nuplane.Loading.Tests/LoadingRegistrationDeterminismTests.cs
+++ b/test/Nuplane.Loading.Tests/LoadingRegistrationDeterminismTests.cs
@@ -89,6 +89,11 @@ public sealed class LoadingRegistrationDeterminismTests
         Assert.Single(services, d => d.ServiceType == typeof(IPackageLoadModeAdvisor));
         Assert.Single(services, d => d.ServiceType == typeof(PackageMetadataLoadModeReader));
         Assert.Single(services, d => d.ServiceType == typeof(PackageMetadataLoadModeAdvisor));
+
+        using var provider = services.BuildServiceProvider();
+        var concreteAdvisor = provider.GetRequiredService<PackageMetadataLoadModeAdvisor>();
+        var interfaceAdvisor = Assert.Single(provider.GetRequiredService<IEnumerable<IPackageLoadModeAdvisor>>());
+        Assert.Same(concreteAdvisor, interfaceAdvisor);
     }
 
     [Fact]

--- a/test/Nuplane.Loading.Tests/LoadingRegistrationDeterminismTests.cs
+++ b/test/Nuplane.Loading.Tests/LoadingRegistrationDeterminismTests.cs
@@ -79,6 +79,19 @@ public sealed class LoadingRegistrationDeterminismTests
     }
 
     [Fact]
+    public void Register_CalledTwice_DoesNotDuplicatePackageLoadModeAdvisor()
+    {
+        var services = new ServiceCollection();
+
+        LoadingRegistrationServices.Register(services);
+        LoadingRegistrationServices.Register(services);
+
+        Assert.Single(services, d => d.ServiceType == typeof(IPackageLoadModeAdvisor));
+        Assert.Single(services, d => d.ServiceType == typeof(PackageMetadataLoadModeReader));
+        Assert.Single(services, d => d.ServiceType == typeof(PackageMetadataLoadModeAdvisor));
+    }
+
+    [Fact]
     public void NuplaneLoadingBuilder_WithDefaultLoadMode_ConfiguresOptions()
     {
         var services = new ServiceCollection();
@@ -90,6 +103,20 @@ public sealed class LoadingRegistrationDeterminismTests
         using var provider = services.BuildServiceProvider();
         var options = provider.GetRequiredService<IOptions<LoadingOptions>>().Value;
         Assert.Equal(PackageLoadMode.HostIntegrated, options.DefaultLoadMode);
+    }
+
+    [Fact]
+    public void NuplaneLoadingBuilder_WithLoadModeSelectionPolicy_ConfiguresOptions()
+    {
+        var services = new ServiceCollection();
+        services.AddOptions();
+        var builder = new NuplaneLoadingBuilder(services);
+
+        builder.WithLoadModeSelectionPolicy(PackageLoadModeSelectionPolicy.ExplicitOnly);
+
+        using var provider = services.BuildServiceProvider();
+        var options = provider.GetRequiredService<IOptions<LoadingOptions>>().Value;
+        Assert.Equal(PackageLoadModeSelectionPolicy.ExplicitOnly, options.LoadModeSelectionPolicy);
     }
 
     [Fact]

--- a/test/Nuplane.Loading.Tests/PackageLoadModeSelectorConflictTests.cs
+++ b/test/Nuplane.Loading.Tests/PackageLoadModeSelectorConflictTests.cs
@@ -16,18 +16,22 @@ public sealed class PackageLoadModeSelectorConflictTests
         ]);
         var options = new LoadingOptions { DefaultLoadMode = PackageLoadMode.Collectible };
 
-        var decision = await sut.SelectGraphAsync([Pkg("pkg-a"), Pkg("pkg-b")], options, "graph:test", CancellationToken.None);
+        var decision = await sut.SelectGraphAsync([Pkg("pkg-a"), Pkg("pkg-b"), Pkg("pkg-c")], options, "graph:test", CancellationToken.None);
 
         Assert.Equal(PackageLoadMode.HostIntegrated, decision.LoadMode);
         Assert.All(decision.Selections, selection => Assert.Equal(PackageLoadMode.HostIntegrated, selection.LoadMode));
-        Assert.All(decision.DiagnosticsByPackageKey.Values, diagnostics =>
+        Assert.Contains(decision.DiagnosticsByPackageKey["pkg-a@1.0.0"], diagnostic =>
+            diagnostic.ReasonCode == LoadModeReasonCodes.MetadataConflict
+            && diagnostic.DeclaringPackageId == "pkg-a");
+        Assert.Contains(decision.DiagnosticsByPackageKey["pkg-b@1.0.0"], diagnostic =>
+            diagnostic.ReasonCode == LoadModeReasonCodes.MetadataConflict
+            && diagnostic.DeclaringPackageId == "pkg-b");
+        Assert.DoesNotContain(decision.DiagnosticsByPackageKey["pkg-c@1.0.0"], diagnostic =>
+            diagnostic.ReasonCode == LoadModeReasonCodes.MetadataConflict);
+        Assert.All(decision.DiagnosticsByPackageKey.Values.SelectMany(static diagnostics => diagnostics), diagnostic =>
         {
-            Assert.Contains(diagnostics, diagnostic => diagnostic.ReasonCode == LoadModeReasonCodes.MetadataConflict);
-            Assert.All(diagnostics, diagnostic =>
-            {
-                Assert.Equal(PackageLoadMode.HostIntegrated, diagnostic.EffectiveGraphLoadMode);
-                Assert.Equal(PackageLoadMode.HostIntegrated, diagnostic.EffectivePackageLoadMode);
-            });
+            Assert.Equal(PackageLoadMode.HostIntegrated, diagnostic.EffectiveGraphLoadMode);
+            Assert.Equal(PackageLoadMode.HostIntegrated, diagnostic.EffectivePackageLoadMode);
         });
     }
 

--- a/test/Nuplane.Loading.Tests/PackageLoadModeSelectorConflictTests.cs
+++ b/test/Nuplane.Loading.Tests/PackageLoadModeSelectorConflictTests.cs
@@ -21,7 +21,14 @@ public sealed class PackageLoadModeSelectorConflictTests
         Assert.Equal(PackageLoadMode.HostIntegrated, decision.LoadMode);
         Assert.All(decision.Selections, selection => Assert.Equal(PackageLoadMode.HostIntegrated, selection.LoadMode));
         Assert.All(decision.DiagnosticsByPackageKey.Values, diagnostics =>
-            Assert.Contains(diagnostics, diagnostic => diagnostic.ReasonCode == LoadModeReasonCodes.MetadataConflict));
+        {
+            Assert.Contains(diagnostics, diagnostic => diagnostic.ReasonCode == LoadModeReasonCodes.MetadataConflict);
+            Assert.All(diagnostics, diagnostic =>
+            {
+                Assert.Equal(PackageLoadMode.HostIntegrated, diagnostic.EffectiveGraphLoadMode);
+                Assert.Equal(PackageLoadMode.HostIntegrated, diagnostic.EffectivePackageLoadMode);
+            });
+        });
     }
 
     private static ResolvedPackage Pkg(string id) => new(id, "1.0.0", "feed-a", "/tmp/pkg", DateTimeOffset.UtcNow, id);

--- a/test/Nuplane.Loading.Tests/PackageLoadModeSelectorConflictTests.cs
+++ b/test/Nuplane.Loading.Tests/PackageLoadModeSelectorConflictTests.cs
@@ -1,0 +1,28 @@
+using Nuplane.Abstractions;
+
+namespace Nuplane.Loading.Tests;
+
+public sealed class PackageLoadModeSelectorConflictTests
+{
+    [Fact]
+    public async Task SelectGraphAsync_WhenMetadataConflicts_ChoosesHostIntegratedAndReportsConflict()
+    {
+        var sut = new PackageLoadModeSelector(
+        [
+            new StaticPackageLoadModeAdvisor(
+                "package-metadata",
+                PackageLoadModeSelectorTests.MetadataResult("pkg-a", PackageLoadMode.HostIntegrated),
+                PackageLoadModeSelectorTests.MetadataResult("pkg-b", PackageLoadMode.Collectible))
+        ]);
+        var options = new LoadingOptions { DefaultLoadMode = PackageLoadMode.Collectible };
+
+        var decision = await sut.SelectGraphAsync([Pkg("pkg-a"), Pkg("pkg-b")], options, "graph:test", CancellationToken.None);
+
+        Assert.Equal(PackageLoadMode.HostIntegrated, decision.LoadMode);
+        Assert.All(decision.Selections, selection => Assert.Equal(PackageLoadMode.HostIntegrated, selection.LoadMode));
+        Assert.All(decision.DiagnosticsByPackageKey.Values, diagnostics =>
+            Assert.Contains(diagnostics, diagnostic => diagnostic.ReasonCode == LoadModeReasonCodes.MetadataConflict));
+    }
+
+    private static ResolvedPackage Pkg(string id) => new(id, "1.0.0", "feed-a", "/tmp/pkg", DateTimeOffset.UtcNow, id);
+}

--- a/test/Nuplane.Loading.Tests/PackageLoadModeSelectorOverrideTests.cs
+++ b/test/Nuplane.Loading.Tests/PackageLoadModeSelectorOverrideTests.cs
@@ -27,5 +27,26 @@ public sealed class PackageLoadModeSelectorOverrideTests
             && diagnostic.EffectivePackageLoadMode == PackageLoadMode.Collectible);
     }
 
+    [Fact]
+    public async Task SelectGraphAsync_WhenSuppressedHostMetadataAndCollectibleMetadataExist_DoesNotReportConflict()
+    {
+        var sut = new PackageLoadModeSelector(
+        [
+            new StaticPackageLoadModeAdvisor(
+                "package-metadata",
+                PackageLoadModeSelectorTests.MetadataResult("pkg-a", PackageLoadMode.HostIntegrated),
+                PackageLoadModeSelectorTests.MetadataResult("pkg-b", PackageLoadMode.Collectible))
+        ]);
+        var options = new LoadingOptions { DefaultLoadMode = PackageLoadMode.Collectible };
+        options.PackageLoadModes.Add(new() { PackageId = "pkg-a", LoadMode = PackageLoadMode.Collectible });
+
+        var decision = await sut.SelectGraphAsync([Pkg("pkg-a"), Pkg("pkg-b")], options, "graph:test", CancellationToken.None);
+
+        Assert.Equal(PackageLoadMode.Collectible, decision.LoadMode);
+        Assert.All(decision.Selections, selection => Assert.Equal(PackageLoadMode.Collectible, selection.LoadMode));
+        Assert.All(decision.DiagnosticsByPackageKey.Values, diagnostics =>
+            Assert.DoesNotContain(diagnostics, diagnostic => diagnostic.ReasonCode == LoadModeReasonCodes.MetadataConflict));
+    }
+
     private static ResolvedPackage Pkg(string id) => new(id, "1.0.0", "feed-a", "/tmp/pkg", DateTimeOffset.UtcNow, id);
 }

--- a/test/Nuplane.Loading.Tests/PackageLoadModeSelectorOverrideTests.cs
+++ b/test/Nuplane.Loading.Tests/PackageLoadModeSelectorOverrideTests.cs
@@ -1,0 +1,31 @@
+using Nuplane.Abstractions;
+
+namespace Nuplane.Loading.Tests;
+
+public sealed class PackageLoadModeSelectorOverrideTests
+{
+    [Fact]
+    public async Task SelectGraphAsync_WhenExplicitCollectibleOverrideSuppressesHostMetadata_UsesCollectible()
+    {
+        var sut = new PackageLoadModeSelector(
+        [
+            new StaticPackageLoadModeAdvisor(
+                "package-metadata",
+                PackageLoadModeSelectorTests.MetadataResult("pkg-a", PackageLoadMode.HostIntegrated))
+        ]);
+        var options = new LoadingOptions { DefaultLoadMode = PackageLoadMode.Collectible };
+        options.PackageLoadModes.Add(new() { PackageId = "pkg-a", LoadMode = PackageLoadMode.Collectible });
+
+        var decision = await sut.SelectGraphAsync([Pkg("pkg-a")], options, "graph:test", CancellationToken.None);
+
+        Assert.Equal(PackageLoadMode.Collectible, decision.LoadMode);
+        var selection = Assert.Single(decision.Selections);
+        Assert.Equal(PackageLoadMode.Collectible, selection.LoadMode);
+        Assert.Equal(LoadModeReasonCodes.PackageOverride, selection.SelectionReason);
+        Assert.Contains(decision.DiagnosticsByPackageKey["pkg-a@1.0.0"], diagnostic =>
+            diagnostic.ReasonCode == LoadModeReasonCodes.MetadataSuppressed
+            && diagnostic.EffectivePackageLoadMode == PackageLoadMode.Collectible);
+    }
+
+    private static ResolvedPackage Pkg(string id) => new(id, "1.0.0", "feed-a", "/tmp/pkg", DateTimeOffset.UtcNow, id);
+}

--- a/test/Nuplane.Loading.Tests/PackageLoadModeSelectorOverrideTests.cs
+++ b/test/Nuplane.Loading.Tests/PackageLoadModeSelectorOverrideTests.cs
@@ -48,5 +48,33 @@ public sealed class PackageLoadModeSelectorOverrideTests
             Assert.DoesNotContain(diagnostics, diagnostic => diagnostic.ReasonCode == LoadModeReasonCodes.MetadataConflict));
     }
 
+    [Fact]
+    public async Task SelectGraphAsync_WhenExplicitOverrideSuppressesCustomAdvisor_UsesAdvisorSuppressedDiagnostic()
+    {
+        var sut = new PackageLoadModeSelector(
+        [
+            new StaticPackageLoadModeAdvisor(
+                "custom-advisor",
+                new LoadModeAdvisorResult(
+                    "custom-advisor",
+                    "pkg-a",
+                    "1.0.0",
+                    PackageLoadMode.HostIntegrated,
+                    LoadModeScopes.DependencyClosure,
+                    "custom-reason",
+                    "custom advisor"))
+        ]);
+        var options = new LoadingOptions { DefaultLoadMode = PackageLoadMode.Collectible };
+        options.PackageLoadModes.Add(new() { PackageId = "pkg-a", LoadMode = PackageLoadMode.Collectible });
+
+        var decision = await sut.SelectGraphAsync([Pkg("pkg-a")], options, "graph:test", CancellationToken.None);
+
+        var diagnostic = Assert.Single(
+            decision.DiagnosticsByPackageKey["pkg-a@1.0.0"],
+            diagnostic => diagnostic.AdvisorName == "custom-advisor");
+        Assert.Equal(LoadModeReasonCodes.AdvisorSuppressed, diagnostic.ReasonCode);
+        Assert.Equal("Package load-mode advisor result was suppressed by a higher-precedence load-mode policy.", diagnostic.Message);
+    }
+
     private static ResolvedPackage Pkg(string id) => new(id, "1.0.0", "feed-a", "/tmp/pkg", DateTimeOffset.UtcNow, id);
 }

--- a/test/Nuplane.Loading.Tests/PackageLoadModeSelectorPolicyTests.cs
+++ b/test/Nuplane.Loading.Tests/PackageLoadModeSelectorPolicyTests.cs
@@ -1,0 +1,51 @@
+using Nuplane.Abstractions;
+
+namespace Nuplane.Loading.Tests;
+
+public sealed class PackageLoadModeSelectorPolicyTests
+{
+    [Fact]
+    public async Task SelectGraphAsync_WhenDefaultIsHostIntegrated_CollectibleMetadataDoesNotForceDown()
+    {
+        var sut = new PackageLoadModeSelector(
+        [
+            new StaticPackageLoadModeAdvisor(
+                "package-metadata",
+                PackageLoadModeSelectorTests.MetadataResult("pkg-a", PackageLoadMode.Collectible))
+        ]);
+        var options = new LoadingOptions { DefaultLoadMode = PackageLoadMode.HostIntegrated };
+
+        var decision = await sut.SelectGraphAsync([Pkg("pkg-a")], options, "graph:test", CancellationToken.None);
+
+        Assert.Equal(PackageLoadMode.HostIntegrated, decision.LoadMode);
+        var selection = Assert.Single(decision.Selections);
+        Assert.Equal(PackageLoadMode.HostIntegrated, selection.LoadMode);
+        Assert.Equal(LoadModeReasonCodes.Default, selection.SelectionReason);
+    }
+
+    [Fact]
+    public async Task SelectGraphAsync_WhenPolicyIsExplicitOnly_IgnoresMetadata()
+    {
+        var sut = new PackageLoadModeSelector(
+        [
+            new StaticPackageLoadModeAdvisor(
+                "package-metadata",
+                PackageLoadModeSelectorTests.MetadataResult("pkg-a", PackageLoadMode.HostIntegrated))
+        ]);
+        var options = new LoadingOptions
+        {
+            DefaultLoadMode = PackageLoadMode.Collectible,
+            LoadModeSelectionPolicy = PackageLoadModeSelectionPolicy.ExplicitOnly
+        };
+
+        var decision = await sut.SelectGraphAsync([Pkg("pkg-a")], options, "graph:test", CancellationToken.None);
+
+        Assert.Equal(PackageLoadMode.Collectible, decision.LoadMode);
+        Assert.DoesNotContain(decision.DiagnosticsByPackageKey["pkg-a@1.0.0"], diagnostic =>
+            diagnostic.ReasonCode == LoadModeReasonCodes.PackageMetadata);
+        Assert.Contains(decision.DiagnosticsByPackageKey["pkg-a@1.0.0"], diagnostic =>
+            diagnostic.ReasonCode == LoadModeReasonCodes.AdvisorsDisabled);
+    }
+
+    private static ResolvedPackage Pkg(string id) => new(id, "1.0.0", "feed-a", "/tmp/pkg", DateTimeOffset.UtcNow, id);
+}

--- a/test/Nuplane.Loading.Tests/PackageLoadModeSelectorPolicyTests.cs
+++ b/test/Nuplane.Loading.Tests/PackageLoadModeSelectorPolicyTests.cs
@@ -21,6 +21,10 @@ public sealed class PackageLoadModeSelectorPolicyTests
         var selection = Assert.Single(decision.Selections);
         Assert.Equal(PackageLoadMode.HostIntegrated, selection.LoadMode);
         Assert.Equal(LoadModeReasonCodes.Default, selection.SelectionReason);
+        Assert.Contains(decision.DiagnosticsByPackageKey["pkg-a@1.0.0"], diagnostic =>
+            diagnostic.ReasonCode == LoadModeReasonCodes.MetadataSuppressed
+            && diagnostic.AdvisorName == "package-metadata"
+            && diagnostic.RequestedScope == LoadModeScopes.DependencyClosure);
     }
 
     [Fact]

--- a/test/Nuplane.Loading.Tests/PackageLoadModeSelectorTests.cs
+++ b/test/Nuplane.Loading.Tests/PackageLoadModeSelectorTests.cs
@@ -90,6 +90,56 @@ public sealed class PackageLoadModeSelectorTests
             diagnostic.ReasonCode == LoadModeReasonCodes.MetadataSuppressed);
     }
 
+    [Fact]
+    public async Task SelectGraphAsync_WhenCustomAdvisorSelectsLoadMode_PreservesAdvisorReasonCode()
+    {
+        var sut = new PackageLoadModeSelector(
+        [
+            new StaticPackageLoadModeAdvisor(
+                "custom-advisor",
+                new LoadModeAdvisorResult(
+                    "custom-advisor",
+                    "pkg-a",
+                    "1.0.0",
+                    PackageLoadMode.HostIntegrated,
+                    LoadModeScopes.DependencyClosure,
+                    "custom-host-requirement",
+                    "custom advisor"))
+        ]);
+        var options = new LoadingOptions { DefaultLoadMode = PackageLoadMode.Collectible };
+
+        var decision = await sut.SelectGraphAsync([Pkg("pkg-a")], options, "graph:test", CancellationToken.None);
+
+        var selection = Assert.Single(decision.Selections);
+        Assert.Equal(PackageLoadMode.HostIntegrated, selection.LoadMode);
+        Assert.Equal("custom-host-requirement", selection.SelectionReason);
+    }
+
+    [Fact]
+    public async Task SelectGraphAsync_WhenCustomAdvisorSelectsCollectible_PreservesAdvisorReasonCode()
+    {
+        var sut = new PackageLoadModeSelector(
+        [
+            new StaticPackageLoadModeAdvisor(
+                "custom-advisor",
+                new LoadModeAdvisorResult(
+                    "custom-advisor",
+                    "pkg-a",
+                    "1.0.0",
+                    PackageLoadMode.Collectible,
+                    LoadModeScopes.PackageOnly,
+                    "custom-collectible-preference",
+                    "custom advisor"))
+        ]);
+        var options = new LoadingOptions { DefaultLoadMode = PackageLoadMode.Collectible };
+
+        var decision = await sut.SelectGraphAsync([Pkg("pkg-a")], options, "graph:test", CancellationToken.None);
+
+        var selection = Assert.Single(decision.Selections);
+        Assert.Equal(PackageLoadMode.Collectible, selection.LoadMode);
+        Assert.Equal("custom-collectible-preference", selection.SelectionReason);
+    }
+
     private static ResolvedPackage Pkg(string id) => new(id, "1.0.0", "feed-a", "/tmp/pkg", DateTimeOffset.UtcNow, id);
 
     internal static LoadModeAdvisorResult MetadataResult(

--- a/test/Nuplane.Loading.Tests/PackageLoadModeSelectorTests.cs
+++ b/test/Nuplane.Loading.Tests/PackageLoadModeSelectorTests.cs
@@ -29,5 +29,79 @@ public sealed class PackageLoadModeSelectorTests
         Assert.Equal("package-override", selection.SelectionReason);
     }
 
+    [Fact]
+    public async Task SelectGraphAsync_WhenMetadataRequiresHostIntegrated_PromotesGraph()
+    {
+        var sut = new PackageLoadModeSelector(
+        [
+            new StaticPackageLoadModeAdvisor(
+                "package-metadata",
+                MetadataResult("pkg-a", PackageLoadMode.HostIntegrated))
+        ]);
+        var options = new LoadingOptions { DefaultLoadMode = PackageLoadMode.Collectible };
+
+        var decision = await sut.SelectGraphAsync([Pkg("pkg-a"), Pkg("pkg-b")], options, "graph:test", CancellationToken.None);
+
+        Assert.Equal(PackageLoadMode.HostIntegrated, decision.LoadMode);
+        Assert.All(decision.Selections, selection => Assert.Equal(PackageLoadMode.HostIntegrated, selection.LoadMode));
+        Assert.Contains(decision.Selections, selection =>
+            selection.PackageId == "pkg-a"
+            && selection.SelectionReason == LoadModeReasonCodes.PackageMetadata);
+        Assert.Contains(decision.Selections, selection =>
+            selection.PackageId == "pkg-b"
+            && selection.SelectionReason == LoadModeReasonCodes.DependencyClosure);
+    }
+
+    [Fact]
+    public async Task SelectGraphAsync_WhenNoMetadataOrOverride_UsesDefaultFallback()
+    {
+        var sut = new PackageLoadModeSelector();
+        var options = new LoadingOptions { DefaultLoadMode = PackageLoadMode.Collectible };
+
+        var decision = await sut.SelectGraphAsync([Pkg("pkg-a"), Pkg("pkg-b")], options, "graph:test", CancellationToken.None);
+
+        Assert.Equal(PackageLoadMode.Collectible, decision.LoadMode);
+        Assert.All(decision.Selections, selection =>
+        {
+            Assert.Equal(PackageLoadMode.Collectible, selection.LoadMode);
+            Assert.Equal(LoadModeReasonCodes.Default, selection.SelectionReason);
+        });
+    }
+
+    [Fact]
+    public async Task SelectGraphAsync_WhenExplicitHostIntegratedOverrideConflictsWithCollectibleMetadata_OverrideWins()
+    {
+        var sut = new PackageLoadModeSelector(
+        [
+            new StaticPackageLoadModeAdvisor(
+                "package-metadata",
+                MetadataResult("pkg-a", PackageLoadMode.Collectible))
+        ]);
+        var options = new LoadingOptions { DefaultLoadMode = PackageLoadMode.Collectible };
+        options.PackageLoadModes.Add(new() { PackageId = "pkg-a", LoadMode = PackageLoadMode.HostIntegrated });
+
+        var decision = await sut.SelectGraphAsync([Pkg("pkg-a"), Pkg("pkg-b")], options, "graph:test", CancellationToken.None);
+
+        Assert.Equal(PackageLoadMode.HostIntegrated, decision.LoadMode);
+        var selection = Assert.Single(decision.Selections, selection => selection.PackageId == "pkg-a");
+        Assert.Equal(PackageLoadMode.HostIntegrated, selection.LoadMode);
+        Assert.Equal(LoadModeReasonCodes.PackageOverride, selection.SelectionReason);
+        Assert.Contains(decision.DiagnosticsByPackageKey["pkg-a@1.0.0"], diagnostic =>
+            diagnostic.ReasonCode == LoadModeReasonCodes.MetadataSuppressed);
+    }
+
     private static ResolvedPackage Pkg(string id) => new(id, "1.0.0", "feed-a", "/tmp/pkg", DateTimeOffset.UtcNow, id);
+
+    internal static LoadModeAdvisorResult MetadataResult(
+        string packageId,
+        PackageLoadMode loadMode,
+        string scope = LoadModeScopes.DependencyClosure) =>
+        new(
+            "package-metadata",
+            packageId,
+            "1.0.0",
+            loadMode,
+            scope,
+            LoadModeReasonCodes.PackageMetadata,
+            "test metadata");
 }

--- a/test/Nuplane.Loading.Tests/PackageLoaderGraphRegressionTests.cs
+++ b/test/Nuplane.Loading.Tests/PackageLoaderGraphRegressionTests.cs
@@ -1,11 +1,32 @@
 using System.Runtime.InteropServices;
 using Nuplane.Abstractions;
+using Nuplane.Loading.Tests.Fixtures;
 
 namespace Nuplane.Loading.Tests;
 
 public sealed class PackageLoaderGraphRegressionTests : IDisposable
 {
     private readonly string tempRoot = Path.Combine(Path.GetTempPath(), $"nuplane-graph-loader-{Guid.NewGuid():N}");
+
+    public static IReadOnlyList<ResolvedPackage> CreateProviderStyleGraph(DirectoryInfo tempDir)
+    {
+        var providerRootPath = PackageMetadataTestSupport.CreateInstallDir(tempDir, "Provider.Root", typeof(FixtureMarker).Assembly);
+        var providerRuntimePath = PackageMetadataTestSupport.CreateInstallDir(tempDir, "Provider.Runtime", typeof(PackageLoaderGraphRegressionTests).Assembly);
+        var facadePath = PackageMetadataTestSupport.CreateNoAssemblyInstallDir(tempDir, "Provider.Facade");
+
+        PackageMetadataTestSupport.WriteMetadata(
+            providerRootPath,
+            PackageLoadMode.HostIntegrated,
+            LoadModeScopes.DependencyClosure,
+            "Uses framework type resolution and provider runtime integration.");
+
+        return
+        [
+            PackageMetadataTestSupport.Package("Provider.Root", "1.0.0", providerRootPath),
+            PackageMetadataTestSupport.Package("Provider.Runtime", "1.0.0", providerRuntimePath),
+            PackageMetadataTestSupport.Package("Provider.Facade", "1.0.0", facadePath)
+        ];
+    }
 
     [Fact]
     public async Task EnsureLoadedAsync_RootAndDependencyGraph_ReflectsRootMetadataWithoutFileNotFoundException()

--- a/test/Nuplane.Loading.Tests/PackageLoaderHostIntegratedTests.cs
+++ b/test/Nuplane.Loading.Tests/PackageLoaderHostIntegratedTests.cs
@@ -90,6 +90,66 @@ public sealed class PackageLoaderHostIntegratedTests : IDisposable
     }
 
     [Fact]
+    public async Task EnsureGraphLoadedAsync_WhenPackageMetadataRequiresHostIntegrated_PromotesDependencyClosure()
+    {
+        var catalog = new HostIntegratedAssemblyResolutionCatalog();
+        var loader = new PackageLoader(
+            hostIntegratedResolutionCatalog: catalog,
+            loadModeAdvisors: [new PackageMetadataLoadModeAdvisor(new PackageMetadataLoadModeReader())]);
+        var graph = PackageLoaderGraphRegressionTests.CreateProviderStyleGraph(tempDir);
+
+        var result = await loader.EnsureGraphLoadedAsync([graph], [], CancellationToken.None);
+
+        Assert.Empty(result.FailedByPackageId);
+        Assert.Equal(2, result.Loaded.Count);
+        Assert.All(result.Loaded, session =>
+        {
+            Assert.Equal(PackageLoadMode.HostIntegrated, session.LoadMode);
+            Assert.True(session.FrameworkIntegrationSafe);
+            Assert.Contains(session.LoadModeDiagnostics ?? [], diagnostic =>
+                diagnostic.ReasonCode is LoadModeReasonCodes.PackageMetadata or LoadModeReasonCodes.DependencyClosure);
+        });
+        Assert.True(catalog.TryResolve(typeof(FixtureMarker).Assembly.GetName(), out _, out _));
+        Assert.True(catalog.TryResolve(typeof(PackageLoaderGraphRegressionTests).Assembly.GetName(), out _, out _));
+    }
+
+    [Fact]
+    public async Task EnsureGraphLoadedAsync_WhenExplicitOverridePromotesGraph_RecordsDependencyClosureDiagnostic()
+    {
+        var firstInstallPath = CreateInstallDir("pkg-a", typeof(FixtureMarker).Assembly);
+        var secondInstallPath = CreateInstallDir("pkg-b", typeof(PackageLoaderHostIntegratedTests).Assembly);
+        var loadingOptions = new LoadingOptions();
+        loadingOptions.PackageLoadModes.Add(new() { PackageId = "pkg-a", LoadMode = PackageLoadMode.HostIntegrated });
+        var loader = new PackageLoader(options: Options.Create(loadingOptions));
+
+        var result = await loader.EnsureGraphLoadedAsync(
+            [[Pkg("pkg-a", "1.0.0", firstInstallPath), Pkg("pkg-b", "1.0.0", secondInstallPath)]],
+            [],
+            CancellationToken.None);
+
+        Assert.Empty(result.FailedByPackageId);
+        var promoted = Assert.Single(result.Loaded, session => session.PackageId == "pkg-b");
+        Assert.Equal(PackageLoadMode.HostIntegrated, promoted.LoadMode);
+        Assert.Contains(promoted.LoadModeDiagnostics ?? [], diagnostic =>
+            diagnostic.ReasonCode == LoadModeReasonCodes.DependencyClosure);
+    }
+
+    [Fact]
+    public async Task EnsureGraphLoadedAsync_WhenGraphRemainsCollectible_DoesNotPublishResolutionEntry()
+    {
+        var installPath = CreateInstallDir("pkg-a", typeof(FixtureMarker).Assembly);
+        var catalog = new HostIntegratedAssemblyResolutionCatalog();
+        var loader = new PackageLoader(hostIntegratedResolutionCatalog: catalog);
+
+        var result = await loader.EnsureGraphLoadedAsync([[Pkg("pkg-a", "1.0.0", installPath)]], [], CancellationToken.None);
+
+        var loaded = Assert.Single(result.Loaded);
+        Assert.Equal(PackageLoadMode.Collectible, loaded.LoadMode);
+        Assert.False(catalog.TryResolve(typeof(FixtureMarker).Assembly.GetName(), out _, out var diagnostic));
+        Assert.Equal("not-found", diagnostic.Outcome);
+    }
+
+    [Fact]
     public async Task EnsureGraphLoadedAsync_HostIntegratedGraphWithNoAssemblyDependency_SkipsDependencyWithoutCatalogEntry()
     {
         var rootInstallPath = CreateInstallDir("Nuplane.Loading.Tests.Fixtures");

--- a/test/Nuplane.Loading.Tests/PackageLoaderTests.cs
+++ b/test/Nuplane.Loading.Tests/PackageLoaderTests.cs
@@ -124,6 +124,29 @@ public sealed class PackageLoaderTests : IDisposable
     }
 
     [Fact]
+    public async Task EnsureGraphLoadedAsync_WhenGraphHasNoMetadataOrOverride_UsesCollectibleFallback()
+    {
+        var firstPath = CreateInstallDir("pkg-a");
+        var secondPath = CreateInstallDir("pkg-b");
+        var loader = new PackageLoader();
+
+        var result = await loader.EnsureGraphLoadedAsync(
+            [[Pkg("pkg-a", "1.0.0", firstPath), Pkg("pkg-b", "1.0.0", secondPath)]],
+            [],
+            CancellationToken.None);
+
+        Assert.Empty(result.FailedByPackageId);
+        Assert.Equal(2, result.Loaded.Count);
+        Assert.All(result.Loaded, session =>
+        {
+            Assert.Equal(PackageLoadMode.Collectible, session.LoadMode);
+            Assert.False(session.FrameworkIntegrationSafe);
+            Assert.Contains(session.LoadModeDiagnostics ?? [], diagnostic =>
+                diagnostic.ReasonCode == LoadModeReasonCodes.Default);
+        });
+    }
+
+    [Fact]
     public void ResolveMainAssemblyPath_MultiTargetPackage_PicksExactHostFrameworkAssembly()
     {
         var installPath = CreateMultiTargetInstallDir("Nuplane.Loading.Tests.Fixtures", GetHostFrameworkFolderName(), "net8.0", "net9.0");

--- a/test/Nuplane.Loading.Tests/PackageMetadataLoadModeAdvisorTests.cs
+++ b/test/Nuplane.Loading.Tests/PackageMetadataLoadModeAdvisorTests.cs
@@ -1,0 +1,37 @@
+namespace Nuplane.Loading.Tests;
+
+public sealed class PackageMetadataLoadModeAdvisorTests : IDisposable
+{
+    private readonly DirectoryInfo tempDir = Directory.CreateTempSubdirectory("nuplane-metadata-advisor-test-");
+
+    public void Dispose() => tempDir.Delete(recursive: true);
+
+    [Fact]
+    public async Task EvaluateAsync_WhenPackageDeclaresHostIntegratedDependencyClosure_ReturnsPackageMetadataResult()
+    {
+        var installPath = PackageMetadataTestSupport.CreateInstallDir(tempDir, "pkg-a");
+        PackageMetadataTestSupport.WriteMetadata(
+            installPath,
+            PackageLoadMode.HostIntegrated,
+            LoadModeScopes.DependencyClosure,
+            "Requires framework type resolution.");
+        var package = PackageMetadataTestSupport.Package("pkg-a", "1.0.0", installPath);
+        var context = new LoadModeAdvisorContext(
+            "graph:pkg-a@1.0.0",
+            [package],
+            PackageLoadModeSelectionPolicy.Automatic,
+            PackageLoadMode.Collectible,
+            new Dictionary<string, PackageLoadMode>(StringComparer.OrdinalIgnoreCase));
+        var sut = new PackageMetadataLoadModeAdvisor(new PackageMetadataLoadModeReader());
+
+        var results = await sut.EvaluateAsync(context, CancellationToken.None);
+
+        var result = Assert.Single(results);
+        Assert.Equal("package-metadata", result.AdvisorName);
+        Assert.Equal("pkg-a", result.PackageId);
+        Assert.Equal(PackageLoadMode.HostIntegrated, result.RequestedLoadMode);
+        Assert.Equal(LoadModeScopes.DependencyClosure, result.Scope);
+        Assert.Equal(LoadModeReasonCodes.PackageMetadata, result.ReasonCode);
+        Assert.True(result.IsValid);
+    }
+}

--- a/test/Nuplane.Loading.Tests/PackageMetadataLoadModeAdvisorTests.cs
+++ b/test/Nuplane.Loading.Tests/PackageMetadataLoadModeAdvisorTests.cs
@@ -1,3 +1,5 @@
+using Microsoft.Extensions.Logging;
+
 namespace Nuplane.Loading.Tests;
 
 public sealed class PackageMetadataLoadModeAdvisorTests : IDisposable
@@ -9,6 +11,8 @@ public sealed class PackageMetadataLoadModeAdvisorTests : IDisposable
     [Fact]
     public async Task EvaluateAsync_WhenPackageDeclaresHostIntegratedDependencyClosure_ReturnsPackageMetadataResult()
     {
+        var messages = new List<string>();
+        using var loggerFactory = LoggerFactory.Create(builder => builder.AddProvider(new CapturingLoggerProvider(messages)));
         var installPath = PackageMetadataTestSupport.CreateInstallDir(tempDir, "pkg-a");
         PackageMetadataTestSupport.WriteMetadata(
             installPath,
@@ -22,7 +26,9 @@ public sealed class PackageMetadataLoadModeAdvisorTests : IDisposable
             PackageLoadModeSelectionPolicy.Automatic,
             PackageLoadMode.Collectible,
             new Dictionary<string, PackageLoadMode>(StringComparer.OrdinalIgnoreCase));
-        var sut = new PackageMetadataLoadModeAdvisor(new PackageMetadataLoadModeReader());
+        var sut = new PackageMetadataLoadModeAdvisor(
+            new PackageMetadataLoadModeReader(),
+            loggerFactory.CreateLogger<PackageMetadataLoadModeAdvisor>());
 
         var results = await sut.EvaluateAsync(context, CancellationToken.None);
 
@@ -33,5 +39,31 @@ public sealed class PackageMetadataLoadModeAdvisorTests : IDisposable
         Assert.Equal(LoadModeScopes.DependencyClosure, result.Scope);
         Assert.Equal(LoadModeReasonCodes.PackageMetadata, result.ReasonCode);
         Assert.True(result.IsValid);
+        Assert.Contains(messages, message =>
+            message.Contains("Discovered package load metadata", StringComparison.Ordinal)
+            && message.Contains("pkg-a@1.0.0", StringComparison.Ordinal)
+            && message.Contains("HostIntegrated", StringComparison.Ordinal));
+    }
+
+    private sealed class CapturingLoggerProvider(List<string> messages) : ILoggerProvider
+    {
+        public ILogger CreateLogger(string categoryName) => new CapturingLogger(messages);
+
+        public void Dispose() { }
+    }
+
+    private sealed class CapturingLogger(List<string> messages) : ILogger
+    {
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter) =>
+            messages.Add(formatter(state, exception));
     }
 }

--- a/test/Nuplane.Loading.Tests/PackageMetadataLoadModeReaderTests.cs
+++ b/test/Nuplane.Loading.Tests/PackageMetadataLoadModeReaderTests.cs
@@ -34,6 +34,7 @@ public sealed class PackageMetadataLoadModeReaderTests : IDisposable
     [InlineData("{")]
     [InlineData("""{"schemaVersion":2,"loading":{"loadMode":"HostIntegrated","scope":"DependencyClosure"}}""")]
     [InlineData("""{"schemaVersion":1,"loading":{"loadMode":"PluginOnly","scope":"DependencyClosure"}}""")]
+    [InlineData("""{"schemaVersion":1,"loading":{"loadMode":"1","scope":"DependencyClosure"}}""")]
     [InlineData("""{"schemaVersion":1,"loading":{"loadMode":"HostIntegrated","scope":"WholeUniverse"}}""")]
     [InlineData("""{"schemaVersion":1}""")]
     [InlineData("""{"schemaVersion":1,"loading":{"scope":"DependencyClosure"}}""")]

--- a/test/Nuplane.Loading.Tests/PackageMetadataLoadModeReaderTests.cs
+++ b/test/Nuplane.Loading.Tests/PackageMetadataLoadModeReaderTests.cs
@@ -1,0 +1,69 @@
+namespace Nuplane.Loading.Tests;
+
+public sealed class PackageMetadataLoadModeReaderTests : IDisposable
+{
+    private readonly DirectoryInfo tempDir = Directory.CreateTempSubdirectory("nuplane-metadata-reader-test-");
+
+    public void Dispose() => tempDir.Delete(recursive: true);
+
+    [Fact]
+    public void Read_WhenPackageRootMetadataIsValid_ReturnsLoadingRequirement()
+    {
+        var installPath = PackageMetadataTestSupport.CreateInstallDir(tempDir, "pkg-a");
+        PackageMetadataTestSupport.WriteMetadata(
+            installPath,
+            PackageLoadMode.HostIntegrated,
+            LoadModeScopes.DependencyClosure,
+            "Uses runtime scheduler integration.");
+        var sut = new PackageMetadataLoadModeReader();
+
+        var result = sut.Read("pkg-a", "1.0.0", installPath);
+
+        Assert.True(result.MetadataFound);
+        Assert.True(result.IsValid);
+        Assert.NotNull(result.Metadata);
+        var metadata = result.Metadata!;
+        Assert.Equal(1, metadata.SchemaVersion);
+        var loading = metadata.Loading!;
+        Assert.Equal(PackageLoadMode.HostIntegrated, loading.LoadMode);
+        Assert.Equal(LoadModeScopes.DependencyClosure, loading.Scope);
+        Assert.Equal("Uses runtime scheduler integration.", loading.Reason);
+    }
+
+    [Theory]
+    [InlineData("{")]
+    [InlineData("""{"schemaVersion":2,"loading":{"loadMode":"HostIntegrated","scope":"DependencyClosure"}}""")]
+    [InlineData("""{"schemaVersion":1,"loading":{"loadMode":"PluginOnly","scope":"DependencyClosure"}}""")]
+    [InlineData("""{"schemaVersion":1,"loading":{"loadMode":"HostIntegrated","scope":"WholeUniverse"}}""")]
+    [InlineData("""{"schemaVersion":1}""")]
+    [InlineData("""{"schemaVersion":1,"loading":{"scope":"DependencyClosure"}}""")]
+    [InlineData("""{"schemaVersion":1,"loading":{"loadMode":"HostIntegrated"}}""")]
+    public void Read_WhenMetadataIsInvalid_ReturnsInvalidDiagnostic(string json)
+    {
+        var installPath = PackageMetadataTestSupport.CreateInstallDir(tempDir, "pkg-a");
+        File.WriteAllText(Path.Combine(installPath, PackageMetadataLoadModeReader.MetadataFileName), json);
+        var sut = new PackageMetadataLoadModeReader();
+
+        var result = sut.Read("pkg-a", "1.0.0", installPath);
+
+        Assert.True(result.MetadataFound);
+        Assert.False(result.IsValid);
+        Assert.NotNull(result.Diagnostic);
+    }
+
+    [Fact]
+    public void Read_WhenMetadataIsOversized_ReturnsInvalidDiagnostic()
+    {
+        var installPath = PackageMetadataTestSupport.CreateInstallDir(tempDir, "pkg-a");
+        File.WriteAllText(
+            Path.Combine(installPath, PackageMetadataLoadModeReader.MetadataFileName),
+            new string('x', 64 * 1024 + 1));
+        var sut = new PackageMetadataLoadModeReader();
+
+        var result = sut.Read("pkg-a", "1.0.0", installPath);
+
+        Assert.True(result.MetadataFound);
+        Assert.False(result.IsValid);
+        Assert.Contains("exceeds", result.Diagnostic, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/test/Nuplane.Loading.Tests/PackageMetadataTestSupport.cs
+++ b/test/Nuplane.Loading.Tests/PackageMetadataTestSupport.cs
@@ -1,0 +1,60 @@
+using System.Reflection;
+using System.Text.Json;
+using Nuplane.Abstractions;
+using Nuplane.Loading.Tests.Fixtures;
+
+namespace Nuplane.Loading.Tests;
+
+internal static class PackageMetadataTestSupport
+{
+    public static string CreateInstallDir(DirectoryInfo root, string packageId, Assembly? assembly = null)
+    {
+        var dir = root.CreateSubdirectory($"{packageId}-{Guid.NewGuid():N}");
+        var sourceAssembly = assembly ?? typeof(FixtureMarker).Assembly;
+        File.Copy(sourceAssembly.Location, Path.Combine(dir.FullName, $"{packageId}.dll"));
+        return dir.FullName;
+    }
+
+    public static string CreateNoAssemblyInstallDir(DirectoryInfo root, string packageId)
+    {
+        var dir = root.CreateSubdirectory($"{packageId}-{Guid.NewGuid():N}");
+        var frameworkDir = Directory.CreateDirectory(Path.Combine(dir.FullName, "lib", "netstandard2.0"));
+        File.WriteAllText(Path.Combine(frameworkDir.FullName, "_._"), string.Empty);
+        return dir.FullName;
+    }
+
+    public static void WriteMetadata(
+        string installPath,
+        PackageLoadMode loadMode = PackageLoadMode.HostIntegrated,
+        string scope = LoadModeScopes.DependencyClosure,
+        string? reason = "Requires host integration.")
+    {
+        var document = new
+        {
+            schemaVersion = 1,
+            loading = new
+            {
+                loadMode = loadMode.ToString(),
+                scope,
+                reason
+            }
+        };
+
+        File.WriteAllText(
+            Path.Combine(installPath, PackageMetadataLoadModeReader.MetadataFileName),
+            JsonSerializer.Serialize(document));
+    }
+
+    public static ResolvedPackage Package(string id, string version, string installPath) =>
+        new(id, version, "feed-a", installPath, DateTimeOffset.UtcNow, "source-a");
+}
+
+internal sealed class StaticPackageLoadModeAdvisor(string name, params LoadModeAdvisorResult[] results) : IPackageLoadModeAdvisor
+{
+    public string Name { get; } = name;
+
+    public ValueTask<IReadOnlyList<LoadModeAdvisorResult>> EvaluateAsync(
+        LoadModeAdvisorContext context,
+        CancellationToken cancellationToken) =>
+        ValueTask.FromResult<IReadOnlyList<LoadModeAdvisorResult>>(results);
+}


### PR DESCRIPTION
## Summary
- add automatic load-mode selection policy and package load-mode advisor contracts
- read package-root nuplane.json metadata and promote host-integrated dependency closures
- expose load-mode diagnostics in loading catalog descriptors and add docs/spec artifacts

## Validation
- dotnet test test/Nuplane.Loading.Tests/Nuplane.Loading.Tests.csproj --no-restore
- dotnet test nuplane.sln --no-restore
