### PR TITLE
[codex] Implement last-known-good startup recovery

### DIFF
--- a/src/Nuplane/Hosting/ILastKnownGoodStartupRecoveryService.cs
+++ b/src/Nuplane/Hosting/ILastKnownGoodStartupRecoveryService.cs
@@ -1,0 +1,8 @@
+namespace Nuplane.Hosting;
+
+internal interface ILastKnownGoodStartupRecoveryService
+{
+    Task<LastKnownGoodStartupRecoveryResult> TryRecoverAsync(
+        string correlationId,
+        CancellationToken cancellationToken);
+}

--- a/src/Nuplane/Hosting/LastKnownGoodStartupRecoveryResult.cs
+++ b/src/Nuplane/Hosting/LastKnownGoodStartupRecoveryResult.cs
@@ -1,0 +1,15 @@
+using Nuplane.Abstractions;
+
+namespace Nuplane.Hosting;
+
+internal sealed record LastKnownGoodStartupRecoveryResult(
+    bool Succeeded,
+    IReadOnlyList<ResolvedPackage> RecoveredPackages,
+    IReadOnlyList<string> FailedPackageIds,
+    string Reason)
+{
+    public static LastKnownGoodStartupRecoveryResult Failed(
+        IReadOnlyList<string> failedPackageIds,
+        string reason) =>
+        new(false, [], failedPackageIds, reason);
+}

--- a/src/Nuplane/Hosting/LastKnownGoodStartupRecoveryService.cs
+++ b/src/Nuplane/Hosting/LastKnownGoodStartupRecoveryService.cs
@@ -1,0 +1,123 @@
+using Nuplane.Abstractions;
+using Nuplane.Events;
+using Nuplane.Store.State;
+
+namespace Nuplane.Hosting;
+
+internal sealed class LastKnownGoodStartupRecoveryService(
+    IStoreRegistry storeRegistry,
+    IObserverEventDispatcher observerEventDispatcher,
+    StartupRecoveryState startupRecoveryState,
+    IEnumerable<ICycleFailureContributor>? cycleFailureContributors = null) : ILastKnownGoodStartupRecoveryService
+{
+    private readonly IStoreRegistry _storeRegistry = storeRegistry ?? throw new ArgumentNullException(nameof(storeRegistry));
+    private readonly IObserverEventDispatcher _observerEventDispatcher = observerEventDispatcher ?? throw new ArgumentNullException(nameof(observerEventDispatcher));
+    private readonly StartupRecoveryState _startupRecoveryState = startupRecoveryState ?? throw new ArgumentNullException(nameof(startupRecoveryState));
+    private readonly IReadOnlyList<ICycleFailureContributor> _cycleFailureContributors = cycleFailureContributors?.ToArray() ?? [];
+
+    public async Task<LastKnownGoodStartupRecoveryResult> TryRecoverAsync(
+        string correlationId,
+        CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(correlationId);
+
+        var state = await _storeRegistry.GetStateAsync(cancellationToken);
+        var validation = Validate(state);
+        if (!validation.Succeeded)
+        {
+            _startupRecoveryState.MarkFailed(correlationId, validation.Reason);
+            return validation;
+        }
+
+        var recoveredPackages = state.ActivePackageDescriptorsByIdNormalized.Values
+            .Where(descriptor => state.ActiveVersionById.TryGetValue(descriptor.PackageId, out var activeVersion)
+                && string.Equals(activeVersion, descriptor.Version, StringComparison.OrdinalIgnoreCase))
+            .OrderBy(descriptor => descriptor.PackageId, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(descriptor => descriptor.Version, StringComparer.OrdinalIgnoreCase)
+            .Select(static descriptor => new ResolvedPackage(
+                descriptor.PackageId,
+                descriptor.Version,
+                descriptor.FeedName ?? string.Empty,
+                descriptor.InstallPath,
+                descriptor.ActivatedAtUtc,
+                descriptor.SourceName ?? string.Empty))
+            .ToArray();
+
+        var changeSet = new PackageChangeSet([], [], [], correlationId, DateTimeOffset.UtcNow);
+        await _observerEventDispatcher.PublishReconciledAsync(changeSet, recoveredPackages, cancellationToken);
+
+        var loadFailedPackageIds = TakeLoadFailedPackageIds(correlationId);
+        if (loadFailedPackageIds.Count > 0)
+        {
+            _startupRecoveryState.MarkFailed(correlationId, "last-known-good-load-failed");
+            return LastKnownGoodStartupRecoveryResult.Failed(loadFailedPackageIds, "last-known-good-load-failed");
+        }
+
+        _startupRecoveryState.MarkRecovered(correlationId, recoveredPackages.Length);
+
+        return new(true, recoveredPackages, [], "last-known-good-recovered");
+    }
+
+    private static LastKnownGoodStartupRecoveryResult Validate(StoreStateRecord state)
+    {
+        if (state.ActiveVersionById.Count == 0)
+        {
+            return LastKnownGoodStartupRecoveryResult.Failed([], "no-active-packages");
+        }
+
+        var failed = new SortedSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var (packageId, activeVersion) in state.ActiveVersionById)
+        {
+            if (!state.LastKnownGoodById.TryGetValue(packageId, out var lkgVersion) ||
+                !string.Equals(lkgVersion, activeVersion, StringComparison.OrdinalIgnoreCase))
+            {
+                failed.Add(packageId);
+                continue;
+            }
+
+            if (!state.ActivePackageDescriptorsByIdNormalized.TryGetValue(packageId, out var descriptor) ||
+                !string.Equals(descriptor.Version, activeVersion, StringComparison.OrdinalIgnoreCase) ||
+                !Directory.Exists(descriptor.InstallPath))
+            {
+                failed.Add(packageId);
+            }
+        }
+
+        foreach (var graph in state.ActiveGraphsByIdNormalized.Values.Where(static graph => graph.Status == GraphActivationStatus.Active))
+        {
+            foreach (var nodePackageId in graph.NodePackageIds)
+            {
+                if (!state.ActiveVersionById.ContainsKey(nodePackageId))
+                {
+                    failed.Add(nodePackageId);
+                }
+            }
+
+            if (graph.NodeVersionsByPackageId is null)
+            {
+                continue;
+            }
+
+            foreach (var (nodePackageId, nodeVersion) in graph.NodeVersionsByPackageId)
+            {
+                if (!state.ActiveVersionById.TryGetValue(nodePackageId, out var activeVersion) ||
+                    !string.Equals(activeVersion, nodeVersion, StringComparison.OrdinalIgnoreCase))
+                {
+                    failed.Add(nodePackageId);
+                }
+            }
+        }
+
+        return failed.Count == 0
+            ? new(true, [], [], "last-known-good-valid")
+            : LastKnownGoodStartupRecoveryResult.Failed(failed.ToArray(), "last-known-good-invalid");
+    }
+
+    private IReadOnlyList<string> TakeLoadFailedPackageIds(string correlationId) =>
+        _cycleFailureContributors
+            .SelectMany(contributor => contributor.TakeFailedPackageIds(correlationId))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(id => id, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+}

--- a/src/Nuplane/Hosting/NuplaneStartupHostedService.cs
+++ b/src/Nuplane/Hosting/NuplaneStartupHostedService.cs
@@ -20,7 +20,8 @@ namespace Nuplane.Hosting;
 internal sealed class NuplaneStartupHostedService(
     IReconciliationTriggerIngress triggerIngress,
     IOptions<ReconciliationOptions> options,
-    ILogger<NuplaneStartupHostedService> logger)
+    ILogger<NuplaneStartupHostedService> logger,
+    ILastKnownGoodStartupRecoveryService? lastKnownGoodStartupRecovery = null)
     : IHostedService
 {
     public async Task StartAsync(CancellationToken cancellationToken)
@@ -40,10 +41,25 @@ internal sealed class NuplaneStartupHostedService(
                     throw CreateStartupReconciliationException(correlationId, result);
 
                 case StartupFailurePolicy.UseLastKnownGood:
-                    logger.LogError(
-                        "StartupFailurePolicy.UseLastKnownGood is not implemented [CorrelationId={CorrelationId}]; failing host startup instead of starting degraded",
-                        correlationId);
-                    throw CreateStartupReconciliationException(correlationId, result);
+                    var recovery = lastKnownGoodStartupRecovery is null
+                        ? LastKnownGoodStartupRecoveryResult.Failed(result.FailedPackages, "last-known-good-recovery-unavailable")
+                        : await lastKnownGoodStartupRecovery.TryRecoverAsync(correlationId, cancellationToken);
+
+                    if (!recovery.Succeeded)
+                    {
+                        logger.LogError(
+                            "StartupFailurePolicy.UseLastKnownGood could not recover startup [CorrelationId={CorrelationId}, Reason={Reason}, FailedPackages={FailedPackages}]",
+                            correlationId,
+                            recovery.Reason,
+                            string.Join(", ", recovery.FailedPackageIds));
+                        throw CreateStartupReconciliationException(correlationId, result);
+                    }
+
+                    logger.LogWarning(
+                        "Startup reconciliation completed degraded, but recovered from last-known-good active packages [CorrelationId={CorrelationId}, RecoveredPackageCount={RecoveredPackageCount}]",
+                        correlationId,
+                        recovery.RecoveredPackages.Count);
+                    break;
 
                 case StartupFailurePolicy.StartDegraded:
                     logger.LogWarning(

--- a/src/Nuplane/Hosting/StartupRecoveryOperationalStateContributor.cs
+++ b/src/Nuplane/Hosting/StartupRecoveryOperationalStateContributor.cs
@@ -1,0 +1,11 @@
+using Nuplane.Operational;
+
+namespace Nuplane.Hosting;
+
+internal sealed class StartupRecoveryOperationalStateContributor(StartupRecoveryState state) : IOperationalStateContributor
+{
+    private readonly StartupRecoveryState _state = state ?? throw new ArgumentNullException(nameof(state));
+
+    public Task<OperationalStateContribution> ContributeAsync(CancellationToken cancellationToken) =>
+        Task.FromResult(_state.GetContribution());
+}

--- a/src/Nuplane/Hosting/StartupRecoveryState.cs
+++ b/src/Nuplane/Hosting/StartupRecoveryState.cs
@@ -1,0 +1,71 @@
+using Nuplane.Operational;
+
+namespace Nuplane.Hosting;
+
+/// <summary>
+/// Tracks startup last-known-good recovery status for operational-state reporting.
+/// </summary>
+public sealed class StartupRecoveryState
+{
+    private readonly object _gate = new();
+    private OperationalStateContribution _contribution = new("startup-recovery", []);
+
+    /// <summary>
+    /// Records that startup recovered from last-known-good packages.
+    /// </summary>
+    public void MarkRecovered(string correlationId, int packageCount)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(correlationId);
+
+        lock (_gate)
+        {
+            _contribution = new(
+                "startup-recovery",
+                [$"startup-lkg-recovery-active:{packageCount}"]);
+        }
+    }
+
+    /// <summary>
+    /// Records that startup last-known-good recovery failed.
+    /// </summary>
+    public void MarkFailed(string correlationId, string reason)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(correlationId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(reason);
+
+        lock (_gate)
+        {
+            _contribution = new(
+                "startup-recovery",
+                [$"startup-lkg-recovery-failed:{Normalize(reason)}"]);
+        }
+    }
+
+    /// <summary>
+    /// Clears startup recovery degradation.
+    /// </summary>
+    public void Clear()
+    {
+        lock (_gate)
+        {
+            _contribution = new("startup-recovery", []);
+        }
+    }
+
+    /// <summary>
+    /// Gets the current operational-state contribution.
+    /// </summary>
+    public OperationalStateContribution GetContribution()
+    {
+        lock (_gate)
+        {
+            return _contribution;
+        }
+    }
+
+    private static string Normalize(string reason) =>
+        reason.Trim()
+            .Replace(' ', '-')
+            .Replace(':', '-')
+            .ToLowerInvariant();
+}

--- a/src/Nuplane/Reconciliation/Configuration/StartupFailurePolicy.cs
+++ b/src/Nuplane/Reconciliation/Configuration/StartupFailurePolicy.cs
@@ -16,7 +16,7 @@ public enum StartupFailurePolicy
     StartDegraded = 1,
 
     /// <summary>
-    /// Reserved for a future policy that starts from validated last-known-good state.
+    /// Start from validated last-known-good active package state when startup reconciliation is degraded.
     /// </summary>
     UseLastKnownGood = 2
 }

--- a/src/Nuplane/Reconciliation/Middleware/HealthAndMetricsMiddleware.cs
+++ b/src/Nuplane/Reconciliation/Middleware/HealthAndMetricsMiddleware.cs
@@ -2,6 +2,7 @@ using Nuplane.Abstractions;
 using Nuplane.Events;
 using Nuplane.Feeds.Configuration;
 using Nuplane.Health;
+using Nuplane.Hosting;
 using Nuplane.Observability;
 
 namespace Nuplane.Reconciliation.Middleware;
@@ -13,7 +14,8 @@ internal sealed class HealthAndMetricsMiddleware(
     ReconciliationMetrics metrics,
     FeedResolutionOptions feedResolutionOptions,
     ObservationDegradationTracker observationDegradationTracker,
-    ICycleFailureContributor? cycleFailureContributor = null) : IReconciliationMiddleware
+    ICycleFailureContributor? cycleFailureContributor = null,
+    StartupRecoveryState? startupRecoveryState = null) : IReconciliationMiddleware
 {
     private bool _previouslyIdle;
 
@@ -64,6 +66,11 @@ internal sealed class HealthAndMetricsMiddleware(
             context.LockFailureCount,
             context.CleanupFailureCount,
             SourceOutages: context.SourceOutageCount + (observationDegradationTracker?.DegradedCount ?? 0)));
+        if (!isDegraded)
+        {
+            startupRecoveryState?.Clear();
+        }
+
         var cycleDuration = DateTimeOffset.UtcNow - context.CycleStartedAt;
         var totalFailureCount = applyResult.FailedPackageIds.Count + loaderFailedIds.Count;
         metrics.RecordCycle(changeSet, totalFailureCount, cycleDuration, context.MergedActive!.Count);

--- a/src/Nuplane/Reconciliation/ReconciliationService.cs
+++ b/src/Nuplane/Reconciliation/ReconciliationService.cs
@@ -3,6 +3,7 @@ using Nuplane.Abstractions;
 using Nuplane.Events;
 using Nuplane.Feeds.Configuration;
 using Nuplane.Health;
+using Nuplane.Hosting;
 using Nuplane.Observability;
 using Nuplane.Reconciliation.Configuration;
 using Nuplane.Reconciliation.Middleware;
@@ -48,6 +49,7 @@ public sealed class ReconciliationService : IReconciliationService
     /// <param name="failureRecorder">The failure recorder.</param>
     /// <param name="observationDegradationTracker">The observation degradation tracker.</param>
     /// <param name="cycleFailureContributor">Optional contributor of per-cycle failure information from external modules.</param>
+    /// <param name="startupRecoveryState">Optional startup recovery state to clear after a healthy cycle.</param>
     public ReconciliationService(
         IEnumerable<IDesiredPackageSource> sources,
         IDesiredStateAggregator desiredStateAggregator,
@@ -67,7 +69,8 @@ public sealed class ReconciliationService : IReconciliationService
         IPackageCleanupService packageCleanupService,
         IFailureRecorder failureRecorder,
         ObservationDegradationTracker observationDegradationTracker,
-        ICycleFailureContributor? cycleFailureContributor = null)
+        ICycleFailureContributor? cycleFailureContributor = null,
+        StartupRecoveryState? startupRecoveryState = null)
     {
         var sourcesList = (sources ?? throw new ArgumentNullException(nameof(sources))).ToArray();
         var reconciliationOpts = (reconciliationOptions ?? throw new ArgumentNullException(nameof(reconciliationOptions))).Value;
@@ -104,7 +107,7 @@ public sealed class ReconciliationService : IReconciliationService
         _pipeline.Use(new DiffAndChangeEventMiddleware(diffEngine, dryRun, retry, storeReg, eventDispatcher, metricsInstance));
         _pipeline.Use(new TransactionExecutionMiddleware(applyExecutor, diffEngine, eventDispatcher));
         _pipeline.Use(new CleanupMiddleware(diffEngine, storeReg, cleanupService, cleanupOpts, metricsInstance));
-        _pipeline.Use(new HealthAndMetricsMiddleware(healthEval, eventDispatcher, loggerInstance, metricsInstance, feedResOpts, observationDegradationTracker, cycleFailureContributor));
+        _pipeline.Use(new HealthAndMetricsMiddleware(healthEval, eventDispatcher, loggerInstance, metricsInstance, feedResOpts, observationDegradationTracker, cycleFailureContributor, startupRecoveryState));
     }
 
     /// <inheritdoc />

--- a/src/Nuplane/Registration/NuplaneRuntimeRegistrationServices.cs
+++ b/src/Nuplane/Registration/NuplaneRuntimeRegistrationServices.cs
@@ -52,9 +52,12 @@ public static class NuplaneRuntimeRegistrationServices
         services.AddSingleton<ReconciliationRetryPolicy>();
         services.AddSingleton<IReconciliationRetryPolicy>(sp => sp.GetRequiredService<ReconciliationRetryPolicy>());
         services.TryAddSingleton<ObservationDegradationTracker>();
+        services.TryAddSingleton<StartupRecoveryState>();
+        services.TryAddSingleton<ILastKnownGoodStartupRecoveryService, LastKnownGoodStartupRecoveryService>();
         services.AddSingleton<ActivePackageCatalog>();
         services.AddSingleton<IActivePackageCatalog>(sp => sp.GetRequiredService<ActivePackageCatalog>());
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IOperationalStateContributor, PackageCatalogOperationalStateContributor>());
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IOperationalStateContributor, StartupRecoveryOperationalStateContributor>());
         services.AddSingleton<ReconciliationService>();
         services.AddSingleton<IReconciliationService>(sp => sp.GetRequiredService<ReconciliationService>());
     }

--- a/test/Nuplane.Runtime.Tests/Hosting/StartupCycleTests.cs
+++ b/test/Nuplane.Runtime.Tests/Hosting/StartupCycleTests.cs
@@ -3,12 +3,15 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Nuplane.Abstractions;
+using Nuplane.Events;
 using Nuplane.Hosting;
 using Nuplane.Observability;
 using Nuplane.Reconciliation;
 using Nuplane.Reconciliation.Configuration;
 using Nuplane.Reconciliation.Convergence;
 using Nuplane.Reconciliation.Models;
+using Nuplane.Runtime.Tests.TestSupport;
+using Nuplane.Store.State;
 
 namespace Nuplane.Runtime.Tests.Hosting;
 
@@ -186,6 +189,124 @@ public sealed class StartupCycleTests
     }
 
     [Fact]
+    public async Task StartupCycleFailurePolicyUseLastKnownGood_WhenValidActiveLkgExists_PublishesRecoveredPackages()
+    {
+        var service = new DegradedStartupReconciliationService();
+        var options = new ReconciliationOptions
+        {
+            StartupFailurePolicy = StartupFailurePolicy.UseLastKnownGood
+        };
+        using var installRoot = new TempDirectory();
+        var (store, packageInstallPath) = await CreateValidLastKnownGoodStoreAsync(installRoot);
+        var dispatcher = new RecordingObserverDispatcher();
+        var startupRecoveryState = new StartupRecoveryState();
+        var recovery = new LastKnownGoodStartupRecoveryService(store, dispatcher, startupRecoveryState);
+        var (queueDispatcher, scheduler, startup) = CreateHostedServices(service, options, recovery);
+
+        await queueDispatcher.StartAsync(CancellationToken.None);
+
+        try
+        {
+            await startup.StartAsync(CancellationToken.None);
+
+            var recovered = Assert.Single(dispatcher.ReconciledPackages);
+            Assert.Equal("pkg-a", recovered.Id);
+            Assert.Equal(packageInstallPath, recovered.InstallPath);
+
+            var contribution = startupRecoveryState.GetContribution();
+            Assert.Contains("startup-lkg-recovery-active:1", contribution.DegradedReasons);
+        }
+        finally
+        {
+            await StopHostedServicesAsync(scheduler, queueDispatcher);
+        }
+    }
+
+    [Fact]
+    public async Task LastKnownGoodRecovery_WhenRecoveredLoadFails_ReturnsFailure()
+    {
+        using var installRoot = new TempDirectory();
+        var (store, _) = await CreateValidLastKnownGoodStoreAsync(installRoot);
+        var loadFailures = new RecordingCycleFailureContributor();
+        var dispatcher = new RecordingObserverDispatcher((changeSet, packages) =>
+        {
+            foreach (var package in packages)
+            {
+                loadFailures.RecordFailure(changeSet.CorrelationId, package.Id);
+            }
+        });
+        var startupRecoveryState = new StartupRecoveryState();
+        var recovery = new LastKnownGoodStartupRecoveryService(store, dispatcher, startupRecoveryState, [loadFailures]);
+
+        var result = await recovery.TryRecoverAsync("corr-recovery", CancellationToken.None);
+
+        Assert.False(result.Succeeded);
+        Assert.Equal("last-known-good-load-failed", result.Reason);
+        Assert.Equal(["pkg-a"], result.FailedPackageIds);
+        Assert.Contains("startup-lkg-recovery-failed:last-known-good-load-failed", startupRecoveryState.GetContribution().DegradedReasons);
+    }
+
+    [Fact]
+    public async Task LastKnownGoodRecovery_WhenStaleGraphReferencesMissingPackage_IgnoresStaleGraph()
+    {
+        using var installRoot = new TempDirectory();
+        var staleGraph = new GraphActivationRecord(
+            "graph-a",
+            "gen-stale",
+            ["missing-pkg"],
+            ["missing-pkg"],
+            DateTimeOffset.UtcNow,
+            "corr-seed",
+            GraphActivationStatus.Stale,
+            NodeVersionsByPackageId: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["missing-pkg"] = "9.0.0"
+            });
+        var (store, _) = await CreateValidLastKnownGoodStoreAsync(
+            installRoot,
+            new Dictionary<string, GraphActivationRecord>(StringComparer.OrdinalIgnoreCase)
+            {
+                [staleGraph.GraphId] = staleGraph
+            });
+        var recovery = new LastKnownGoodStartupRecoveryService(store, new RecordingObserverDispatcher(), new StartupRecoveryState());
+
+        var result = await recovery.TryRecoverAsync("corr-recovery", CancellationToken.None);
+
+        Assert.True(result.Succeeded);
+    }
+
+    [Fact]
+    public async Task LastKnownGoodRecovery_WhenActiveGraphVersionMismatches_ReturnsFailure()
+    {
+        using var installRoot = new TempDirectory();
+        var activeGraph = new GraphActivationRecord(
+            "graph-a",
+            "gen-active",
+            ["pkg-a"],
+            ["pkg-a"],
+            DateTimeOffset.UtcNow,
+            "corr-seed",
+            GraphActivationStatus.Active,
+            NodeVersionsByPackageId: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["pkg-a"] = "2.0.0"
+            });
+        var (store, _) = await CreateValidLastKnownGoodStoreAsync(
+            installRoot,
+            new Dictionary<string, GraphActivationRecord>(StringComparer.OrdinalIgnoreCase)
+            {
+                [activeGraph.GraphId] = activeGraph
+            });
+        var recovery = new LastKnownGoodStartupRecoveryService(store, new RecordingObserverDispatcher(), new StartupRecoveryState());
+
+        var result = await recovery.TryRecoverAsync("corr-recovery", CancellationToken.None);
+
+        Assert.False(result.Succeeded);
+        Assert.Equal("last-known-good-invalid", result.Reason);
+        Assert.Equal(["pkg-a"], result.FailedPackageIds);
+    }
+
+    [Fact]
     public async Task StartupCycleFailurePolicyUnknownValue_WhenStartupCompletesDegraded_ThrowsNotSupported()
     {
         var service = new DegradedStartupReconciliationService();
@@ -238,7 +359,8 @@ public sealed class StartupCycleTests
 
     private static (ReconciliationTriggerDispatcherHostedService Dispatcher, ReconciliationHostedService Scheduler, NuplaneStartupHostedService Startup) CreateHostedServices(
         IReconciliationService reconciliationService,
-        ReconciliationOptions? options = null)
+        ReconciliationOptions? options = null,
+        ILastKnownGoodStartupRecoveryService? lastKnownGoodStartupRecovery = null)
     {
         options ??= new()
         {
@@ -263,7 +385,43 @@ public sealed class StartupCycleTests
             new(
                 queue,
                 new OptionsWrapper<ReconciliationOptions>(options),
-                NullLogger<NuplaneStartupHostedService>.Instance));
+                NullLogger<NuplaneStartupHostedService>.Instance,
+                lastKnownGoodStartupRecovery));
+    }
+
+    private static async Task<(StoreRegistry Store, string PackageInstallPath)> CreateValidLastKnownGoodStoreAsync(
+        TempDirectory installRoot,
+        IReadOnlyDictionary<string, GraphActivationRecord>? activeGraphs = null)
+    {
+        var packageInstallPath = Path.Combine(installRoot.Path, "pkg-a", "1.0.0");
+        Directory.CreateDirectory(packageInstallPath);
+
+        var store = new StoreRegistry(new StoreStateSerializer(), stateFilePath: null);
+        await store.PersistActiveVersionsAsync(
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["pkg-a"] = "1.0.0"
+            },
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["pkg-a"] = "1.0.0"
+            },
+            "corr-seed",
+            CancellationToken.None,
+            new Dictionary<string, ActivePackageDescriptor>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["pkg-a"] = new(
+                    "pkg-a",
+                    "1.0.0",
+                    "local-cache",
+                    "desired-source",
+                    packageInstallPath,
+                    DateTimeOffset.UtcNow,
+                    "corr-seed")
+            },
+            activeGraphs);
+
+        return (store, packageInstallPath);
     }
 
     private static async Task StopHostedServicesAsync(ReconciliationHostedService scheduler, ReconciliationTriggerDispatcherHostedService dispatcher)
@@ -362,6 +520,61 @@ public sealed class StartupCycleTests
             }
 
             return Task.FromResult(new ReconciliationRunResult(false, EmptyChangeSet, [], false));
+        }
+    }
+
+    private sealed class RecordingCycleFailureContributor : ICycleFailureContributor
+    {
+        private readonly Dictionary<string, List<string>> _failedPackageIdsByCorrelation = new(StringComparer.OrdinalIgnoreCase);
+
+        public void RecordFailure(string correlationId, string packageId)
+        {
+            if (!_failedPackageIdsByCorrelation.TryGetValue(correlationId, out var packageIds))
+            {
+                packageIds = [];
+                _failedPackageIdsByCorrelation[correlationId] = packageIds;
+            }
+
+            packageIds.Add(packageId);
+        }
+
+        public IReadOnlyList<string> TakeFailedPackageIds(string correlationId)
+        {
+            if (!_failedPackageIdsByCorrelation.Remove(correlationId, out var packageIds))
+            {
+                return [];
+            }
+
+            return packageIds
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .OrderBy(static id => id, StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+        }
+    }
+
+    private sealed class RecordingObserverDispatcher(
+        Action<PackageChangeSet, IReadOnlyList<ResolvedPackage>>? onReconciled = null) : IObserverEventDispatcher
+    {
+        public List<ResolvedPackage> ReconciledPackages { get; } = [];
+
+        public Task PublishChangingAsync(PackageChangeSet changeSet, CancellationToken cancellationToken) => Task.CompletedTask;
+
+        public Task PublishChangedAsync(PackageChangeSet changeSet, CancellationToken cancellationToken) => Task.CompletedTask;
+
+        public Task NotifyPackageFailedAsync(
+            string packageId,
+            Exception exception,
+            string correlationId,
+            CancellationToken cancellationToken) => Task.CompletedTask;
+
+        public Task PublishReconciledAsync(
+            PackageChangeSet changeSet,
+            IReadOnlyList<ResolvedPackage> appliedPackages,
+            CancellationToken cancellationToken)
+        {
+            onReconciled?.Invoke(changeSet, appliedPackages);
+            ReconciledPackages.AddRange(appliedPackages);
+            return Task.CompletedTask;
         }
     }
 

--- a/test/Nuplane.Runtime.Tests/Reconciliation/Middleware/HealthAndMetricsMiddlewareTests.cs
+++ b/test/Nuplane.Runtime.Tests/Reconciliation/Middleware/HealthAndMetricsMiddlewareTests.cs
@@ -1,6 +1,7 @@
 using Nuplane.Abstractions;
 using Nuplane.Events;
 using Nuplane.Health;
+using Nuplane.Hosting;
 using Nuplane.Observability;
 using Nuplane.Reconciliation.Middleware;
 using Nuplane.Reconciliation.Models;
@@ -61,15 +62,30 @@ public sealed class HealthAndMetricsMiddlewareTests
         Assert.False(ctx.Result!.IsDegraded);
     }
 
+    [Fact]
+    public async Task InvokeAsync_HealthyCycle_ClearsStartupRecoveryState()
+    {
+        var changeSet = new PackageChangeSet([], [], [], "test", DateTimeOffset.UtcNow);
+        var startupRecoveryState = new StartupRecoveryState();
+        startupRecoveryState.MarkRecovered("startup-correlation", packageCount: 1);
+
+        var ctx = Ctx(changeSet);
+        await Build(startupRecoveryState: startupRecoveryState).InvokeAsync(ctx, () => Task.CompletedTask);
+
+        Assert.Empty(startupRecoveryState.GetContribution().DegradedReasons);
+    }
+
     private static HealthAndMetricsMiddleware Build(
         IObserverEventDispatcher? dispatcher = null,
-        IReconciliationHealthEvaluator? evaluator = null) =>
+        IReconciliationHealthEvaluator? evaluator = null,
+        StartupRecoveryState? startupRecoveryState = null) =>
         new(evaluator ?? new FakeHealthEvaluator(false),
             dispatcher ?? new NullDispatcher(),
             new NullLogger(),
             new(new()),
             new(), 
-            new());
+            new(),
+            startupRecoveryState: startupRecoveryState);
 
     private static ReconciliationCycleContext Ctx(PackageChangeSet changeSet)
     {


### PR DESCRIPTION
## Summary

Implements `StartupFailurePolicy.UseLastKnownGood` as a real startup recovery path instead of failing host startup unconditionally.

## Changes

- Adds a last-known-good startup recovery service that validates persisted active package state before replaying recovered packages to observers.
- Validates active versions against LKG versions, persisted descriptors, install paths, and active graph node/version consistency.
- Treats recovered package load failures as recovery failures by consuming cycle failure contributors after replay.
- Adds startup recovery operational-state contribution for degraded visibility, and clears it after a later healthy reconciliation cycle.
- Updates startup policy handling and runtime DI registration.
- Adds focused tests for successful LKG recovery, load failure behavior, active/stale graph validation, and recovery-state clearing.

## Validation

- `dotnet test test/Nuplane.Runtime.Tests/Nuplane.Runtime.Tests.csproj --filter "FullyQualifiedName~StartupCycleTests|FullyQualifiedName~HealthAndMetricsMiddlewareTests"`
- `dotnet test test/Nuplane.Runtime.Tests/Nuplane.Runtime.Tests.csproj`
- `dotnet test nuplane.sln`
