### PR TITLE
Add keyed feed setup configuration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,6 +79,8 @@ Run focused tests first for the area changed, then run the full solution when pr
 - C# with SDK-style .NET libraries targeting `net8.0;net9.0;net10.0`; tests target `net10.0`.
 - Microsoft.Extensions.DependencyInjection/Options/Logging/Hosting, NuGet.Protocol, NuGet.Versioning, System.Runtime.Loader, xUnit, and NSubstitute.
 - File-backed Nuplane store state and package install directories under configured state/package roots; no database.
+- C# / .NET 8.0, 9.0, 10.0 source libraries; tests target .NET 10.0 + Microsoft.Extensions.Configuration, Microsoft.Extensions.DependencyInjection, Microsoft.Extensions.Options, Microsoft.Extensions.Logging; existing Nuplane builder and feed registration APIs (027-keyed-feed-config)
+- N/A for this feature; configuration is translated into runtime options and desired-state sources (027-keyed-feed-config)
 
 ## Recent Changes
 - 017-dependency-closure-loading: Added C# with SDK-style .NET libraries targeting `net8.0;net9.0;net10.0`; tests target `net10.0` + Microsoft.Extensions.DependencyInjection/Options/Logging/Hosting, NuGet.Protocol and NuGet.Versioning already used by feed version resolution, System.Runtime.Loader, xUnit, NSubstitute

--- a/README.md
+++ b/README.md
@@ -190,9 +190,8 @@ builder.Services.AddNuplane(nuplaneConfiguration, nuplane =>
     "Setup": {
       "AutomaticReconciliation": true,
       "PollInterval": "00:01:00",
-      "Feeds": [
-        {
-          "Name": "local-packages",
+      "Feeds": {
+        "local-packages": {
           "DirectoryPath": "packages",
           "IncludePatterns": [
             "*"
@@ -202,14 +201,13 @@ builder.Services.AddNuplane(nuplaneConfiguration, nuplane =>
             "DebounceWindow": "00:00:01"
           }
         },
-        {
-          "Name": "nuget.org",
+        "nuget.org": {
           "ServiceIndex": "https://api.nuget.org/v3/index.json",
           "IncludePatterns": [
             "Elsa.*"
           ]
         }
-      ]
+      }
     },
     "Loading": {
       "Enabled": true,
@@ -294,6 +292,39 @@ For unrestricted feeds, prefer one of these explicit forms:
 - configuration alias: `"IncludeAll": true`
 - fluent API: `feed.IncludeAll()`
 
+For configuration-driven setup, prefer the keyed `Nuplane:Setup:Feeds` object shape:
+
+```json
+"Feeds": {
+  "feedz.io": {
+    "ServiceIndex": "https://new.example/nuget/index.json"
+  }
+}
+```
+
+The feed key is the feed name. This shape is preferred for layered .NET configuration because later providers can override `Feeds:feedz.io` by identity instead of merging array entries by numeric position. Feed resolution order is not based on object order; use the existing feed priority configuration when one feed should be preferred over another.
+
+Migration from the legacy array shape is mechanical:
+
+```json
+"Feeds": [
+  {
+    "Name": "feedz.io",
+    "ServiceIndex": "https://old.example/nuget/index.json"
+  }
+]
+```
+
+becomes:
+
+```json
+"Feeds": {
+  "feedz.io": {
+    "ServiceIndex": "https://new.example/nuget/index.json"
+  }
+}
+```
+
 ---
 
 ## Kubernetes And Restart Persistence
@@ -321,15 +352,14 @@ Example configuration:
       "StateFilePath": "/var/lib/nuplane/store-state.json",
       "AutomaticReconciliation": true,
       "PollInterval": "00:01:00",
-      "Feeds": [
-        {
-          "Name": "nuget.org",
+      "Feeds": {
+        "nuget.org": {
           "ServiceIndex": "https://api.nuget.org/v3/index.json",
           "IncludePatterns": [
             "*"
           ]
         }
-      ]
+      }
     },
     "FeedResolution": {
       "PackageInstallRoot": "/var/lib/nuplane/packages"

--- a/docs/posts/introducing-nuplane.md
+++ b/docs/posts/introducing-nuplane.md
@@ -58,9 +58,8 @@ The configuration side of this declares the folder feed, the watcher behavior, a
     "Setup": {
       "AutomaticReconciliation": true,
       "PollInterval": "00:01:00",
-      "Feeds": [
-        {
-          "Name": "local-packages",
+      "Feeds": {
+        "local-packages": {
           "DirectoryPath": "packages",
           "IncludePatterns": ["*"],
           "Directory": {
@@ -68,7 +67,7 @@ The configuration side of this declares the folder feed, the watcher behavior, a
             "DebounceWindow": "00:00:01"
           }
         }
-      ]
+      }
     },
     "Loading": {
       "Enabled": true,
@@ -211,13 +210,12 @@ Or declaratively in configuration, using the full `Nuplane:Setup:Feeds` shape an
 {
   "Nuplane": {
     "Setup": {
-      "Feeds": [
-        {
-          "Name": "nuget.org",
+      "Feeds": {
+        "nuget.org": {
           "ServiceIndex": "https://api.nuget.org/v3/index.json",
           "IncludePatterns": ["MyCompany.Plugins.*"]
         }
-      ]
+      }
     }
   }
 }

--- a/docs/wiki/Usage-Guide.md
+++ b/docs/wiki/Usage-Guide.md
@@ -75,6 +75,10 @@ Choose configuration-first setup when you want the host to declare:
 - optional loading settings when the loading module is installed.
 
 The sample `appsettings.json` is the best concrete repository anchor for this path.
+Prefer keyed feed setup under `Nuplane:Setup:Feeds`, where each feed key is the feed name.
+This avoids positional array merging when `appsettings.json`, environment variables, and mounted
+configuration files are layered. Feed object order is not semantic; configure feed priorities
+separately when resolution order matters.
 
 ## Code-driven adoption
 

--- a/samples/Nuplane.Sample.AspNetCore/appsettings.json
+++ b/samples/Nuplane.Sample.AspNetCore/appsettings.json
@@ -9,9 +9,8 @@
     "Setup": {
       "AutomaticReconciliation": true,
       "PollInterval": "00:01:00",
-      "Feeds": [
-        {
-          "Name": "local-packages",
+      "Feeds": {
+        "local-packages": {
           "DirectoryPath": "packages",
           "IncludePatterns": [
             "*"
@@ -21,7 +20,7 @@
             "DebounceWindow": "00:00:01"
           }
         }
-      ]
+      }
     },
     "Loading": {
       "Enabled": true,

--- a/specs/027-keyed-feed-config/checklists/requirements.md
+++ b/specs/027-keyed-feed-config/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Key-Based Feed Setup Configuration
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-18
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Validation passed after initial review. The spec deliberately keeps existing array-only duplicate behavior unchanged, uses existing feed priority configuration for ordering, and chooses validation failure for keyed feed key/name mismatches.

--- a/specs/027-keyed-feed-config/contracts/feed-setup-reader-contract.md
+++ b/specs/027-keyed-feed-config/contracts/feed-setup-reader-contract.md
@@ -1,0 +1,58 @@
+# Contract: Feed Setup Declaration Reader
+
+## Interface
+
+```csharp
+public static class NuplaneFeedSetupDeclarationReader
+{
+    public static IReadOnlyList<NuplaneFeedSetupDeclaration> Read(IConfiguration setupOrFeedsSection);
+}
+```
+
+**Location**: `src/Nuplane/Feeds/Setup/`  
+**Consumers**:
+- `NuplaneFeedSetupConfiguration` for remote feeds
+- `NuplaneDirectoryFeedSetupConfiguration` for directory feeds
+- `NuplaneSetupOptionsValidator` or its validation adapter for setup feed validation
+- `INuplaneSetupFeedDeclarationSource` for preserving raw keyed declarations across DI validation and translation
+
+## Behavioral Contract
+
+- The reader MUST accept either the `Nuplane:Setup` section or the `Nuplane:Setup:Feeds` section.
+- The reader MUST inspect direct children of `Feeds`.
+- Child keys made only of digits MUST be treated as array entries.
+- Child keys not made only of digits MUST be treated as keyed entries.
+- Array entries MUST use the existing inner `Name` property as the canonical feed name.
+- Keyed entries MUST use the child key as the canonical feed name.
+- Keyed entries MAY include an inner `Name` only when it matches the child key using Nuplane feed-name comparison rules.
+- Effective declarations MUST be grouped by feed name using case-insensitive comparison.
+- If a group contains one keyed declaration and one or more array declarations, the keyed declaration MUST be returned as the effective declaration and the ignored array declarations MUST be available for warning diagnostics.
+- The reader MUST preserve existing feed property values: `ServiceIndex`, `DirectoryPath`, `IncludePatterns`, `IncludeAll`, `Credentials`, and `Directory`.
+- The reader MUST NOT emit or log credential secret values.
+- The reader MUST be usable from a DI-registered declaration source so validation can see keyed child paths that `NuplaneSetupOptions.Feeds` list binding cannot represent.
+
+## Ordering Contract
+
+- The reader MUST NOT rely on JSON object order for semantic feed resolution behavior.
+- Returned declarations MAY be sorted deterministically by feed name for stable tests and diagnostics.
+- Feed resolution order remains the responsibility of `FeedResolutionPolicy` using existing feed priority configuration and name-based tie-breaking.
+
+## Error Contract
+
+- The reader MAY collect invalid declarations for validation rather than throwing immediately.
+- Validation failures MUST identify the configuration path and feed name when available.
+- A key/name mismatch MUST be reported as an error by validation.
+- Same-name mixed array/keyed declarations MUST NOT throw; they produce an effective keyed declaration plus a warning diagnostic.
+
+## Test Contract
+
+- Reads keyed remote feed without inner `Name`.
+- Reads keyed directory feed without inner `Name`.
+- Reads keyed feed with matching inner `Name`.
+- Reports keyed feed with mismatched inner `Name`.
+- Preserves legacy array feed behavior.
+- Treats all-digit child keys as array entries.
+- Treats non-numeric child keys as keyed entries.
+- Handles same-name array/keyed declarations by returning only keyed as effective.
+- Preserves `IncludePatterns`, `IncludeAll`, `Credentials`, and `Directory` values.
+- Produces deterministic output for the same effective configuration.

--- a/specs/027-keyed-feed-config/contracts/feed-setup-validation-contract.md
+++ b/specs/027-keyed-feed-config/contracts/feed-setup-validation-contract.md
@@ -1,0 +1,62 @@
+# Contract: Feed Setup Validation And Diagnostics
+
+## Validator
+
+```csharp
+internal sealed class NuplaneSetupOptionsValidator : IValidateOptions<NuplaneSetupOptions>
+```
+
+The existing validator remains the startup fail-fast validation surface. Keyed feed support may use a helper that validates `NuplaneFeedSetupDeclaration` instances, but validation policy must remain reachable through the options validation pipeline.
+
+## Raw Configuration Contract
+
+- `NuplaneSetupOptions` MUST remain data-only.
+- A DI-registered declaration source MUST read raw `IConfiguration` with `NuplaneFeedSetupDeclarationReader`.
+- `NuplaneSetupOptionsValidator` MUST consume that declaration source so keyed child names, mixed array/keyed declarations, and configuration paths are available during `ValidateOnStart()`.
+- Validation MUST NOT rely solely on `NuplaneSetupOptions.Feeds` list binding for keyed feed rules because non-numeric feed keys are not represented by array binding.
+
+## Validation Contract
+
+- Setup validation MUST reject array entries with missing or whitespace `Name`.
+- Setup validation MUST reject keyed entries whose inner `Name` is present and does not match the containing key.
+- Setup validation MUST reject duplicate keyed declarations for the same feed name if the effective configuration can expose them.
+- Setup validation MUST classify all-digit `Feeds` child keys as array entries before keyed-feed validation; there is no separate all-digit keyed-feed validation path.
+- Setup validation MUST reject entries with both `ServiceIndex` and `DirectoryPath`.
+- Setup validation MUST reject entries with neither `ServiceIndex` nor `DirectoryPath`.
+- Setup validation MUST reject remote feed `ServiceIndex` values that are not valid absolute URIs.
+- Setup validation MUST reject directory feed `DirectoryPath` values that are empty or whitespace.
+- Setup validation MUST preserve the existing rule that `Directory.DebounceWindow` must be greater than zero.
+- Setup validation MUST compare feed names case-insensitively.
+- Same-name mixed array/keyed declarations MUST be warning diagnostics, not validation failures.
+
+## Warning Diagnostic Contract
+
+When an array declaration and keyed declaration resolve to the same feed name:
+
+- The keyed declaration MUST be registered.
+- The array declaration MUST be ignored for that feed.
+- A warning MUST identify:
+  - the canonical feed name
+  - the keyed declaration path
+  - the ignored array declaration path or index
+- The warning MUST NOT contain credential secret values.
+
+## Registration Contract
+
+- Remote setup translation MUST register only effective remote declarations.
+- Directory setup translation MUST register only effective directory declarations.
+- A declaration with `DirectoryPath` MUST be ignored by the remote translator and handled by `Nuplane.Sources.Directory`.
+- A declaration with `ServiceIndex` MUST be ignored by the directory translator and handled by the remote translator.
+- The two translators MUST consume the same effective declaration rules to avoid duplicate or divergent registrations.
+
+## Test Contract
+
+- Validator fails on key/name mismatch.
+- Validator fails on both source types.
+- Validator fails on missing source type.
+- Validator fails on invalid remote URI.
+- Validator fails on blank directory path.
+- Validator preserves existing array duplicate behavior.
+- Mixed array/keyed same-name declarations produce a warning and one effective registration.
+- Layered configuration override by keyed feed path produces one effective registration with the later value.
+- Warning diagnostics redact credential values.

--- a/specs/027-keyed-feed-config/data-model.md
+++ b/specs/027-keyed-feed-config/data-model.md
@@ -1,0 +1,148 @@
+# Data Model: Key-Based Feed Setup Configuration
+
+**Feature**: 027-keyed-feed-config  
+**Date**: 2026-05-18
+
+## Entities
+
+### Setup Feed Section
+
+Represents the effective `Nuplane:Setup:Feeds` configuration section after all providers have been layered.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| Path | string | Configuration path, normally `Nuplane:Setup:Feeds` |
+| Children | IConfigurationSection[] | Direct child sections keyed by either numeric array index or feed name |
+
+**Validation rules**:
+- No validation is performed at this aggregate level beyond child classification.
+- All-digit child keys are interpreted as array entries.
+- Non-numeric child keys are interpreted as keyed entries.
+
+### Setup Feed Declaration
+
+Effective representation of one feed declaration, independent of whether it came from array or keyed configuration.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| Name | string | Canonical feed name used for registration |
+| SourceShape | enum | `Array` or `Keyed` |
+| ConfigurationPath | string | Original child configuration path for diagnostics |
+| ArrayIndex | int? | Numeric index when declared through the array shape |
+| Key | string? | Keyed feed name when declared through the keyed shape |
+| Options | NuplaneFeedSetupOptions | Existing property bag for feed setup values |
+| IgnoredArrayDeclarations | IReadOnlyList<SetupFeedDeclaration> | Array declarations ignored because a keyed declaration with the same name wins |
+
+**Validation rules**:
+- `Name` must be non-empty after shape-specific name resolution.
+- Keyed declarations derive `Name` from `Key`.
+- Keyed declarations with an inner `Name` must match `Key` using Nuplane feed-name comparison rules.
+- Array declarations use the existing inner `Name`.
+- All-digit keys cannot be keyed feed names.
+
+### Setup Feed Declaration Source
+
+DI-registered source that exposes raw effective setup feed declarations to validators and setup translators.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| ConfigurationPath | string | Root setup or feeds section path used to read declarations |
+| ReadResult | NuplaneFeedSetupReadResult | Effective declarations and diagnostics produced from raw configuration |
+
+**Validation rules**:
+- The source must read from raw `IConfiguration`, not from list-bound `NuplaneSetupOptions.Feeds`.
+- The source must preserve keyed child names and configuration paths for validation diagnostics.
+- Validators consume this source while remaining in the `IValidateOptions<T>` pipeline.
+
+### Remote Feed Declaration
+
+A setup feed declaration with `ServiceIndex` and no `DirectoryPath`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| Name | string | Canonical feed name |
+| ServiceIndex | string | Absolute NuGet service index URI |
+| Credentials | string? | Credential reference |
+| IncludeAll | bool | Whether all packages are included |
+| IncludePatterns | IReadOnlyList<string> | Include patterns copied from setup configuration |
+
+**Validation rules**:
+- `ServiceIndex` must be an absolute URI.
+- `DirectoryPath` must be absent or blank.
+- Credential values are references and must not be emitted as secret material in logs.
+
+### Directory Feed Declaration
+
+A setup feed declaration with `DirectoryPath` and no `ServiceIndex`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| Name | string | Canonical feed name |
+| DirectoryPath | string | Local directory path for `.nupkg` files |
+| IncludeAll | bool | Whether all packages are included |
+| IncludePatterns | IReadOnlyList<string> | Include patterns copied from setup configuration |
+| Watch | bool | Directory watcher setting |
+| DebounceWindow | TimeSpan | Directory watcher debounce window |
+
+**Validation rules**:
+- `DirectoryPath` must be non-empty.
+- `ServiceIndex` must be absent or blank.
+- `DebounceWindow` must be greater than zero, preserving current validation behavior.
+
+### Feed Setup Diagnostic
+
+Structured diagnostic emitted or returned when setup feed declarations are ambiguous or invalid.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| Severity | enum | `Warning` or `Error` |
+| Code | string | Stable diagnostic code for tests and logs |
+| Message | string | Human-readable diagnostic |
+| ConfigurationPath | string | Path to the relevant feed declaration |
+| FeedName | string? | Feed name when one can be resolved |
+
+**Diagnostic cases**:
+- Key/name mismatch: error.
+- Empty or whitespace feed name: error.
+- All-digit feed child key: array classification.
+- Both `ServiceIndex` and `DirectoryPath`: error.
+- Neither `ServiceIndex` nor `DirectoryPath`: error.
+- Invalid `ServiceIndex`: error.
+- Blank `DirectoryPath`: error.
+- Same-name array and keyed declarations: warning; keyed wins.
+
+## Relationships
+
+```text
+Nuplane:Setup:Feeds
+    |
+    v
+NuplaneFeedSetupDeclarationReader
+    |
+    v
+INuplaneSetupFeedDeclarationSource
+    |
+    +-- array child ("0") -> Setup Feed Declaration (SourceShape=Array, Name from inner Name)
+    |
+    +-- keyed child ("feedz.io") -> Setup Feed Declaration (SourceShape=Keyed, Name from key)
+    |
+    v
+Effective declarations keyed by feed name
+    |
+    +-- Remote declarations -> NuplaneFeedSetupConfiguration -> builder.AddFeed(...)
+    |
+    +-- Directory declarations -> NuplaneDirectoryFeedSetupConfiguration -> builder.AddDirectoryFeed(...)
+    |
+    v
+FeedResolutionOptions / desired sources / directory source registration
+```
+
+## State Transitions
+
+1. Raw configuration children are classified as array or keyed declarations.
+2. Shape-specific name rules produce a canonical feed name.
+3. Declarations are grouped case-insensitively by canonical feed name.
+4. If a group contains keyed declarations, the effective keyed declaration wins over array declarations.
+5. Ignored array declarations are recorded for warning diagnostics.
+6. Effective declarations are validated.
+7. Valid declarations are translated into the existing builder registration surfaces.

--- a/specs/027-keyed-feed-config/plan.md
+++ b/specs/027-keyed-feed-config/plan.md
@@ -1,0 +1,128 @@
+# Implementation Plan: Key-Based Feed Setup Configuration
+
+**Branch**: `027-keyed-feed-config` | **Date**: 2026-05-18 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/027-keyed-feed-config/spec.md`
+
+**Note**: This template is filled in by the `/speckit.plan` command. See `.specify/templates/plan-template.md` for the execution workflow.
+
+## Summary
+
+Nuplane setup configuration currently reads `Nuplane:Setup:Feeds` as an array, which is fragile under layered .NET configuration providers because feeds merge by numeric index. This feature adds a shared setup-feed reader that classifies numeric children as legacy array entries and non-numeric children as keyed feed declarations, derives keyed feed names from the configuration key, validates conflicts through the existing options validation pipeline with access to raw `IConfiguration` paths, and lets the remote-feed and directory-feed setup translators consume the same effective declaration set. Existing array configuration remains valid; same-name mixed array/keyed declarations register the keyed declaration and emit a warning.
+
+## Technical Context
+
+**Language/Version**: C# / .NET 8.0, 9.0, 10.0 source libraries; tests target .NET 10.0  
+**Primary Dependencies**: Microsoft.Extensions.Configuration, Microsoft.Extensions.DependencyInjection, Microsoft.Extensions.Options, Microsoft.Extensions.Logging; existing Nuplane builder and feed registration APIs  
+**Storage**: N/A for this feature; configuration is translated into runtime options and desired-state sources  
+**Testing**: xUnit, Microsoft.Extensions.Configuration in-memory providers, Microsoft.Extensions.Options validation, existing service registration assertions  
+**Target Platform**: Cross-platform .NET libraries consumed by host applications  
+**Project Type**: Library/runtime infrastructure  
+**Performance Goals**: Setup feed parsing is startup-time work over the effective feed section and should be linear in feed declaration count; no reconciliation-cycle overhead after registration  
+**Constraints**: Preserve array-based compatibility; do not rely on JSON object order; keep directory-specific registration in `Nuplane.Sources.Directory`; keep validation in `IValidateOptions<T>` and startup fail-fast paths; do not log credential secret values  
+**Scale/Scope**: Typically 0-20 configured feeds per host, with layered providers such as `appsettings.json`, environment variables, and mounted configuration files
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- **Deterministic reconciliation**: PASS - This is a startup configuration translation change. Effective feed declarations are de-duplicated deterministically by feed name, mixed array/keyed conflicts choose the keyed declaration, and candidate feed ordering remains governed by existing feed priority then feed name.
+- **Transactional store safety**: PASS - No store mutation behavior changes. Invalid feed setup fails during configuration validation/registration before reconciliation applies package changes, preserving existing LKG behavior.
+- **Source integrity**: PASS - Feed source validation remains explicit: each feed must specify exactly one source type, remote service indexes must be absolute URIs, directory paths must be non-blank, and credential values are treated as references without secret logging.
+- **Observability**: PASS - Mixed array/keyed same-name declarations emit a structured warning. Validation diagnostics include paths and identities for mismatches, duplicate/conflicting source types, invalid URIs, and invalid directory paths without credential secrets.
+- **Test discipline**: PASS - Plan includes unit/registration tests for keyed remote feeds, keyed directory feeds, array compatibility, key/name mismatch, numeric-key classification, layered overrides, mixed declarations, include patterns, directory options, and deterministic ordering.
+- **Decomposition discipline**: PASS - The shared feed setup reader, validation integration, remote translator, directory translator, tests, and docs are separate artifacts. Configuration properties already exist and continue to have concrete consumers.
+- **Options validation discipline**: PASS - Existing `NuplaneSetupOptionsValidator` and `ValidateOnStart()` remain the validation path. The options class stays data-only; a DI-registered raw setup feed declaration source gives validation access to keyed feed paths that standard list binding cannot preserve.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/027-keyed-feed-config/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   ├── feed-setup-reader-contract.md
+│   └── feed-setup-validation-contract.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+src/
+├── Nuplane/
+│   ├── Feeds/
+│   │   └── Setup/
+│   │       ├── NuplaneFeedSetupConfiguration.cs        # update: consume effective remote declarations
+│   │       ├── NuplaneFeedSetupDeclaration.cs          # new: effective feed declaration model
+│   │       ├── NuplaneFeedSetupDeclarationReader.cs    # new: classify array/keyed children and merge declarations
+│   │       └── NuplaneFeedSetupOptions.cs              # keep existing array entry shape
+│   ├── Observability/
+│   │   └── ReconciliationLogger.cs                     # extend or add source-generated warning for mixed setup declarations if reused here
+│   ├── Registration/
+│   │   ├── NuplaneOptionsRegistrationServices.cs       # bind non-feed setup options and feed declarations without losing keyed shape
+│   │   └── NuplaneSetupConfigurationServices.cs        # consume setup feed reader output
+│   └── Setup/
+│       ├── INuplaneSetupFeedDeclarationSource.cs       # new: exposes raw effective feed declarations to validators/translators
+│       ├── ConfigurationNuplaneSetupFeedDeclarationSource.cs # new: reads raw IConfiguration once through shared reader
+│       ├── NuplaneSetupOptions.cs                      # keep data-only; retain `Feeds` for legacy/bound effective declarations
+│       └── NuplaneSetupOptionsValidator.cs             # validate effective feed declarations and names
+├── Nuplane.Sources.Directory/
+│   └── Configuration/
+│       └── NuplaneDirectoryFeedSetupConfiguration.cs   # update: consume effective directory declarations
+└── Nuplane.Runtime/
+    └── Feeds/
+        └── Policy/
+            └── FeedResolutionPolicy.cs                 # no behavior change; ordering contract referenced by tests
+
+test/
+├── Nuplane.Runtime.Tests/
+│   └── Configuration/
+│       ├── ConfigurationDrivenRegistrationTests.cs      # extend: keyed remote, array compatibility, layered override, mixed declarations
+│       └── NuplaneSetupOptionsValidatorTests.cs         # extend: key/name mismatch and source-type validation
+└── Nuplane.Sources.Directory.Tests/
+    └── Configuration/
+        └── DirectoryFeedSetupConfigurationTests.cs      # new or extend: keyed directory feeds and directory options
+
+docs/
+├── wiki/                                               # update relevant setup/configuration pages when present
+└── posts/introducing-nuplane.md                        # update examples if still current
+
+README.md                                              # prefer keyed setup examples and migration note
+samples/Nuplane.Sample.AspNetCore/appsettings.json      # update sample config if it uses setup feeds
+```
+
+**Structure Decision**: Keep setup feed declaration parsing in the `Nuplane` package because both the core remote-feed translator and `Nuplane.Sources.Directory` already depend on `Nuplane.Feeds.Setup` types. Directory-backed registration remains in `Nuplane.Sources.Directory`, preserving module ownership. The shared reader returns effective declarations so both translators apply identical name, shape, and mixed-format rules.
+
+## Phase 0 Research Summary
+
+See [research.md](research.md). Key decisions:
+
+- Classify all-digit feed children as legacy array entries; non-numeric children are keyed feed entries.
+- Derive keyed feed names from the configuration key; optional inner `Name` must match.
+- For same-name mixed array/keyed declarations, keyed wins and the array declaration is ignored with a warning.
+- Continue using existing `FeedPriorities` for resolution order; do not add per-feed order metadata.
+- Preserve `NuplaneSetupOptions` as a data-only options type and implement keyed feed support through a shared reader plus a DI-registered raw declaration source consumed by validation and translators.
+
+## Phase 1 Design Summary
+
+See [data-model.md](data-model.md), [contracts/feed-setup-reader-contract.md](contracts/feed-setup-reader-contract.md), [contracts/feed-setup-validation-contract.md](contracts/feed-setup-validation-contract.md), and [quickstart.md](quickstart.md).
+
+## Post-Design Constitution Re-evaluation
+
+All gates remain PASS after Phase 1 design.
+
+- **Deterministic reconciliation**: Effective declarations are deterministic, de-duplicated by case-insensitive feed name, and resolution ordering remains priority-based.
+- **Transactional store safety**: The design only affects startup/configuration registration; invalid declarations fail before reconciliation runs.
+- **Source integrity**: Validation preserves exactly-one-source-type checks and absolute URI/directory path constraints.
+- **Observability**: Warning/error contracts define precise diagnostics without secret values.
+- **Test discipline**: Contracts and quickstart define targeted unit and boundary tests for the changed behavior.
+- **Decomposition discipline**: New artifacts map to one concern each: read/classify, validate, translate remote, translate directory, document.
+- **Options validation discipline**: Validation remains in `IValidateOptions<NuplaneSetupOptions>` with `ValidateOnStart()`, and raw keyed declaration context is supplied by DI rather than by adding validation methods to options classes.
+
+## Complexity Tracking
+
+No constitution violations to justify. All gates pass.

--- a/specs/027-keyed-feed-config/quickstart.md
+++ b/specs/027-keyed-feed-config/quickstart.md
@@ -1,0 +1,183 @@
+# Quickstart: Key-Based Feed Setup Configuration
+
+**Feature**: 027-keyed-feed-config  
+**Date**: 2026-05-18
+
+## Recommended Configuration Shape
+
+Use keyed feed setup under `Nuplane:Setup:Feeds`. The feed key is the canonical feed name.
+
+```json
+{
+  "Nuplane": {
+    "Setup": {
+      "AutomaticReconciliation": true,
+      "PollInterval": "00:01:00",
+      "Feeds": {
+        "local-packages": {
+          "DirectoryPath": "packages",
+          "IncludePatterns": ["*"],
+          "Directory": {
+            "Watch": true,
+            "DebounceWindow": "00:00:01"
+          }
+        },
+        "nuget.org": {
+          "ServiceIndex": "https://api.nuget.org/v3/index.json",
+          "IncludePatterns": ["MyCompany.Plugins.*"]
+        }
+      }
+    }
+  }
+}
+```
+
+## Migration Example
+
+Before:
+
+```json
+{
+  "Feeds": [
+    {
+      "Name": "feedz.io",
+      "ServiceIndex": "https://old.example/nuget/index.json"
+    }
+  ]
+}
+```
+
+After:
+
+```json
+{
+  "Feeds": {
+    "feedz.io": {
+      "ServiceIndex": "https://new.example/nuget/index.json"
+    }
+  }
+}
+```
+
+## Layered Override Scenario
+
+Base configuration:
+
+```json
+{
+  "Nuplane": {
+    "Setup": {
+      "Feeds": {
+        "feedz.io": {
+          "ServiceIndex": "https://old.example/nuget/index.json",
+          "IncludePatterns": ["Elsa.*"]
+        }
+      }
+    }
+  }
+}
+```
+
+Later provider:
+
+```json
+{
+  "Nuplane": {
+    "Setup": {
+      "Feeds": {
+        "feedz.io": {
+          "ServiceIndex": "https://new.example/nuget/index.json",
+          "IncludePatterns": ["Elsa.Persistence.*"]
+        }
+      }
+    }
+  }
+}
+```
+
+Expected result:
+
+- One feed named `feedz.io` is registered.
+- The effective `ServiceIndex` is `https://new.example/nuget/index.json`.
+- Include pattern behavior follows normal .NET configuration binding for the same keyed path.
+- No duplicate `feedz.io` feed is registered.
+
+## Mixed Legacy And Keyed Configuration
+
+If effective configuration contains both:
+
+```json
+{
+  "Feeds": [
+    {
+      "Name": "feedz.io",
+      "ServiceIndex": "https://old.example/nuget/index.json"
+    }
+  ]
+}
+```
+
+and:
+
+```json
+{
+  "Feeds": {
+    "feedz.io": {
+      "ServiceIndex": "https://new.example/nuget/index.json"
+    }
+  }
+}
+```
+
+Expected result:
+
+- The keyed declaration wins.
+- The array declaration is ignored for `feedz.io`.
+- Nuplane emits a warning diagnostic identifying the ignored array declaration.
+
+## Validation Examples
+
+Invalid key/name mismatch:
+
+```json
+{
+  "Feeds": {
+    "feedz.io": {
+      "Name": "other-feed",
+      "ServiceIndex": "https://example.test/v3/index.json"
+    }
+  }
+}
+```
+
+Expected result: startup validation fails with a message identifying both `feedz.io` and `other-feed`.
+
+Invalid source type conflict:
+
+```json
+{
+  "Feeds": {
+    "local-packages": {
+      "ServiceIndex": "https://example.test/v3/index.json",
+      "DirectoryPath": "packages"
+    }
+  }
+}
+```
+
+Expected result: startup validation fails because a feed must specify exactly one source type.
+
+## Verification Commands
+
+Run focused tests for configuration-driven registration and directory setup:
+
+```bash
+dotnet test test/Nuplane.Runtime.Tests/Nuplane.Runtime.Tests.csproj --filter "FullyQualifiedName~Configuration"
+dotnet test test/Nuplane.Sources.Directory.Tests/Nuplane.Sources.Directory.Tests.csproj
+```
+
+Run the full solution when practical:
+
+```bash
+dotnet test nuplane.sln
+```

--- a/specs/027-keyed-feed-config/research.md
+++ b/specs/027-keyed-feed-config/research.md
@@ -1,0 +1,59 @@
+# Research: Key-Based Feed Setup Configuration
+
+**Feature**: 027-keyed-feed-config  
+**Date**: 2026-05-18
+
+## R-001: Feed Section Shape Detection
+
+**Decision**: Classify each direct child of `Nuplane:Setup:Feeds` independently. All-digit child keys are legacy array entries. Non-numeric child keys are key-based feed entries.
+
+**Rationale**: .NET configuration arrays are represented as numeric child keys. Classifying each child independently supports effective configurations that contain both legacy array entries and keyed entries after providers are layered. Reserving all-digit keys for arrays avoids heuristics and makes shape detection deterministic.
+
+**Alternatives considered**:
+- Treat the entire `Feeds` section as either array or object based on the first child. This fails for mixed effective configuration.
+- Allow all-digit keyed feed names when the entry has no `Name`. This creates ambiguous parsing for valid array entries and makes tests depend on property presence.
+- Add a marker property to distinguish numeric keyed feeds. This adds schema complexity for a narrow edge case.
+
+## R-002: Canonical Feed Name For Keyed Entries
+
+**Decision**: For key-based entries, the configuration key is the canonical feed name. Inner `Name` is optional but must match the key when supplied.
+
+**Rationale**: The goal is layered override by feed identity. Letting an inner `Name` override the key would reintroduce ambiguity and make `Nuplane:Setup:Feeds:{feedName}` misleading. Allowing a matching inner `Name` supports gradual migration and copied legacy entries while still validating intent.
+
+**Alternatives considered**:
+- Let inner `Name` take precedence. Rejected because the path key would no longer be authoritative.
+- Ignore inner `Name` silently. Rejected because mismatches likely indicate a bad migration or wrong provider path.
+- Forbid inner `Name` in keyed entries. Rejected because it makes migration from array examples unnecessarily brittle.
+
+## R-003: Mixed Array/Keyed Same-Name Declarations
+
+**Decision**: If the effective configuration contains both an array entry and a keyed entry for the same feed name, register only the keyed entry and emit a warning diagnostic identifying the ignored array declaration.
+
+**Rationale**: Keyed declarations are the preferred migration target and compose better under layered providers. Choosing keyed-wins prevents duplicate registrations while allowing operators to add keyed overrides without immediately deleting old array configuration from every source. A warning keeps the configuration visible and actionable.
+
+**Alternatives considered**:
+- Fail startup. Safer but less migration-friendly and would make staged config rollout harder.
+- Keep both when source types differ. Rejected because a feed name is a logical identity, not a source-type tuple.
+- Last provider wins by enumeration order. Rejected because provider ordering is already reflected in the effective keyed path and should not be inferred from child enumeration order.
+
+## R-004: Feed Ordering And Priority
+
+**Decision**: Do not add ordering metadata to setup feed entries. Continue using existing `FeedResolutionOptions.FeedPriorities` for feed resolution order. Missing or equal priority values tie-break by feed name.
+
+**Rationale**: The codebase already has explicit feed priority configuration and `FeedResolutionPolicy` orders by priority then feed name. Reusing it avoids semantic dependence on JSON object order and keeps setup feed declarations focused on source configuration.
+
+**Alternatives considered**:
+- Add `Priority` to each setup feed entry. Rejected because it duplicates existing priority configuration and creates precedence questions.
+- Use JSON object order. Rejected because object order is not a reliable semantic contract across providers.
+- Sort only by key. Rejected because explicit priority already exists for cases where feed order matters.
+
+## R-005: Options Binding And Validation Topology
+
+**Decision**: Preserve `NuplaneSetupOptions` as a data-only options object and keep validation in `NuplaneSetupOptionsValidator`. Add a shared feed setup declaration reader for raw `IConfiguration` so keyed entries are not lost through list binding.
+
+**Rationale**: The existing options binder maps `Feeds` to `List<NuplaneFeedSetupOptions>`, which cannot represent non-numeric keyed entries correctly. A raw configuration reader can classify and merge array/keyed declarations before translators and validators consume effective declarations. Keeping validation in `IValidateOptions<T>` preserves the repository constitution and existing startup fail-fast model.
+
+**Alternatives considered**:
+- Replace `Feeds` with a dictionary on `NuplaneSetupOptions`. Rejected because it would break existing array binding and force more migration.
+- Maintain parallel `List` and `Dictionary` properties. Rejected because it increases drift risk and still relies on binder semantics.
+- Duplicate parsing in remote and directory translators. Rejected because mixed-format behavior and diagnostics must stay consistent.

--- a/specs/027-keyed-feed-config/spec.md
+++ b/specs/027-keyed-feed-config/spec.md
@@ -1,0 +1,179 @@
+# Feature Specification: Key-Based Feed Setup Configuration
+
+**Feature Branch**: `027-keyed-feed-config`  
+**Created**: 2026-05-18  
+**Status**: Draft  
+**Input**: User description: "Change Nuplane feed setup configuration from array-based feeds to key-based feeds, while preserving backwards compatibility with the current array format."
+
+## Problem
+
+Nuplane setup configuration currently declares feeds as an array under `Nuplane:Setup:Feeds`. This works when a host has one configuration file, but it behaves poorly with layered .NET configuration providers because array entries merge by numeric position rather than by logical feed identity. A later provider that intends to override `feedz.io` may instead override `Feeds:0`, partially merge into the wrong feed, or leave duplicate entries depending on provider order and array length.
+
+Nuplane feeds are logically named resources. Configuration should allow operators to address a feed by its name so mounted or later-loaded configuration can override the same feed deterministically.
+
+## Goals
+
+- Support a key-based `Nuplane:Setup:Feeds` object where each child key is the canonical feed name.
+- Preserve the existing array-based `Nuplane:Setup:Feeds` format for backwards compatibility.
+- Allow key-based remote feeds and directory-backed feeds to use the same feed properties supported today.
+- Make mixed, layered, or conflicting declarations deterministic and diagnosable.
+- Prefer key-based examples in user documentation because they compose predictably with layered .NET configuration.
+
+## Non-Goals
+
+- Removing support for the existing array-based feed setup format.
+- Changing feed source trust policy, package resolution policy, or credential secret-handling semantics.
+- Making JSON object declaration order semantically meaningful.
+- Changing duplicate feed-name behavior for purely array-based configuration unless necessary to prevent ambiguous mixed-format registration.
+- Replacing the existing feed priority model.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Configure Feeds By Name (Priority: P1)
+
+As a host operator, I want to declare setup feeds as a keyed object so each feed is configured by its logical name instead of by its array position.
+
+**Why this priority**: This is the core feature and fixes the configuration layering problem without requiring existing users to migrate immediately.
+
+**Independent Test**: Configure remote and directory feeds under `Nuplane:Setup:Feeds:{feedName}` with no inner `Name` property, start configuration-driven Nuplane registration, and verify each feed is registered with the key as its name and with all configured properties preserved.
+
+**Acceptance Scenarios**:
+
+1. **Given** a key-based remote feed named `nuget.org`, **When** Nuplane reads setup configuration, **Then** the registered feed name is `nuget.org` and the configured `ServiceIndex`, `IncludePatterns`, `IncludeAll`, and `Credentials` values are applied.
+2. **Given** a key-based directory feed named `local-packages`, **When** `Nuplane.Sources.Directory` reads setup configuration, **Then** the directory feed is registered with `local-packages` as its name and the configured `DirectoryPath`, include settings, and directory watcher options are applied.
+3. **Given** a key-based feed entry without a `Name` property, **When** configuration is read, **Then** the entry remains valid and the containing key is used as the feed name.
+
+---
+
+### User Story 2 - Preserve Existing Array Configuration (Priority: P2)
+
+As an existing Nuplane user, I want my current array-based feed setup configuration to keep working so upgrading Nuplane does not force an immediate configuration rewrite.
+
+**Why this priority**: Backwards compatibility is required for safe adoption and should be independently verifiable.
+
+**Independent Test**: Use the current `Nuplane:Setup:Feeds:0:Name` array shape with remote and directory feeds and verify the same registration results as before the feature.
+
+**Acceptance Scenarios**:
+
+1. **Given** existing array-based feed configuration, **When** Nuplane reads setup configuration, **Then** feed registration, include pattern handling, directory options, and credentials behave as they did before this feature.
+2. **Given** duplicate feed names in array-only configuration, **When** Nuplane reads setup configuration, **Then** duplicate handling follows the current behavior unless a separate documented validation rule already applies.
+
+---
+
+### User Story 3 - Override Feeds Through Layered Configuration (Priority: P3)
+
+As a platform maintainer, I want later configuration providers to override a same-named feed by key without creating duplicate feed registrations or relying on matching array indexes.
+
+**Why this priority**: Layered configuration is the motivating operational scenario for the new format.
+
+**Independent Test**: Build configuration from a base provider and a later provider where both define `Nuplane:Setup:Feeds:feedz.io`; verify the later provider's feed properties win according to normal .NET key precedence and exactly one `feedz.io` feed is registered.
+
+**Acceptance Scenarios**:
+
+1. **Given** a base configuration defines `Nuplane:Setup:Feeds:feedz.io:ServiceIndex` and a later configuration provider defines the same key with a different service index, **When** Nuplane reads setup configuration, **Then** only one `feedz.io` feed is registered and it uses the effective layered configuration value.
+2. **Given** one provider contributes include patterns and a later provider overrides the same keyed feed, **When** Nuplane reads setup configuration, **Then** include patterns follow standard .NET configuration binding for that keyed path and do not produce a second feed with the same name.
+
+---
+
+### User Story 4 - Diagnose Ambiguous Feed Names (Priority: P4)
+
+As an operator, I want clear diagnostics when feed names are ambiguous or conflicting so configuration mistakes fail predictably.
+
+**Why this priority**: Keyed configuration introduces a second declaration shape, so conflicts must not silently register unintended sources.
+
+**Independent Test**: Configure a keyed feed where the containing key and inner `Name` property disagree, then verify startup or configuration activation fails with a message identifying both names and the configuration path.
+
+**Acceptance Scenarios**:
+
+1. **Given** a keyed feed entry `Nuplane:Setup:Feeds:feedz.io` with `Name` set to `other-feed`, **When** Nuplane validates setup configuration, **Then** validation fails with a clear key/name mismatch error.
+2. **Given** effective configuration contains both an array-style and keyed-style declaration for the same feed name, **When** Nuplane translates setup configuration, **Then** keyed declaration wins deterministically for that feed name, no duplicate registration is created, and a warning diagnostic identifies the ignored array declaration.
+
+### Edge Cases
+
+- `Nuplane:Setup:Feeds` has no children.
+- A keyed feed key is empty, whitespace, or only present because a provider emitted an empty path segment.
+- A feed child key is all digits and must be interpreted as an array entry rather than a keyed feed name.
+- A keyed feed contains both `ServiceIndex` and `DirectoryPath`.
+- A keyed feed contains neither `ServiceIndex` nor `DirectoryPath`.
+- A keyed feed includes `Name` with different casing but the same logical name as the containing key.
+- A keyed feed uses `IncludeAll` and `IncludePatterns` together.
+- `IncludePatterns` has duplicate, blank, or layered array entries.
+- Directory-backed keyed feed options include `Directory:Watch` and `Directory:DebounceWindow`.
+- A mixed configuration contains one array feed named `feedz.io` and one keyed feed named `feedz.io`.
+- Feed names differ only by case across array and keyed declarations.
+- Feed resolution priorities are configured separately from setup feed declarations.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The setup feed configuration translator MUST support key-based feeds under `Nuplane:Setup:Feeds:{feedName}` in addition to the existing `Nuplane:Setup:Feeds:{index}` array form.
+- **FR-002**: For key-based feed entries, the containing configuration key MUST be the canonical feed name.
+- **FR-003**: For key-based feed entries, the `Name` property MUST be optional.
+- **FR-004**: If a key-based feed entry includes `Name`, setup validation MUST require it to match the containing key using Nuplane's feed-name comparison rules; mismatches MUST fail with a message that includes the containing key, the supplied `Name`, and the configuration path.
+- **FR-005**: Key-based feed entries MUST support the existing setup properties `ServiceIndex`, `DirectoryPath`, `IncludePatterns`, `IncludeAll`, `Credentials`, and `Directory`.
+- **FR-006**: Remote feed setup registration MUST translate key-based entries with `ServiceIndex` into the same feed registration outcome as equivalent array-based entries.
+- **FR-007**: Directory feed setup registration in `Nuplane.Sources.Directory` MUST translate key-based entries with `DirectoryPath` into the same directory source registration outcome as equivalent array-based entries.
+- **FR-008**: Setup translation MUST classify feed children as array entries when the child key is all digits and as keyed entries when the child key is non-numeric; all-digit feed names are not supported in the key-based format.
+- **FR-009**: Array-based feed entries MUST continue to require their existing `Name` value and preserve current array-only duplicate handling unless an existing validator already rejects the configuration.
+- **FR-010**: Key-based setup translation MUST NOT rely on JSON object order to define feed resolution behavior.
+- **FR-011**: Feed resolution order for both array-based and key-based setup feeds MUST continue to use existing feed priority configuration: lower configured priority values are considered first, and feeds with equal or missing priority are ordered deterministically by feed name.
+- **FR-012**: Documentation MUST describe how operators configure feed priority separately from keyed feed declarations when feed resolution order matters.
+- **FR-013**: When effective configuration contains both array-style and keyed-style declarations for the same feed name, setup translation MUST register a single feed where the keyed declaration takes precedence and MUST emit an actionable warning diagnostic about the ignored array declaration.
+- **FR-014**: Mixed array/keyed duplicate detection MUST compare feed names case-insensitively to match existing feed registration semantics.
+- **FR-015**: Validation MUST reject key-based feed entries with empty or whitespace feed keys; all-digit `Feeds` child keys MUST be classified as array entries before keyed-feed validation is applied.
+- **FR-016**: Validation MUST reject any feed entry that specifies both `ServiceIndex` and `DirectoryPath`.
+- **FR-017**: Validation MUST reject any feed entry that specifies neither `ServiceIndex` nor `DirectoryPath`.
+- **FR-018**: Validation MUST reject `ServiceIndex` values that are missing, relative, or not valid absolute URIs for remote feed entries.
+- **FR-019**: Validation MUST reject `DirectoryPath` values that are empty or whitespace for directory feed entries.
+- **FR-020**: `IncludePatterns` and `IncludeAll` behavior MUST remain unchanged for both configuration shapes, including current handling of blank, duplicate, and wildcard pattern values.
+- **FR-021**: Setup translation MUST expose useful diagnostics for skipped, overridden, ambiguous, or conflicting feed declarations without logging credential secret values.
+- **FR-022**: User documentation, README examples, and relevant wiki pages MUST prefer the key-based feed setup format and include a before/after migration example.
+
+### Operational & Safety Requirements *(mandatory)*
+
+- **OSR-001**: Reconciliation/apply flows MUST remain idempotent for repeated identical effective feed configuration, regardless of whether feeds were declared by array or by key.
+- **OSR-002**: Update flows MUST preserve existing transactional behavior and last-known-good fallback semantics; invalid feed setup configuration MUST fail before package source changes are applied under an unintended feed identity.
+- **OSR-003**: Source trust and credential validation requirements MUST remain unchanged; keyed feed support MUST NOT change allowed sources, integrity checks, credential lookup, or secret redaction behavior.
+- **OSR-004**: Observability MUST include structured diagnostics for key/name mismatches, mixed array/keyed duplicate resolution warnings, invalid source-type declarations, and feed registration identity, without logging credential secret values.
+- **OSR-005**: Tests MUST cover key-based remote feeds, key-based directory feeds, existing array feeds, missing `Name`, matching `Name`, mismatched `Name`, layered overrides, include pattern preservation, directory option preservation, deterministic priority-based ordering, and mixed array/keyed declarations.
+
+### Key Entities
+
+- **Setup Feed Declaration**: The effective configuration entry under `Nuplane:Setup:Feeds`, expressed either as a numeric array entry or a named keyed entry.
+- **Feed Name**: The canonical logical identity for a feed. In keyed entries it comes from the configuration key; in array entries it comes from the existing `Name` property.
+- **Remote Feed Declaration**: A setup feed declaration with `ServiceIndex`, optional `Credentials`, and include selection settings.
+- **Directory Feed Declaration**: A setup feed declaration with `DirectoryPath`, include selection settings, and directory watcher settings.
+- **Feed Priority**: Existing Nuplane feed resolution metadata that orders candidate feeds; it remains separate from setup feed declaration order.
+- **Feed Setup Diagnostic**: A validation or registration diagnostic that identifies ambiguous, overridden, or invalid feed setup configuration without exposing secrets.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A host can declare at least one remote feed using `Nuplane:Setup:Feeds:{feedName}` without an inner `Name` property and Nuplane registers it under `{feedName}`.
+- **SC-002**: A host can declare at least one directory feed using `Nuplane:Setup:Feeds:{feedName}` and `Nuplane.Sources.Directory` preserves directory watcher settings.
+- **SC-003**: Existing array-based feed setup examples continue to register feeds successfully without user changes.
+- **SC-004**: A later configuration provider can override `Nuplane:Setup:Feeds:feedz.io:ServiceIndex` and the effective registration contains exactly one `feedz.io` feed with the later value.
+- **SC-005**: A key/name mismatch fails validation with a diagnostic that identifies both names and the affected configuration path.
+- **SC-006**: Mixed array/keyed declarations for the same feed name produce exactly one registered feed and a warning diagnostic describing the keyed override and ignored array declaration.
+- **SC-007**: Candidate feed ordering remains deterministic and is verified by tests using existing feed priority configuration and name-based tie-breaking.
+- **SC-008**: Documentation includes key-based feed setup examples, a before/after migration example, and an explanation of why keyed configuration is preferred for layered .NET configuration.
+
+## Assumptions
+
+- Existing feed priority configuration is the correct mechanism for feed resolution order; keyed feed declarations do not introduce an `Order` or `Priority` property inside each feed entry.
+- Feed names are compared case-insensitively where Nuplane currently treats feed names case-insensitively.
+- The effective `IConfiguration` view may contain both numeric and non-numeric children under `Feeds`, so setup translation should classify entries by child key rather than by assuming the entire section has one shape.
+- All-digit child keys under `Nuplane:Setup:Feeds` are reserved for array entries and cannot be used as key-based feed names.
+- Keyed-feed validation requires access to raw `IConfiguration` feed child paths because standard list binding cannot preserve non-numeric keyed children or their configuration paths.
+- Keyed declarations take precedence over array declarations with the same feed name only when both shapes are present in the same effective configuration.
+- Array-only duplicate behavior remains unchanged to avoid adding an unrelated breaking change.
+
+## Clarifications
+
+- **2026-05-18**: Q: How should same-name mixed array/keyed feed declarations be handled? → A: Keyed declaration wins, array declaration is ignored for that feed, and Nuplane emits a warning diagnostic.
+- **2026-05-18**: Q: How should numeric-looking feed child keys be interpreted? → A: All-digit child keys are always array entries; keyed feed names must not be all digits.
+- **2026-05-18**: Feed resolution order for key-based setup uses existing feed priority configuration: lower priority first, then feed name for deterministic tie-breaking. JSON object order is not semantic.
+- **2026-05-18**: A `Name` property inside a keyed feed is allowed only when it matches the containing key; mismatch is a configuration error.
+- **2026-05-18**: If a mixed array/keyed effective configuration declares the same feed name in both shapes, the keyed declaration wins and Nuplane emits a warning diagnostic instead of registering duplicates.

--- a/specs/027-keyed-feed-config/tasks.md
+++ b/specs/027-keyed-feed-config/tasks.md
@@ -1,0 +1,251 @@
+# Tasks: Key-Based Feed Setup Configuration
+
+**Input**: Design documents from `/specs/027-keyed-feed-config/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/
+
+**Tests**: Test tasks are REQUIRED for changed behavior and boundaries. Include unit tests plus
+contract and/or integration tests as applicable.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Confirm target files and create the shared test locations without changing behavior.
+
+- [X] T001 Inspect existing configuration-driven feed tests and note reusable helpers in `test/Nuplane.Runtime.Tests/Configuration/ConfigurationDrivenRegistrationTests.cs`
+- [X] T002 [P] Inspect existing directory feed registration tests and decide whether to extend or create `test/Nuplane.Sources.Directory.Tests/Configuration/DirectoryFeedSetupConfigurationTests.cs`
+- [X] T003 [P] Inspect current feed setup translator and options validator in `src/Nuplane/Feeds/Setup/NuplaneFeedSetupConfiguration.cs` and `src/Nuplane/Setup/NuplaneSetupOptionsValidator.cs`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Shared declaration model and reader foundation that every user story consumes.
+
+**CRITICAL**: No user story implementation should start until these shared contracts exist.
+
+- [X] T004 Create `NuplaneFeedSetupSourceShape` enum in `src/Nuplane/Feeds/Setup/NuplaneFeedSetupSourceShape.cs`
+- [X] T005 Create `NuplaneFeedSetupDeclaration` data model in `src/Nuplane/Feeds/Setup/NuplaneFeedSetupDeclaration.cs`
+- [X] T006 Create `NuplaneFeedSetupDiagnostic` data model in `src/Nuplane/Feeds/Setup/NuplaneFeedSetupDiagnostic.cs`
+- [X] T007 Create `NuplaneFeedSetupReadResult` data model in `src/Nuplane/Feeds/Setup/NuplaneFeedSetupReadResult.cs`
+- [X] T008 Create `NuplaneFeedSetupDeclarationReader` shell with section normalization in `src/Nuplane/Feeds/Setup/NuplaneFeedSetupDeclarationReader.cs`
+- [X] T009 Create `INuplaneSetupFeedDeclarationSource` abstraction in `src/Nuplane/Setup/INuplaneSetupFeedDeclarationSource.cs`
+- [X] T010 Create `ConfigurationNuplaneSetupFeedDeclarationSource` shell in `src/Nuplane/Setup/ConfigurationNuplaneSetupFeedDeclarationSource.cs`
+- [X] T011 Add reader contract test skeleton for empty setup sections in `test/Nuplane.Runtime.Tests/Configuration/NuplaneFeedSetupDeclarationReaderTests.cs`
+
+**Checkpoint**: Shared types compile and user story tests can target one reader contract.
+
+---
+
+## Phase 3: User Story 1 - Configure Feeds By Name (Priority: P1) MVP
+
+**Goal**: Operators can declare keyed remote and directory feeds without an inner `Name`; the key becomes the feed name and existing feed properties are preserved.
+
+**Independent Test**: Configure `Nuplane:Setup:Feeds:{feedName}` entries for one remote feed and one directory feed, then verify service registration uses the key as the feed name and preserves `ServiceIndex`, `DirectoryPath`, include settings, credentials, and directory options.
+
+### Tests for User Story 1
+
+- [X] T012 [P] [US1] Add reader tests for keyed remote and keyed directory entries without `Name` in `test/Nuplane.Runtime.Tests/Configuration/NuplaneFeedSetupDeclarationReaderTests.cs`
+- [X] T013 [P] [US1] Add configuration-driven keyed remote feed registration test in `test/Nuplane.Runtime.Tests/Configuration/ConfigurationDrivenRegistrationTests.cs`
+- [X] T014 [P] [US1] Add keyed directory feed registration test preserving `Directory:Watch` and `Directory:DebounceWindow` in `test/Nuplane.Sources.Directory.Tests/Configuration/DirectoryFeedSetupConfigurationTests.cs`
+
+### Implementation for User Story 1
+
+- [X] T015 [US1] Implement keyed child classification, key-derived names, property binding, and deterministic output in `src/Nuplane/Feeds/Setup/NuplaneFeedSetupDeclarationReader.cs`
+- [X] T016 [US1] Implement raw configuration declaration source in `src/Nuplane/Setup/ConfigurationNuplaneSetupFeedDeclarationSource.cs`
+- [X] T017 [US1] Register raw setup feed declaration source for validators and translators in `src/Nuplane/Registration/NuplaneOptionsRegistrationServices.cs`
+- [X] T018 [US1] Update remote setup translation to consume effective keyed declarations from `INuplaneSetupFeedDeclarationSource` in `src/Nuplane/Feeds/Setup/NuplaneFeedSetupConfiguration.cs`
+- [X] T019 [US1] Update directory setup translation to consume effective keyed declarations from `INuplaneSetupFeedDeclarationSource` in `src/Nuplane.Sources.Directory/Configuration/NuplaneDirectoryFeedSetupConfiguration.cs`
+- [X] T020 [US1] Extend setup validation to accept keyed declarations without inner `Name` using raw declaration source in `src/Nuplane/Setup/NuplaneSetupOptionsValidator.cs`
+- [X] T021 [US1] Run focused US1 tests with `dotnet test test/Nuplane.Runtime.Tests/Nuplane.Runtime.Tests.csproj --filter "FullyQualifiedName~ConfigurationDrivenRegistrationTests|FullyQualifiedName~NuplaneFeedSetupDeclarationReaderTests"` and `dotnet test test/Nuplane.Sources.Directory.Tests/Nuplane.Sources.Directory.Tests.csproj --filter "FullyQualifiedName~DirectoryFeedSetupConfigurationTests"`
+
+**Checkpoint**: Keyed remote and directory feed configuration works without inner `Name`.
+
+---
+
+## Phase 4: User Story 2 - Preserve Existing Array Configuration (Priority: P2)
+
+**Goal**: Existing array-based feed setup continues to behave as it does today.
+
+**Independent Test**: Use `Nuplane:Setup:Feeds:0:Name` array-style configuration for remote and directory feeds and verify registration, include settings, credentials, and existing duplicate-name validation behavior are unchanged.
+
+### Tests for User Story 2
+
+- [X] T022 [P] [US2] Add reader tests proving all-digit child keys are array entries and use inner `Name` in `test/Nuplane.Runtime.Tests/Configuration/NuplaneFeedSetupDeclarationReaderTests.cs`
+- [X] T023 [P] [US2] Add array compatibility regression tests for remote feed registration in `test/Nuplane.Runtime.Tests/Configuration/ConfigurationDrivenRegistrationTests.cs`
+- [X] T024 [P] [US2] Add array compatibility regression tests for directory feed registration in `test/Nuplane.Sources.Directory.Tests/Configuration/DirectoryFeedSetupConfigurationTests.cs`
+- [X] T025 [P] [US2] Add duplicate array feed-name validation regression test in `test/Nuplane.Runtime.Tests/Configuration/NuplaneSetupOptionsValidatorTests.cs`
+
+### Implementation for User Story 2
+
+- [X] T026 [US2] Implement numeric child handling and array-name extraction in `src/Nuplane/Feeds/Setup/NuplaneFeedSetupDeclarationReader.cs`
+- [X] T027 [US2] Preserve array-only duplicate validation behavior in `src/Nuplane/Setup/NuplaneSetupOptionsValidator.cs`
+- [X] T028 [US2] Verify remote translator ignores directory array declarations and handles remote array declarations in `src/Nuplane/Feeds/Setup/NuplaneFeedSetupConfiguration.cs`
+- [X] T029 [US2] Verify directory translator ignores remote array declarations and handles directory array declarations in `src/Nuplane.Sources.Directory/Configuration/NuplaneDirectoryFeedSetupConfiguration.cs`
+- [X] T030 [US2] Run focused US2 tests with `dotnet test test/Nuplane.Runtime.Tests/Nuplane.Runtime.Tests.csproj --filter "FullyQualifiedName~ConfigurationDrivenRegistrationTests|FullyQualifiedName~NuplaneSetupOptionsValidatorTests|FullyQualifiedName~NuplaneFeedSetupDeclarationReaderTests"` and `dotnet test test/Nuplane.Sources.Directory.Tests/Nuplane.Sources.Directory.Tests.csproj --filter "FullyQualifiedName~DirectoryFeedSetupConfigurationTests"`
+
+**Checkpoint**: Legacy array configuration remains functional.
+
+---
+
+## Phase 5: User Story 3 - Override Feeds Through Layered Configuration (Priority: P3)
+
+**Goal**: Later configuration providers can override a same-named keyed feed without creating duplicate registrations.
+
+**Independent Test**: Build configuration from multiple providers that define `Nuplane:Setup:Feeds:feedz.io`, verify the later provider's effective values are used, and verify exactly one feed named `feedz.io` is registered.
+
+### Tests for User Story 3
+
+- [X] T031 [P] [US3] Add layered keyed override reader tests for `ServiceIndex` and `IncludePatterns` in `test/Nuplane.Runtime.Tests/Configuration/NuplaneFeedSetupDeclarationReaderTests.cs`
+- [X] T032 [P] [US3] Add layered keyed remote registration test verifying one `feedz.io` feed with the later `ServiceIndex` in `test/Nuplane.Runtime.Tests/Configuration/ConfigurationDrivenRegistrationTests.cs`
+- [X] T033 [P] [US3] Add keyed feed priority ordering regression test using existing `FeedResolutionPolicy` in `test/Nuplane.Runtime.Tests/Reconciliation/MultiFeedResolutionPolicyTests.cs`
+
+### Implementation for User Story 3
+
+- [X] T034 [US3] Implement case-insensitive effective declaration grouping by feed name in `src/Nuplane/Feeds/Setup/NuplaneFeedSetupDeclarationReader.cs`
+- [X] T035 [US3] Preserve standard provider precedence for keyed feed property values in `src/Nuplane/Feeds/Setup/NuplaneFeedSetupDeclarationReader.cs`
+- [X] T036 [US3] Ensure remote feed registration replaces or avoids duplicate same-name registrations from effective declarations in `src/Nuplane/Feeds/Registration/NuplaneFeedRegistrationServices.cs`
+- [X] T037 [US3] Ensure directory feed registration replaces or avoids duplicate same-name registrations from effective declarations in `src/Nuplane.Sources.Directory/Registration/DirectorySourceRegistrationServices.cs`
+- [X] T038 [US3] Run focused US3 tests with `dotnet test test/Nuplane.Runtime.Tests/Nuplane.Runtime.Tests.csproj --filter "FullyQualifiedName~ConfigurationDrivenRegistrationTests|FullyQualifiedName~NuplaneFeedSetupDeclarationReaderTests|FullyQualifiedName~MultiFeedResolutionPolicyTests"`
+
+**Checkpoint**: Layered keyed configuration overrides by feed name without duplicate registrations.
+
+---
+
+## Phase 6: User Story 4 - Diagnose Ambiguous Feed Names (Priority: P4)
+
+**Goal**: Ambiguous or conflicting feed names fail or warn deterministically with useful diagnostics.
+
+**Independent Test**: Configure a keyed feed with mismatched inner `Name` and verify startup validation fails with both names and the configuration path; configure same-name array/keyed declarations and verify keyed wins with a warning diagnostic and no duplicate registration.
+
+### Tests for User Story 4
+
+- [X] T039 [P] [US4] Add key/name mismatch validation test in `test/Nuplane.Runtime.Tests/Configuration/NuplaneSetupOptionsValidatorTests.cs`
+- [X] T040 [P] [US4] Add both-source-types and missing-source-type keyed validation tests in `test/Nuplane.Runtime.Tests/Configuration/NuplaneSetupOptionsValidatorTests.cs`
+- [X] T041 [P] [US4] Add invalid `ServiceIndex` and blank `DirectoryPath` validation tests in `test/Nuplane.Runtime.Tests/Configuration/NuplaneSetupOptionsValidatorTests.cs`
+- [X] T042 [P] [US4] Add mixed array/keyed same-name reader and registration tests in `test/Nuplane.Runtime.Tests/Configuration/NuplaneFeedSetupDeclarationReaderTests.cs`
+- [X] T043 [P] [US4] Add warning diagnostic capture test for ignored mixed array declaration in `test/Nuplane.Runtime.Tests/Configuration/ConfigurationDrivenRegistrationTests.cs`
+
+### Implementation for User Story 4
+
+- [X] T044 [US4] Implement key/name mismatch and source-type diagnostic creation in `src/Nuplane/Feeds/Setup/NuplaneFeedSetupDeclarationReader.cs`
+- [X] T045 [US4] Wire declaration diagnostics from raw declaration source into `IValidateOptions<NuplaneSetupOptions>` failure messages in `src/Nuplane/Setup/NuplaneSetupOptionsValidator.cs`
+- [X] T046 [US4] Add source-generated warning log method for ignored mixed array feed declarations in `src/Nuplane/Setup/NuplaneSetupFeedDiagnosticReporter.cs`
+- [X] T047 [US4] Emit warning diagnostics from setup options materialization without credential values in `src/Nuplane/Setup/NuplaneSetupFeedDiagnosticReporter.cs`
+- [X] T048 [US4] Verify remote and directory setup translators consume the same effective declarations without duplicating warnings in `src/Nuplane/Feeds/Setup/NuplaneFeedSetupConfiguration.cs` and `src/Nuplane.Sources.Directory/Configuration/NuplaneDirectoryFeedSetupConfiguration.cs`
+- [X] T049 [US4] Run focused US4 tests with `dotnet test test/Nuplane.Runtime.Tests/Nuplane.Runtime.Tests.csproj --filter "FullyQualifiedName~NuplaneSetupOptionsValidatorTests|FullyQualifiedName~NuplaneFeedSetupDeclarationReaderTests|FullyQualifiedName~ConfigurationDrivenRegistrationTests"`
+
+**Checkpoint**: Ambiguous feed configuration produces deterministic validation errors or warning diagnostics.
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+**Purpose**: Documentation, samples, cleanup, and full validation.
+
+- [X] T050 [P] Update keyed feed setup examples and migration guidance in `README.md`
+- [X] T051 [P] Update configuration examples in `docs/posts/introducing-nuplane.md`
+- [X] T052 [P] Update relevant wiki documentation under `docs/wiki/`
+- [X] T053 [P] Update sample keyed feed configuration in `samples/Nuplane.Sample.AspNetCore/appsettings.json`
+- [X] T054 Review feed setup reader, validators, and translators for duplicated parsing logic and extract only necessary local helpers in `src/Nuplane/Feeds/Setup/NuplaneFeedSetupDeclarationReader.cs`
+- [X] T055 Run quickstart validation commands from `specs/027-keyed-feed-config/quickstart.md`
+- [X] T056 Run full solution tests with `dotnet test nuplane.sln`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies.
+- **Foundational (Phase 2)**: Depends on Setup; blocks all user stories.
+- **User Story 1 (Phase 3)**: Depends on Foundational; MVP.
+- **User Story 2 (Phase 4)**: Depends on Foundational; can run after or alongside US1 once shared reader shape exists.
+- **User Story 3 (Phase 5)**: Depends on Foundational; easiest after US1 because it builds on keyed declarations.
+- **User Story 4 (Phase 6)**: Depends on Foundational; can run after US1/US2 test surfaces exist.
+- **Polish (Phase 7)**: Depends on completed target stories.
+
+### User Story Dependencies
+
+- **US1 Configure Feeds By Name**: No dependency on other stories after Foundation.
+- **US2 Preserve Existing Array Configuration**: No dependency on other stories after Foundation, but shares reader files with US1.
+- **US3 Override Feeds Through Layered Configuration**: Depends on keyed feed reading from US1 for simplest delivery.
+- **US4 Diagnose Ambiguous Feed Names**: Depends on shared diagnostic model from Foundation and benefits from reader coverage from US1/US2.
+
+### Within Each User Story
+
+- Write/extend tests before implementation.
+- Reader behavior before translator behavior.
+- Translator behavior before service registration assertions.
+- Validation diagnostics before startup failure assertions.
+- Story complete before moving to the next priority unless work is explicitly parallelized across disjoint files.
+
+---
+
+## Parallel Opportunities
+
+- T001-T003 can be done independently as inspection tasks.
+- T004-T007 and T009-T010 create separate model/source files and can run in parallel.
+- T012-T014 can be written in parallel across runtime and directory test projects.
+- T022-T025 can be written in parallel across reader, registration, directory, and validator tests.
+- T031-T033 can be written in parallel because they target separate test files.
+- T039-T043 can be written in parallel across validator, reader, and registration diagnostic tests.
+- T050-T053 can be done in parallel across documentation and sample files.
+
+## Parallel Example: User Story 1
+
+```bash
+# Tests can be drafted together because they touch different files/projects:
+Task: "T012 [US1] Add reader tests for keyed remote and keyed directory entries without Name in test/Nuplane.Runtime.Tests/Configuration/NuplaneFeedSetupDeclarationReaderTests.cs"
+Task: "T013 [US1] Add configuration-driven keyed remote feed registration test in test/Nuplane.Runtime.Tests/Configuration/ConfigurationDrivenRegistrationTests.cs"
+Task: "T014 [US1] Add keyed directory feed registration test preserving Directory options in test/Nuplane.Sources.Directory.Tests/Configuration/DirectoryFeedSetupConfigurationTests.cs"
+```
+
+## Parallel Example: User Story 4
+
+```bash
+# Diagnostics tests can be split by boundary:
+Task: "T039 [US4] Add key/name mismatch validation test in test/Nuplane.Runtime.Tests/Configuration/NuplaneSetupOptionsValidatorTests.cs"
+Task: "T042 [US4] Add mixed array/keyed same-name reader and registration tests in test/Nuplane.Runtime.Tests/Configuration/NuplaneFeedSetupDeclarationReaderTests.cs"
+Task: "T043 [US4] Add warning diagnostic capture test in test/Nuplane.Runtime.Tests/Configuration/ConfigurationDrivenRegistrationTests.cs"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1 and Phase 2.
+2. Complete Phase 3 tests and implementation.
+3. Validate keyed remote and directory feeds without inner `Name`.
+4. Stop and review before expanding compatibility and diagnostics.
+
+### Incremental Delivery
+
+1. Foundation reader/model.
+2. US1 keyed configuration support.
+3. US2 legacy array compatibility regression.
+4. US3 layered override behavior.
+5. US4 diagnostics and warning behavior.
+6. Documentation, samples, and full validation.
+
+### Risk Notes
+
+- `NuplaneFeedSetupDeclarationReader.cs` is shared by all stories; coordinate edits carefully if stories run in parallel.
+- `NuplaneSetupOptionsValidator.cs` is touched by US1, US2, and US4; avoid overlapping edits without merging between phases.
+- Remote and directory translators must consume the same reader output to avoid divergent registrations.
+
+## Notes
+
+- [P] tasks = different files, no dependency on an incomplete task.
+- [Story] label maps each task to a user story for traceability.
+- Every implementation task includes an exact file path.
+- Tests should fail before implementation for changed behavior.
+- Options classes remain data-only; validation stays in `IValidateOptions<T>` with existing `ValidateOnStart()` registration.

--- a/src/Nuplane.Sources.Directory/Configuration/NuplaneDirectoryFeedSetupConfiguration.cs
+++ b/src/Nuplane.Sources.Directory/Configuration/NuplaneDirectoryFeedSetupConfiguration.cs
@@ -1,7 +1,6 @@
 using Microsoft.Extensions.Configuration;
 using Nuplane.Builder;
 using Nuplane.Feeds.Setup;
-using Nuplane.Setup;
 using Nuplane.Sources.Directory.Builder;
 
 namespace Nuplane.Sources.Directory.Configuration;
@@ -28,39 +27,30 @@ public static class NuplaneDirectoryFeedSetupConfiguration
 
         var setupSection = GetSetupSectionOrSelf(configuration);
 
-        foreach (var feedSection in setupSection.GetSection(nameof(NuplaneSetupOptions.Feeds)).GetChildren())
+        foreach (var declaration in NuplaneFeedSetupDeclarationReader.Read(setupSection).Declarations)
         {
-            var directoryPath = feedSection[nameof(NuplaneFeedSetupOptions.DirectoryPath)];
+            var feedOptions = declaration.Options;
+            var directoryPath = feedOptions.DirectoryPath;
             if (string.IsNullOrWhiteSpace(directoryPath))
             {
                 continue;
             }
 
-            var feedName = feedSection[nameof(NuplaneFeedSetupOptions.Name)];
-            if (string.IsNullOrWhiteSpace(feedName))
-            {
-                continue;
-            }
-
-            var directorySection = feedSection.GetSection(nameof(NuplaneFeedSetupOptions.Directory));
+            var feedName = declaration.Name;
 
             builder.AddDirectoryFeed(feedName, directoryPath, feed =>
             {
-                feed.Watch = directorySection.GetValue<bool?>(nameof(NuplaneDirectoryFeedSetupOptions.Watch)) ?? true;
-                feed.DebounceWindow = directorySection.GetValue<TimeSpan?>(nameof(NuplaneDirectoryFeedSetupOptions.DebounceWindow))
-                    ?? TimeSpan.FromSeconds(1);
+                feed.Watch = feedOptions.Directory.Watch;
+                feed.DebounceWindow = feedOptions.Directory.DebounceWindow;
 
-                if (feedSection.GetValue<bool?>(nameof(NuplaneFeedSetupOptions.IncludeAll)) is true)
+                if (feedOptions.IncludeAll)
                 {
                     feed.IncludeAll();
                 }
                 else
                 {
-                    foreach (var pattern in feedSection
-                                 .GetSection(nameof(NuplaneFeedSetupOptions.IncludePatterns))
-                                 .GetChildren()
-                                 .Select(static child => child.Value ?? string.Empty)
-                                 .Where(static v => !string.IsNullOrWhiteSpace(v)))
+                    foreach (var pattern in feedOptions.IncludePatterns
+                                 .Where(static value => !string.IsNullOrWhiteSpace(value)))
                     {
                         feed.Include(pattern);
                     }

--- a/src/Nuplane/Feeds/Setup/NuplaneFeedSetupConfiguration.cs
+++ b/src/Nuplane/Feeds/Setup/NuplaneFeedSetupConfiguration.cs
@@ -1,6 +1,5 @@
 using Microsoft.Extensions.Configuration;
 using Nuplane.Builder;
-using Nuplane.Setup;
 
 namespace Nuplane.Feeds.Setup;
 
@@ -8,31 +7,31 @@ internal static class NuplaneFeedSetupConfiguration
 {
     internal static void ApplyConfiguredFeeds(NuplaneBuilder builder, IConfiguration configuration)
     {
-        foreach (var feedSection in configuration.GetSection(nameof(NuplaneSetupOptions.Feeds)).GetChildren())
+        foreach (var declaration in NuplaneFeedSetupDeclarationReader.Read(configuration).Declarations)
         {
             // Directory-backed feeds are handled by Nuplane.Sources.Directory.Hosting
-            var directoryPath = feedSection[nameof(NuplaneFeedSetupOptions.DirectoryPath)];
-            if (!string.IsNullOrWhiteSpace(directoryPath))
+            var feed = declaration.Options;
+            if (!string.IsNullOrWhiteSpace(feed.DirectoryPath))
             {
                 continue;
             }
 
-            builder.AddFeed(feedSection[nameof(NuplaneFeedSetupOptions.Name)]!, configuredFeed =>
+            if (!Uri.TryCreate(feed.ServiceIndex, UriKind.Absolute, out var serviceIndex))
             {
-                var credentials = feedSection[nameof(NuplaneFeedSetupOptions.Credentials)];
-                configuredFeed.FromUri(new(feedSection[nameof(NuplaneFeedSetupOptions.ServiceIndex)]!, UriKind.Absolute), credentials);
+                continue;
+            }
 
-                if (feedSection.GetValue<bool?>(nameof(NuplaneFeedSetupOptions.IncludeAll)) is true)
+            builder.AddFeed(declaration.Name, configuredFeed =>
+            {
+                configuredFeed.FromUri(serviceIndex, feed.Credentials);
+
+                if (feed.IncludeAll)
                 {
                     configuredFeed.IncludeAll();
                 }
                 else
                 {
-                    foreach (var pattern in DistinctNonBlank(
-                                 feedSection
-                                     .GetSection(nameof(NuplaneFeedSetupOptions.IncludePatterns))
-                                     .GetChildren()
-                                     .Select(static child => child.Value ?? string.Empty)))
+                    foreach (var pattern in DistinctNonBlank(feed.IncludePatterns))
                     {
                         configuredFeed.Include(pattern);
                     }
@@ -46,4 +45,3 @@ internal static class NuplaneFeedSetupConfiguration
         .Where(static value => !string.IsNullOrWhiteSpace(value))
         .Distinct(StringComparer.OrdinalIgnoreCase);
 }
-

--- a/src/Nuplane/Feeds/Setup/NuplaneFeedSetupDeclaration.cs
+++ b/src/Nuplane/Feeds/Setup/NuplaneFeedSetupDeclaration.cs
@@ -1,0 +1,20 @@
+namespace Nuplane.Feeds.Setup;
+
+/// <summary>
+/// Represents one effective setup feed declaration after configuration shape classification.
+/// </summary>
+/// <param name="Name">The canonical feed name used for registration.</param>
+/// <param name="SourceShape">The configuration shape used to declare the feed.</param>
+/// <param name="ConfigurationPath">The configuration path for diagnostics.</param>
+/// <param name="ArrayIndex">The numeric array index when the declaration came from an array entry.</param>
+/// <param name="Key">The keyed feed name when the declaration came from a keyed entry.</param>
+/// <param name="Options">The feed setup options bound from the declaration.</param>
+/// <param name="IgnoredArrayDeclarations">Array declarations ignored because a keyed declaration with the same name wins.</param>
+public sealed record NuplaneFeedSetupDeclaration(
+    string Name,
+    NuplaneFeedSetupSourceShape SourceShape,
+    string ConfigurationPath,
+    int? ArrayIndex,
+    string? Key,
+    NuplaneFeedSetupOptions Options,
+    IReadOnlyList<NuplaneFeedSetupDeclaration> IgnoredArrayDeclarations);

--- a/src/Nuplane/Feeds/Setup/NuplaneFeedSetupDeclarationReader.cs
+++ b/src/Nuplane/Feeds/Setup/NuplaneFeedSetupDeclarationReader.cs
@@ -1,0 +1,166 @@
+using Microsoft.Extensions.Configuration;
+using Nuplane.Setup;
+
+namespace Nuplane.Feeds.Setup;
+
+/// <summary>
+/// Reads setup feed declarations from raw configuration while preserving array and keyed shapes.
+/// </summary>
+public static class NuplaneFeedSetupDeclarationReader
+{
+    private const string MixedShapeOverrideCode = "NuplaneSetupFeedMixedShapeOverride";
+    private const string KeyNameMismatchCode = "NuplaneSetupFeedKeyNameMismatch";
+    private const string DuplicateKeyedFeedCode = "NuplaneSetupFeedDuplicateKeyed";
+
+    /// <summary>
+    /// Reads setup feed declarations from a <c>Nuplane</c>, <c>Setup</c>, or <c>Feeds</c> section.
+    /// </summary>
+    /// <param name="configuration">The configuration section to read.</param>
+    /// <returns>The effective feed declarations and diagnostics.</returns>
+    public static NuplaneFeedSetupReadResult Read(IConfiguration configuration)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        var feedsSection = GetFeedsSection(configuration);
+        var rawDeclarations = new List<NuplaneFeedSetupDeclaration>();
+        var diagnostics = new List<NuplaneFeedSetupDiagnostic>();
+
+        foreach (var feedSection in feedsSection.GetChildren())
+        {
+            var isArrayEntry = IsAllDigits(feedSection.Key);
+            var options = new NuplaneFeedSetupOptions();
+            feedSection.Bind(options);
+
+            var declaration = isArrayEntry
+                ? CreateArrayDeclaration(feedSection, options)
+                : CreateKeyedDeclaration(feedSection, options, diagnostics);
+
+            rawDeclarations.Add(declaration);
+        }
+
+        var effectiveDeclarations = SelectEffectiveDeclarations(rawDeclarations, diagnostics);
+
+        return new(effectiveDeclarations, diagnostics);
+    }
+
+    private static IConfigurationSection GetFeedsSection(IConfiguration configuration)
+    {
+        if (configuration is IConfigurationSection section)
+        {
+            if (string.Equals(section.Key, nameof(NuplaneSetupOptions.Feeds), StringComparison.OrdinalIgnoreCase))
+            {
+                return section;
+            }
+
+            if (string.Equals(section.Key, "Setup", StringComparison.OrdinalIgnoreCase))
+            {
+                return section.GetSection(nameof(NuplaneSetupOptions.Feeds));
+            }
+        }
+
+        var setupSection = configuration.GetSection("Setup");
+        return setupSection.Exists()
+            ? setupSection.GetSection(nameof(NuplaneSetupOptions.Feeds))
+            : configuration.GetSection(nameof(NuplaneSetupOptions.Feeds));
+    }
+
+    private static NuplaneFeedSetupDeclaration CreateArrayDeclaration(
+        IConfigurationSection feedSection,
+        NuplaneFeedSetupOptions options)
+    {
+        _ = int.TryParse(feedSection.Key, out var index);
+        return new(
+            options.Name,
+            NuplaneFeedSetupSourceShape.Array,
+            feedSection.Path,
+            index,
+            null,
+            options,
+            []);
+    }
+
+    private static NuplaneFeedSetupDeclaration CreateKeyedDeclaration(
+        IConfigurationSection feedSection,
+        NuplaneFeedSetupOptions options,
+        List<NuplaneFeedSetupDiagnostic> diagnostics)
+    {
+        if (!string.IsNullOrWhiteSpace(options.Name)
+            && !string.Equals(options.Name, feedSection.Key, StringComparison.OrdinalIgnoreCase))
+        {
+            diagnostics.Add(new(
+                NuplaneFeedSetupDiagnosticSeverity.Error,
+                KeyNameMismatchCode,
+                $"Nuplane setup keyed feed '{feedSection.Key}' has Name '{options.Name}', but keyed feed Name must match the containing key.",
+                feedSection.Path,
+                feedSection.Key));
+        }
+
+        options.Name = feedSection.Key;
+        return new(
+            feedSection.Key,
+            NuplaneFeedSetupSourceShape.Keyed,
+            feedSection.Path,
+            null,
+            feedSection.Key,
+            options,
+            []);
+    }
+
+    private static IReadOnlyList<NuplaneFeedSetupDeclaration> SelectEffectiveDeclarations(
+        IReadOnlyList<NuplaneFeedSetupDeclaration> declarations,
+        List<NuplaneFeedSetupDiagnostic> diagnostics)
+    {
+        var effective = new List<NuplaneFeedSetupDeclaration>();
+
+        foreach (var group in declarations
+                     .GroupBy(static declaration => declaration.Name, StringComparer.OrdinalIgnoreCase)
+                     .OrderBy(static group => group.Key, StringComparer.OrdinalIgnoreCase))
+        {
+            var keyed = group
+                .Where(static declaration => declaration.SourceShape == NuplaneFeedSetupSourceShape.Keyed)
+                .OrderBy(static declaration => declaration.ConfigurationPath, StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+            var array = group
+                .Where(static declaration => declaration.SourceShape == NuplaneFeedSetupSourceShape.Array)
+                .OrderBy(static declaration => declaration.ArrayIndex)
+                .ToArray();
+
+            if (keyed.Length > 1)
+            {
+                foreach (var duplicate in keyed.Skip(1))
+                {
+                    diagnostics.Add(new(
+                        NuplaneFeedSetupDiagnosticSeverity.Error,
+                        DuplicateKeyedFeedCode,
+                        $"Nuplane setup contains duplicate keyed feed declaration for '{duplicate.Name}'.",
+                        duplicate.ConfigurationPath,
+                        duplicate.Name));
+                }
+            }
+
+            if (keyed.Length > 0)
+            {
+                var selected = keyed[0];
+                foreach (var ignored in array)
+                {
+                    diagnostics.Add(new(
+                        NuplaneFeedSetupDiagnosticSeverity.Warning,
+                        MixedShapeOverrideCode,
+                        $"Nuplane setup feed '{selected.Name}' is declared by key at '{selected.ConfigurationPath}', so array declaration at '{ignored.ConfigurationPath}' is ignored.",
+                        ignored.ConfigurationPath,
+                        selected.Name));
+                }
+
+                effective.Add(selected with { IgnoredArrayDeclarations = array });
+                continue;
+            }
+
+            effective.AddRange(array);
+        }
+
+        return effective;
+    }
+
+    private static bool IsAllDigits(string value) =>
+        value.Length > 0 && value.All(static ch => ch is >= '0' and <= '9');
+}

--- a/src/Nuplane/Feeds/Setup/NuplaneFeedSetupDeclarationReader.cs
+++ b/src/Nuplane/Feeds/Setup/NuplaneFeedSetupDeclarationReader.cs
@@ -113,8 +113,7 @@ public static class NuplaneFeedSetupDeclarationReader
         var effective = new List<NuplaneFeedSetupDeclaration>();
 
         foreach (var group in declarations
-                     .GroupBy(static declaration => declaration.Name, StringComparer.OrdinalIgnoreCase)
-                     .OrderBy(static group => group.Key, StringComparer.OrdinalIgnoreCase))
+                     .GroupBy(static declaration => declaration.Name, StringComparer.OrdinalIgnoreCase))
         {
             var keyed = group
                 .Where(static declaration => declaration.SourceShape == NuplaneFeedSetupSourceShape.Keyed)

--- a/src/Nuplane/Feeds/Setup/NuplaneFeedSetupDiagnostic.cs
+++ b/src/Nuplane/Feeds/Setup/NuplaneFeedSetupDiagnostic.cs
@@ -1,0 +1,16 @@
+namespace Nuplane.Feeds.Setup;
+
+/// <summary>
+/// Describes a setup feed configuration warning or error.
+/// </summary>
+/// <param name="Severity">The diagnostic severity.</param>
+/// <param name="Code">The stable diagnostic code.</param>
+/// <param name="Message">The human-readable diagnostic message.</param>
+/// <param name="ConfigurationPath">The configuration path associated with the diagnostic.</param>
+/// <param name="FeedName">The feed name associated with the diagnostic, when available.</param>
+public sealed record NuplaneFeedSetupDiagnostic(
+    NuplaneFeedSetupDiagnosticSeverity Severity,
+    string Code,
+    string Message,
+    string ConfigurationPath,
+    string? FeedName);

--- a/src/Nuplane/Feeds/Setup/NuplaneFeedSetupDiagnosticSeverity.cs
+++ b/src/Nuplane/Feeds/Setup/NuplaneFeedSetupDiagnosticSeverity.cs
@@ -1,0 +1,17 @@
+namespace Nuplane.Feeds.Setup;
+
+/// <summary>
+/// Identifies the severity of a setup feed diagnostic.
+/// </summary>
+public enum NuplaneFeedSetupDiagnosticSeverity
+{
+    /// <summary>
+    /// The diagnostic describes a non-fatal configuration condition.
+    /// </summary>
+    Warning,
+
+    /// <summary>
+    /// The diagnostic describes a configuration error that should fail validation.
+    /// </summary>
+    Error
+}

--- a/src/Nuplane/Feeds/Setup/NuplaneFeedSetupReadResult.cs
+++ b/src/Nuplane/Feeds/Setup/NuplaneFeedSetupReadResult.cs
@@ -1,0 +1,16 @@
+namespace Nuplane.Feeds.Setup;
+
+/// <summary>
+/// Contains effective setup feed declarations and diagnostics from configuration reading.
+/// </summary>
+/// <param name="Declarations">The effective setup feed declarations.</param>
+/// <param name="Diagnostics">Warnings and errors discovered while reading setup feed configuration.</param>
+public sealed record NuplaneFeedSetupReadResult(
+    IReadOnlyList<NuplaneFeedSetupDeclaration> Declarations,
+    IReadOnlyList<NuplaneFeedSetupDiagnostic> Diagnostics)
+{
+    /// <summary>
+    /// Gets an empty read result.
+    /// </summary>
+    public static NuplaneFeedSetupReadResult Empty { get; } = new([], []);
+}

--- a/src/Nuplane/Feeds/Setup/NuplaneFeedSetupSourceShape.cs
+++ b/src/Nuplane/Feeds/Setup/NuplaneFeedSetupSourceShape.cs
@@ -1,0 +1,17 @@
+namespace Nuplane.Feeds.Setup;
+
+/// <summary>
+/// Identifies the configuration shape used for a setup feed declaration.
+/// </summary>
+public enum NuplaneFeedSetupSourceShape
+{
+    /// <summary>
+    /// The feed was declared as a legacy numeric array entry.
+    /// </summary>
+    Array,
+
+    /// <summary>
+    /// The feed was declared as a keyed object entry.
+    /// </summary>
+    Keyed
+}

--- a/src/Nuplane/Registration/NuplaneOptionsRegistrationServices.cs
+++ b/src/Nuplane/Registration/NuplaneOptionsRegistrationServices.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
 using Nuplane.Feeds.Configuration;
 using Nuplane.Reconciliation.Configuration;
@@ -59,6 +60,11 @@ internal static class NuplaneOptionsRegistrationServices
 
     internal static void BindConfiguredOptions(IServiceCollection services, IConfiguration configuration)
     {
+        var setupSection = GetNamedSectionOrSelf(configuration, SetupSectionName);
+        services.Replace(ServiceDescriptor.Singleton<INuplaneSetupFeedDeclarationSource>(
+            new ConfigurationNuplaneSetupFeedDeclarationSource(setupSection)));
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IPostConfigureOptions<NuplaneSetupOptions>, NuplaneSetupFeedDiagnosticReporter>());
+
         foreach (var bindOptions in ConfiguredOptionBinders)
         {
             bindOptions(services, configuration);

--- a/src/Nuplane/Setup/ConfigurationNuplaneSetupFeedDeclarationSource.cs
+++ b/src/Nuplane/Setup/ConfigurationNuplaneSetupFeedDeclarationSource.cs
@@ -6,13 +6,22 @@ namespace Nuplane.Setup;
 /// <summary>
 /// Reads setup feed declarations from an <see cref="IConfiguration"/> source.
 /// </summary>
-public sealed class ConfigurationNuplaneSetupFeedDeclarationSource(IConfiguration configuration)
-    : INuplaneSetupFeedDeclarationSource
+public sealed class ConfigurationNuplaneSetupFeedDeclarationSource : INuplaneSetupFeedDeclarationSource
 {
-    private readonly IConfiguration configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
-    private NuplaneFeedSetupReadResult? result;
+    private readonly Lazy<NuplaneFeedSetupReadResult> result;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ConfigurationNuplaneSetupFeedDeclarationSource"/> class.
+    /// </summary>
+    /// <param name="configuration">The configuration source to read setup feed declarations from.</param>
+    public ConfigurationNuplaneSetupFeedDeclarationSource(IConfiguration configuration)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        result = new(() => NuplaneFeedSetupDeclarationReader.Read(configuration));
+    }
 
     /// <inheritdoc />
     public NuplaneFeedSetupReadResult Read() =>
-        result ??= NuplaneFeedSetupDeclarationReader.Read(configuration);
+        result.Value;
 }

--- a/src/Nuplane/Setup/ConfigurationNuplaneSetupFeedDeclarationSource.cs
+++ b/src/Nuplane/Setup/ConfigurationNuplaneSetupFeedDeclarationSource.cs
@@ -1,0 +1,18 @@
+using Microsoft.Extensions.Configuration;
+using Nuplane.Feeds.Setup;
+
+namespace Nuplane.Setup;
+
+/// <summary>
+/// Reads setup feed declarations from an <see cref="IConfiguration"/> source.
+/// </summary>
+public sealed class ConfigurationNuplaneSetupFeedDeclarationSource(IConfiguration configuration)
+    : INuplaneSetupFeedDeclarationSource
+{
+    private readonly IConfiguration configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+    private NuplaneFeedSetupReadResult? result;
+
+    /// <inheritdoc />
+    public NuplaneFeedSetupReadResult Read() =>
+        result ??= NuplaneFeedSetupDeclarationReader.Read(configuration);
+}

--- a/src/Nuplane/Setup/INuplaneSetupFeedDeclarationSource.cs
+++ b/src/Nuplane/Setup/INuplaneSetupFeedDeclarationSource.cs
@@ -1,0 +1,14 @@
+using Nuplane.Feeds.Setup;
+
+namespace Nuplane.Setup;
+
+/// <summary>
+/// Exposes raw setup feed declarations to validators and setup translators.
+/// </summary>
+public interface INuplaneSetupFeedDeclarationSource
+{
+    /// <summary>
+    /// Gets the effective setup feed declarations and diagnostics.
+    /// </summary>
+    NuplaneFeedSetupReadResult Read();
+}

--- a/src/Nuplane/Setup/NuplaneSetupFeedDiagnosticReporter.cs
+++ b/src/Nuplane/Setup/NuplaneSetupFeedDiagnosticReporter.cs
@@ -1,0 +1,44 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Nuplane.Feeds.Setup;
+
+namespace Nuplane.Setup;
+
+internal sealed partial class NuplaneSetupFeedDiagnosticReporter : IPostConfigureOptions<NuplaneSetupOptions>
+{
+    private readonly INuplaneSetupFeedDeclarationSource feedDeclarationSource;
+    private readonly ILogger<NuplaneSetupFeedDiagnosticReporter> logger;
+
+    public NuplaneSetupFeedDiagnosticReporter(
+        INuplaneSetupFeedDeclarationSource feedDeclarationSource,
+        ILogger<NuplaneSetupFeedDiagnosticReporter> logger)
+    {
+        this.feedDeclarationSource = feedDeclarationSource ?? throw new ArgumentNullException(nameof(feedDeclarationSource));
+        this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public void PostConfigure(string? name, NuplaneSetupOptions options)
+    {
+        foreach (var diagnostic in feedDeclarationSource.Read().Diagnostics
+                     .Where(static diagnostic => diagnostic.Severity == NuplaneFeedSetupDiagnosticSeverity.Warning))
+        {
+            SetupFeedWarning(
+                logger,
+                diagnostic.Code,
+                diagnostic.FeedName,
+                diagnostic.ConfigurationPath,
+                diagnostic.Message);
+        }
+    }
+
+    [LoggerMessage(
+        EventId = 1022,
+        Level = LogLevel.Warning,
+        Message = "Nuplane setup feed diagnostic {Code} for feed {FeedName} at {ConfigurationPath}: {DiagnosticMessage}")]
+    private static partial void SetupFeedWarning(
+        ILogger logger,
+        string code,
+        string? feedName,
+        string configurationPath,
+        string diagnosticMessage);
+}

--- a/src/Nuplane/Setup/NuplaneSetupOptionsValidator.cs
+++ b/src/Nuplane/Setup/NuplaneSetupOptionsValidator.cs
@@ -98,7 +98,7 @@ internal sealed class NuplaneSetupOptionsValidator : IValidateOptions<NuplaneSet
             errors.Add($"{label} has an invalid absolute ServiceIndex URI '{feed.ServiceIndex}'.");
         }
 
-        if (feed.Directory.DebounceWindow <= TimeSpan.Zero)
+        if (hasDirectoryPath && feed.Directory.DebounceWindow <= TimeSpan.Zero)
         {
             errors.Add($"{label} Directory.DebounceWindow must be greater than zero.");
         }

--- a/src/Nuplane/Setup/NuplaneSetupOptionsValidator.cs
+++ b/src/Nuplane/Setup/NuplaneSetupOptionsValidator.cs
@@ -1,9 +1,21 @@
 using Microsoft.Extensions.Options;
+using Nuplane.Feeds.Setup;
 
 namespace Nuplane.Setup;
 
 internal sealed class NuplaneSetupOptionsValidator : IValidateOptions<NuplaneSetupOptions>
 {
+    private readonly INuplaneSetupFeedDeclarationSource? feedDeclarationSource;
+
+    public NuplaneSetupOptionsValidator()
+    {
+    }
+
+    public NuplaneSetupOptionsValidator(INuplaneSetupFeedDeclarationSource feedDeclarationSource)
+    {
+        this.feedDeclarationSource = feedDeclarationSource ?? throw new ArgumentNullException(nameof(feedDeclarationSource));
+    }
+
     public ValidateOptionsResult Validate(string? name, NuplaneSetupOptions options)
     {
         ArgumentNullException.ThrowIfNull(options);
@@ -25,41 +37,70 @@ internal sealed class NuplaneSetupOptionsValidator : IValidateOptions<NuplaneSet
             errors.Add("Nuplane setup UseInMemoryStore cannot be combined with a non-empty StateFilePath.");
         }
 
-        var feedNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        for (var i = 0; i < options.Feeds.Count; i++)
+        if (feedDeclarationSource is { } source)
         {
-            var feed = options.Feeds[i];
-            var label = $"Nuplane setup feed at index {i}";
-
-            if (string.IsNullOrWhiteSpace(feed.Name))
+            var readResult = source.Read();
+            var feedNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            errors.AddRange(readResult.Diagnostics
+                .Where(static diagnostic => diagnostic.Severity == NuplaneFeedSetupDiagnosticSeverity.Error)
+                .Select(static diagnostic => diagnostic.Message));
+            foreach (var declaration in readResult.Declarations)
             {
-                errors.Add($"{label} must have a non-empty Name.");
+                if (string.IsNullOrWhiteSpace(declaration.Name))
+                {
+                    errors.Add($"Nuplane setup feed at '{declaration.ConfigurationPath}' must have a non-empty Name.");
+                }
+                else if (!feedNames.Add(declaration.Name))
+                {
+                    errors.Add($"Nuplane setup contains duplicate feed name '{declaration.Name}'.");
+                }
+
+                ValidateFeed(errors, declaration.Options, $"Nuplane setup feed '{declaration.Name}' at '{declaration.ConfigurationPath}'");
             }
-            else if (!feedNames.Add(feed.Name))
+        }
+        else
+        {
+            var feedNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            for (var i = 0; i < options.Feeds.Count; i++)
             {
-                errors.Add($"Nuplane setup contains duplicate feed name '{feed.Name}'.");
-            }
+                var feed = options.Feeds[i];
+                var label = $"Nuplane setup feed at index {i}";
 
-            var hasDirectoryPath = !string.IsNullOrWhiteSpace(feed.DirectoryPath);
-            var hasServiceIndex = !string.IsNullOrWhiteSpace(feed.ServiceIndex);
+                if (string.IsNullOrWhiteSpace(feed.Name))
+                {
+                    errors.Add($"{label} must have a non-empty Name.");
+                }
+                else if (!feedNames.Add(feed.Name))
+                {
+                    errors.Add($"Nuplane setup contains duplicate feed name '{feed.Name}'.");
+                }
 
-            if (hasDirectoryPath == hasServiceIndex)
-            {
-                errors.Add($"{label} must set exactly one of DirectoryPath or ServiceIndex.");
-            }
-
-            if (hasServiceIndex && !Uri.TryCreate(feed.ServiceIndex, UriKind.Absolute, out _))
-            {
-                errors.Add($"{label} has an invalid absolute ServiceIndex URI '{feed.ServiceIndex}'.");
-            }
-
-            if (feed.Directory.DebounceWindow <= TimeSpan.Zero)
-            {
-                errors.Add($"{label} Directory.DebounceWindow must be greater than zero.");
+                ValidateFeed(errors, feed, label);
             }
         }
 
 
         return errors.Count == 0 ? ValidateOptionsResult.Success : ValidateOptionsResult.Fail(errors);
+    }
+
+    private static void ValidateFeed(List<string> errors, NuplaneFeedSetupOptions feed, string label)
+    {
+        var hasDirectoryPath = !string.IsNullOrWhiteSpace(feed.DirectoryPath);
+        var hasServiceIndex = !string.IsNullOrWhiteSpace(feed.ServiceIndex);
+
+        if (hasDirectoryPath == hasServiceIndex)
+        {
+            errors.Add($"{label} must set exactly one of DirectoryPath or ServiceIndex.");
+        }
+
+        if (hasServiceIndex && !Uri.TryCreate(feed.ServiceIndex, UriKind.Absolute, out _))
+        {
+            errors.Add($"{label} has an invalid absolute ServiceIndex URI '{feed.ServiceIndex}'.");
+        }
+
+        if (feed.Directory.DebounceWindow <= TimeSpan.Zero)
+        {
+            errors.Add($"{label} Directory.DebounceWindow must be greater than zero.");
+        }
     }
 }

--- a/test/Nuplane.Runtime.Tests/Configuration/ConfigurationDrivenRegistrationTests.cs
+++ b/test/Nuplane.Runtime.Tests/Configuration/ConfigurationDrivenRegistrationTests.cs
@@ -4,6 +4,8 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Nuplane.Abstractions;
+using Nuplane.Feeds.Configuration;
+using Nuplane.Feeds.Registration;
 using Nuplane.Hosting;
 using Nuplane.Loading;
 using Nuplane.Loading.Hosting.Builder;
@@ -17,6 +19,133 @@ namespace Nuplane.Runtime.Tests.Configuration;
 
 public sealed class ConfigurationDrivenRegistrationTests
 {
+    [Fact]
+    public void AddNuplane_FromConfiguration_KeyedRemoteFeed_RegistersFeedUsingKeyName()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Nuplane:Setup:Feeds:nuget.org:ServiceIndex"] = "https://api.nuget.org/v3/index.json",
+                ["Nuplane:Setup:Feeds:nuget.org:Credentials"] = "secrets://nuget",
+                ["Nuplane:Setup:Feeds:nuget.org:IncludePatterns:0"] = "Elsa.*"
+            })
+            .Build();
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddNuplane(configuration.GetSection("Nuplane"));
+
+        using var provider = services.BuildServiceProvider();
+        var feed = Assert.Single(provider.GetRequiredService<IOptions<FeedResolutionOptions>>().Value.Feeds);
+        var registration = Assert.Single(provider.GetServices<NuplaneFeedRegistration>());
+
+        Assert.Equal("nuget.org", feed.Name);
+        Assert.Equal(new Uri("https://api.nuget.org/v3/index.json"), feed.ServiceIndex);
+        Assert.Equal("secrets://nuget", feed.Credentials);
+        Assert.Equal("nuget.org", registration.Name);
+        Assert.Equal("Elsa.*", Assert.Single(registration.IncludePatterns));
+    }
+
+    [Fact]
+    public void AddNuplane_FromConfiguration_LayeredKeyedRemoteFeed_RegistersEffectiveLaterValueOnce()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Nuplane:Setup:Feeds:feedz.io:ServiceIndex"] = "https://old.example/v3/index.json",
+                ["Nuplane:Setup:Feeds:feedz.io:IncludePatterns:0"] = "Elsa.*"
+            })
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Nuplane:Setup:Feeds:feedz.io:ServiceIndex"] = "https://new.example/v3/index.json",
+                ["Nuplane:Setup:Feeds:feedz.io:IncludePatterns:0"] = "Elsa.Persistence.*"
+            })
+            .Build();
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddNuplane(configuration.GetSection("Nuplane"));
+
+        using var provider = services.BuildServiceProvider();
+        var feed = Assert.Single(provider.GetRequiredService<IOptions<FeedResolutionOptions>>().Value.Feeds);
+        var registration = Assert.Single(provider.GetServices<NuplaneFeedRegistration>());
+
+        Assert.Equal("feedz.io", feed.Name);
+        Assert.Equal(new Uri("https://new.example/v3/index.json"), feed.ServiceIndex);
+        Assert.Equal("Elsa.Persistence.*", Assert.Single(registration.IncludePatterns));
+    }
+
+    [Fact]
+    public void AddNuplane_FromConfiguration_MixedArrayAndKeyedSameName_RegistersKeyedFeedOnly()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Nuplane:Setup:Feeds:0:Name"] = "feedz.io",
+                ["Nuplane:Setup:Feeds:0:ServiceIndex"] = "https://old.example/v3/index.json",
+                ["Nuplane:Setup:Feeds:feedz.io:ServiceIndex"] = "https://new.example/v3/index.json"
+            })
+            .Build();
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddNuplane(configuration.GetSection("Nuplane"));
+
+        using var provider = services.BuildServiceProvider();
+        var feed = Assert.Single(provider.GetRequiredService<IOptions<FeedResolutionOptions>>().Value.Feeds);
+
+        Assert.Equal("feedz.io", feed.Name);
+        Assert.Equal(new Uri("https://new.example/v3/index.json"), feed.ServiceIndex);
+    }
+
+    [Fact]
+    public void AddNuplane_FromConfiguration_MixedArrayAndKeyedSameName_LogsWarningDiagnostic()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Nuplane:Setup:Feeds:0:Name"] = "feedz.io",
+                ["Nuplane:Setup:Feeds:0:ServiceIndex"] = "https://old.example/v3/index.json",
+                ["Nuplane:Setup:Feeds:feedz.io:ServiceIndex"] = "https://new.example/v3/index.json"
+            })
+            .Build();
+        var logMessages = new List<string>();
+
+        var services = new ServiceCollection();
+        services.AddLogging(logging => logging.AddProvider(new CapturingLoggerProvider(logMessages)));
+        services.AddNuplane(configuration.GetSection("Nuplane"));
+
+        using var provider = services.BuildServiceProvider();
+        _ = provider.GetRequiredService<IOptions<NuplaneSetupOptions>>().Value;
+
+        var message = Assert.Single(logMessages, message => message.Contains("NuplaneSetupFeedMixedShapeOverride", StringComparison.Ordinal));
+        Assert.Contains("feedz.io", message, StringComparison.Ordinal);
+        Assert.Contains("Nuplane:Setup:Feeds:0", message, StringComparison.Ordinal);
+        Assert.DoesNotContain("https://old.example", message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void AddNuplane_FromConfiguration_ArrayRemoteFeed_RemainsSupported()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Nuplane:Setup:Feeds:0:Name"] = "nuget.org",
+                ["Nuplane:Setup:Feeds:0:ServiceIndex"] = "https://api.nuget.org/v3/index.json"
+            })
+            .Build();
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddNuplane(configuration.GetSection("Nuplane"));
+
+        using var provider = services.BuildServiceProvider();
+        var feed = Assert.Single(provider.GetRequiredService<IOptions<FeedResolutionOptions>>().Value.Feeds);
+
+        Assert.Equal("nuget.org", feed.Name);
+        Assert.Equal(new Uri("https://api.nuget.org/v3/index.json"), feed.ServiceIndex);
+    }
+
     [Fact]
     public void AddNuplane_FromConfiguration_RegistersAutomaticSchedulerAndDispatcher()
     {

--- a/test/Nuplane.Runtime.Tests/Configuration/NuplaneFeedSetupDeclarationReaderTests.cs
+++ b/test/Nuplane.Runtime.Tests/Configuration/NuplaneFeedSetupDeclarationReaderTests.cs
@@ -1,0 +1,143 @@
+using Microsoft.Extensions.Configuration;
+using Nuplane.Feeds.Setup;
+
+namespace Nuplane.Runtime.Tests.Configuration;
+
+public sealed class NuplaneFeedSetupDeclarationReaderTests
+{
+    [Fact]
+    public void Read_EmptySetupSection_ReturnsEmptyResult()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection([])
+            .Build();
+
+        var result = NuplaneFeedSetupDeclarationReader.Read(configuration.GetSection("Nuplane"));
+
+        Assert.Empty(result.Declarations);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void Read_KeyedRemoteFeedWithoutName_UsesKeyAsName()
+    {
+        var result = Read(new Dictionary<string, string?>
+        {
+            ["Nuplane:Setup:Feeds:nuget.org:ServiceIndex"] = "https://api.nuget.org/v3/index.json",
+            ["Nuplane:Setup:Feeds:nuget.org:Credentials"] = "credentials://nuget",
+            ["Nuplane:Setup:Feeds:nuget.org:IncludePatterns:0"] = "Elsa.*"
+        });
+
+        var declaration = Assert.Single(result.Declarations);
+        Assert.Equal("nuget.org", declaration.Name);
+        Assert.Equal(NuplaneFeedSetupSourceShape.Keyed, declaration.SourceShape);
+        Assert.Equal("https://api.nuget.org/v3/index.json", declaration.Options.ServiceIndex);
+        Assert.Equal("credentials://nuget", declaration.Options.Credentials);
+        Assert.Equal("Elsa.*", Assert.Single(declaration.Options.IncludePatterns));
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void Read_KeyedDirectoryFeedWithoutName_PreservesDirectoryOptions()
+    {
+        var result = Read(new Dictionary<string, string?>
+        {
+            ["Nuplane:Setup:Feeds:local-packages:DirectoryPath"] = "packages",
+            ["Nuplane:Setup:Feeds:local-packages:IncludePatterns:0"] = "*",
+            ["Nuplane:Setup:Feeds:local-packages:Directory:Watch"] = "false",
+            ["Nuplane:Setup:Feeds:local-packages:Directory:DebounceWindow"] = "00:00:02"
+        });
+
+        var declaration = Assert.Single(result.Declarations);
+        Assert.Equal("local-packages", declaration.Name);
+        Assert.Equal(NuplaneFeedSetupSourceShape.Keyed, declaration.SourceShape);
+        Assert.Equal("packages", declaration.Options.DirectoryPath);
+        Assert.Equal("*", Assert.Single(declaration.Options.IncludePatterns));
+        Assert.False(declaration.Options.Directory.Watch);
+        Assert.Equal(TimeSpan.FromSeconds(2), declaration.Options.Directory.DebounceWindow);
+    }
+
+    [Fact]
+    public void Read_NumericChildKey_TreatsEntryAsArrayDeclaration()
+    {
+        var result = Read(new Dictionary<string, string?>
+        {
+            ["Nuplane:Setup:Feeds:0:Name"] = "nuget.org",
+            ["Nuplane:Setup:Feeds:0:ServiceIndex"] = "https://api.nuget.org/v3/index.json"
+        });
+
+        var declaration = Assert.Single(result.Declarations);
+        Assert.Equal("nuget.org", declaration.Name);
+        Assert.Equal(NuplaneFeedSetupSourceShape.Array, declaration.SourceShape);
+        Assert.Equal(0, declaration.ArrayIndex);
+        Assert.Null(declaration.Key);
+    }
+
+    [Fact]
+    public void Read_KeyedNameMismatch_AddsErrorDiagnostic()
+    {
+        var result = Read(new Dictionary<string, string?>
+        {
+            ["Nuplane:Setup:Feeds:feedz.io:Name"] = "other-feed",
+            ["Nuplane:Setup:Feeds:feedz.io:ServiceIndex"] = "https://feedz.example/v3/index.json"
+        });
+
+        var diagnostic = Assert.Single(result.Diagnostics);
+        Assert.Equal(NuplaneFeedSetupDiagnosticSeverity.Error, diagnostic.Severity);
+        Assert.Contains("feedz.io", diagnostic.Message);
+        Assert.Contains("other-feed", diagnostic.Message);
+    }
+
+    [Fact]
+    public void Read_MixedArrayAndKeyedSameName_KeyedDeclarationWinsWithWarning()
+    {
+        var result = Read(new Dictionary<string, string?>
+        {
+            ["Nuplane:Setup:Feeds:0:Name"] = "feedz.io",
+            ["Nuplane:Setup:Feeds:0:ServiceIndex"] = "https://old.example/v3/index.json",
+            ["Nuplane:Setup:Feeds:feedz.io:ServiceIndex"] = "https://new.example/v3/index.json"
+        });
+
+        var declaration = Assert.Single(result.Declarations);
+        Assert.Equal("feedz.io", declaration.Name);
+        Assert.Equal(NuplaneFeedSetupSourceShape.Keyed, declaration.SourceShape);
+        Assert.Equal("https://new.example/v3/index.json", declaration.Options.ServiceIndex);
+        Assert.Single(declaration.IgnoredArrayDeclarations);
+
+        var diagnostic = Assert.Single(result.Diagnostics);
+        Assert.Equal(NuplaneFeedSetupDiagnosticSeverity.Warning, diagnostic.Severity);
+        Assert.Contains("ignored", diagnostic.Message);
+    }
+
+    [Fact]
+    public void Read_LayeredKeyedFeed_UsesEffectiveLaterProviderValues()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Nuplane:Setup:Feeds:feedz.io:ServiceIndex"] = "https://old.example/v3/index.json",
+                ["Nuplane:Setup:Feeds:feedz.io:IncludePatterns:0"] = "Elsa.*"
+            })
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Nuplane:Setup:Feeds:feedz.io:ServiceIndex"] = "https://new.example/v3/index.json",
+                ["Nuplane:Setup:Feeds:feedz.io:IncludePatterns:0"] = "Elsa.Persistence.*"
+            })
+            .Build();
+
+        var result = NuplaneFeedSetupDeclarationReader.Read(configuration.GetSection("Nuplane"));
+
+        var declaration = Assert.Single(result.Declarations);
+        Assert.Equal("https://new.example/v3/index.json", declaration.Options.ServiceIndex);
+        Assert.Equal("Elsa.Persistence.*", Assert.Single(declaration.Options.IncludePatterns));
+    }
+
+    private static NuplaneFeedSetupReadResult Read(Dictionary<string, string?> values)
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(values)
+            .Build();
+
+        return NuplaneFeedSetupDeclarationReader.Read(configuration.GetSection("Nuplane"));
+    }
+}

--- a/test/Nuplane.Runtime.Tests/Configuration/NuplaneSetupOptionsValidatorTests.cs
+++ b/test/Nuplane.Runtime.Tests/Configuration/NuplaneSetupOptionsValidatorTests.cs
@@ -147,6 +147,20 @@ public sealed class NuplaneSetupOptionsValidatorTests
     }
 
     [Fact]
+    public void Validate_RemoteFeedWithZeroDirectoryDebounceWindow_Succeeds()
+    {
+        var sut = CreateValidator(new Dictionary<string, string?>
+        {
+            ["Nuplane:Setup:Feeds:nuget.org:ServiceIndex"] = "https://api.nuget.org/v3/index.json",
+            ["Nuplane:Setup:Feeds:nuget.org:Directory:DebounceWindow"] = "00:00:00"
+        });
+
+        var result = sut.Validate(null, new NuplaneSetupOptions());
+
+        Assert.True(result.Succeeded);
+    }
+
+    [Fact]
     public void Validate_KeyedFeedWithBlankDirectoryPath_Fails()
     {
         var sut = CreateValidator(new Dictionary<string, string?>

--- a/test/Nuplane.Runtime.Tests/Configuration/NuplaneSetupOptionsValidatorTests.cs
+++ b/test/Nuplane.Runtime.Tests/Configuration/NuplaneSetupOptionsValidatorTests.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Configuration;
 using Nuplane.Setup;
 
 namespace Nuplane.Runtime.Tests.Configuration;
@@ -71,5 +72,117 @@ public sealed class NuplaneSetupOptionsValidatorTests
         });
 
         Assert.True(result.Succeeded);
+    }
+
+    [Fact]
+    public void Validate_KeyedFeedWithoutName_Succeeds()
+    {
+        var sut = CreateValidator(new Dictionary<string, string?>
+        {
+            ["Nuplane:Setup:Feeds:nuget.org:ServiceIndex"] = "https://api.nuget.org/v3/index.json"
+        });
+
+        var result = sut.Validate(null, new NuplaneSetupOptions());
+
+        Assert.True(result.Succeeded);
+    }
+
+    [Fact]
+    public void Validate_KeyedFeedWithMismatchedName_Fails()
+    {
+        var sut = CreateValidator(new Dictionary<string, string?>
+        {
+            ["Nuplane:Setup:Feeds:feedz.io:Name"] = "other-feed",
+            ["Nuplane:Setup:Feeds:feedz.io:ServiceIndex"] = "https://feedz.example/v3/index.json"
+        });
+
+        var result = sut.Validate(null, new NuplaneSetupOptions());
+
+        Assert.True(result.Failed);
+        Assert.Contains("feedz.io", result.FailureMessage);
+        Assert.Contains("other-feed", result.FailureMessage);
+    }
+
+    [Fact]
+    public void Validate_KeyedFeedWithBothSourceTypes_Fails()
+    {
+        var sut = CreateValidator(new Dictionary<string, string?>
+        {
+            ["Nuplane:Setup:Feeds:local-packages:ServiceIndex"] = "https://feed.example/v3/index.json",
+            ["Nuplane:Setup:Feeds:local-packages:DirectoryPath"] = "packages"
+        });
+
+        var result = sut.Validate(null, new NuplaneSetupOptions());
+
+        Assert.True(result.Failed);
+        Assert.Contains("exactly one of DirectoryPath or ServiceIndex", result.FailureMessage);
+    }
+
+    [Fact]
+    public void Validate_KeyedFeedWithMissingSourceType_Fails()
+    {
+        var sut = CreateValidator(new Dictionary<string, string?>
+        {
+            ["Nuplane:Setup:Feeds:empty-feed:IncludePatterns:0"] = "*"
+        });
+
+        var result = sut.Validate(null, new NuplaneSetupOptions());
+
+        Assert.True(result.Failed);
+        Assert.Contains("exactly one of DirectoryPath or ServiceIndex", result.FailureMessage);
+    }
+
+    [Fact]
+    public void Validate_KeyedFeedWithInvalidServiceIndex_Fails()
+    {
+        var sut = CreateValidator(new Dictionary<string, string?>
+        {
+            ["Nuplane:Setup:Feeds:nuget.org:ServiceIndex"] = "not-a-uri"
+        });
+
+        var result = sut.Validate(null, new NuplaneSetupOptions());
+
+        Assert.True(result.Failed);
+        Assert.Contains("invalid absolute ServiceIndex URI", result.FailureMessage);
+    }
+
+    [Fact]
+    public void Validate_KeyedFeedWithBlankDirectoryPath_Fails()
+    {
+        var sut = CreateValidator(new Dictionary<string, string?>
+        {
+            ["Nuplane:Setup:Feeds:local-packages:DirectoryPath"] = "  "
+        });
+
+        var result = sut.Validate(null, new NuplaneSetupOptions());
+
+        Assert.True(result.Failed);
+        Assert.Contains("exactly one of DirectoryPath or ServiceIndex", result.FailureMessage);
+    }
+
+    [Fact]
+    public void Validate_DuplicateArrayFeedNamesWithRawSource_Fails()
+    {
+        var sut = CreateValidator(new Dictionary<string, string?>
+        {
+            ["Nuplane:Setup:Feeds:0:Name"] = "nuget.org",
+            ["Nuplane:Setup:Feeds:0:ServiceIndex"] = "https://api.nuget.org/v3/index.json",
+            ["Nuplane:Setup:Feeds:1:Name"] = "NuGet.Org",
+            ["Nuplane:Setup:Feeds:1:ServiceIndex"] = "https://mirror.example/v3/index.json"
+        });
+
+        var result = sut.Validate(null, new NuplaneSetupOptions());
+
+        Assert.True(result.Failed);
+        Assert.Contains("duplicate feed name", result.FailureMessage);
+    }
+
+    private static NuplaneSetupOptionsValidator CreateValidator(Dictionary<string, string?> values)
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(values)
+            .Build();
+
+        return new(new ConfigurationNuplaneSetupFeedDeclarationSource(configuration.GetSection("Nuplane:Setup")));
     }
 }

--- a/test/Nuplane.Sources.Directory.Tests/Configuration/DirectoryFeedSetupConfigurationTests.cs
+++ b/test/Nuplane.Sources.Directory.Tests/Configuration/DirectoryFeedSetupConfigurationTests.cs
@@ -1,0 +1,87 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+using Nuplane;
+using Nuplane.Feeds.Configuration;
+using Nuplane.Sources.Directory.Configuration;
+
+namespace Nuplane.Sources.Directory.Tests.Configuration;
+
+public sealed class DirectoryFeedSetupConfigurationTests
+{
+    [Fact]
+    public void AddDirectoryFeedsFromConfiguration_KeyedDirectoryFeed_RegistersFeedAndDirectoryOptions()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "nuplane-keyed-dir", Guid.NewGuid().ToString("N"));
+        System.IO.Directory.CreateDirectory(root);
+
+        try
+        {
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    ["Nuplane:Setup:Feeds:local-packages:DirectoryPath"] = root,
+                    ["Nuplane:Setup:Feeds:local-packages:IncludePatterns:0"] = "*",
+                    ["Nuplane:Setup:Feeds:local-packages:Directory:Watch"] = "false",
+                    ["Nuplane:Setup:Feeds:local-packages:Directory:DebounceWindow"] = "00:00:02"
+                })
+                .Build();
+
+            var services = new ServiceCollection();
+            services.AddLogging();
+            services.AddNuplane(configuration.GetSection("Nuplane"), nuplane =>
+            {
+                nuplane.AddDirectoryFeedsFromConfiguration(configuration.GetSection("Nuplane"));
+            });
+
+            using var provider = services.BuildServiceProvider();
+            var feeds = provider.GetRequiredService<IOptions<FeedResolutionOptions>>().Value.Feeds;
+
+            var feed = Assert.Single(feeds);
+            Assert.Equal("local-packages", feed.Name);
+            Assert.Equal("file", feed.ServiceIndex.Scheme);
+            Assert.DoesNotContain(services, descriptor => descriptor.ServiceType == typeof(IHostedService)
+                && descriptor.ImplementationFactory is not null);
+        }
+        finally
+        {
+            try { System.IO.Directory.Delete(root, recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
+    public void AddDirectoryFeedsFromConfiguration_ArrayDirectoryFeed_RemainsSupported()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "nuplane-array-dir", Guid.NewGuid().ToString("N"));
+        System.IO.Directory.CreateDirectory(root);
+
+        try
+        {
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    ["Nuplane:Setup:Feeds:0:Name"] = "local-packages",
+                    ["Nuplane:Setup:Feeds:0:DirectoryPath"] = root,
+                    ["Nuplane:Setup:Feeds:0:IncludeAll"] = "true"
+                })
+                .Build();
+
+            var services = new ServiceCollection();
+            services.AddLogging();
+            services.AddNuplane(configuration.GetSection("Nuplane"), nuplane =>
+            {
+                nuplane.AddDirectoryFeedsFromConfiguration(configuration.GetSection("Nuplane"));
+            });
+
+            using var provider = services.BuildServiceProvider();
+            var feed = Assert.Single(provider.GetRequiredService<IOptions<FeedResolutionOptions>>().Value.Feeds);
+
+            Assert.Equal("local-packages", feed.Name);
+        }
+        finally
+        {
+            try { System.IO.Directory.Delete(root, recursive: true); } catch { }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add keyed feed setup declaration reading and validation
- wire setup declarations into Nuplane options registration
- document keyed feed setup configuration and sample appsettings

## Validation
- dotnet test test/Nuplane.Runtime.Tests/Nuplane.Runtime.Tests.csproj --filter "FullyQualifiedName~Configuration"
- dotnet test test/Nuplane.Sources.Directory.Tests/Nuplane.Sources.Directory.Tests.csproj --filter "FullyQualifiedName~Configuration"