### PR TITLE
Add PackageContent for reading files from installed packages

### DIFF
--- a/src/Nuplane/PackageContent.cs
+++ b/src/Nuplane/PackageContent.cs
@@ -1,0 +1,118 @@
+using System.IO.Compression;
+
+namespace Nuplane;
+
+/// <summary>
+/// Reads files shipped inside an installed package's content, transparently handling both extracted install
+/// directories and <c>.nupkg</c> archives. Hosts that need to inspect package-shipped files — manifests,
+/// nuspecs, and similar — should use this rather than re-deriving the on-disk package layout themselves.
+/// </summary>
+public static class PackageContent
+{
+    /// <summary>
+    /// Reads the bytes of a package-relative file (for example <c>"build/my-manifest.json"</c>) from the package
+    /// installed at <paramref name="installPath"/>.
+    /// </summary>
+    /// <param name="installPath">The package install path — either an extracted directory or a <c>.nupkg</c> file.</param>
+    /// <param name="relativePath">The forward-slash or backslash separated path of the file within the package.</param>
+    /// <returns>The file bytes, or <see langword="null"/> when the file does not exist or the content cannot be read.</returns>
+    public static byte[]? TryReadFile(string installPath, string relativePath)
+    {
+        if (string.IsNullOrWhiteSpace(installPath) || string.IsNullOrWhiteSpace(relativePath))
+            return null;
+
+        try
+        {
+            if (Directory.Exists(installPath))
+            {
+                var path = Path.Combine(installPath, ToOsRelativePath(relativePath));
+                return File.Exists(path) ? File.ReadAllBytes(path) : null;
+            }
+
+            if (IsNupkg(installPath) && File.Exists(installPath))
+                return ReadArchiveEntry(installPath, entry => PathsEqual(entry, relativePath));
+
+            return null;
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or InvalidDataException)
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Finds the first file at the package content root whose name ends with <paramref name="extension"/>
+    /// (case-insensitive, for example <c>".nuspec"</c>) and returns its name and bytes.
+    /// </summary>
+    /// <param name="installPath">The package install path — either an extracted directory or a <c>.nupkg</c> file.</param>
+    /// <param name="extension">The file extension to match, including the leading dot.</param>
+    /// <returns>The matching file, or <see langword="null"/> when none exists or the content cannot be read.</returns>
+    public static PackageContentFile? TryFindByExtension(string installPath, string extension)
+    {
+        if (string.IsNullOrWhiteSpace(installPath) || string.IsNullOrWhiteSpace(extension))
+            return null;
+
+        try
+        {
+            if (Directory.Exists(installPath))
+            {
+                var match = Directory
+                    .EnumerateFiles(installPath, "*" + extension, SearchOption.TopDirectoryOnly)
+                    .FirstOrDefault();
+
+                return match is null ? null : new PackageContentFile(Path.GetFileName(match), File.ReadAllBytes(match));
+            }
+
+            if (IsNupkg(installPath) && File.Exists(installPath))
+            {
+                using var stream = File.OpenRead(installPath);
+                using var archive = new ZipArchive(stream, ZipArchiveMode.Read);
+                var entry = archive.Entries.FirstOrDefault(x =>
+                    IsRootEntry(x.FullName) &&
+                    x.FullName.EndsWith(extension, StringComparison.OrdinalIgnoreCase));
+
+                return entry is null ? null : new PackageContentFile(entry.Name, ReadEntry(entry));
+            }
+
+            return null;
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or InvalidDataException)
+        {
+            return null;
+        }
+    }
+
+    private static byte[]? ReadArchiveEntry(string archivePath, Func<string, bool> matches)
+    {
+        using var stream = File.OpenRead(archivePath);
+        using var archive = new ZipArchive(stream, ZipArchiveMode.Read);
+        var entry = archive.Entries.FirstOrDefault(x => matches(x.FullName));
+        return entry is null ? null : ReadEntry(entry);
+    }
+
+    private static byte[] ReadEntry(ZipArchiveEntry entry)
+    {
+        using var entryStream = entry.Open();
+        using var memory = new MemoryStream();
+        entryStream.CopyTo(memory);
+        return memory.ToArray();
+    }
+
+    private static bool IsNupkg(string path) =>
+        string.Equals(Path.GetExtension(path), ".nupkg", StringComparison.OrdinalIgnoreCase);
+
+    private static string ToOsRelativePath(string relativePath) =>
+        Normalize(relativePath).Replace('/', Path.DirectorySeparatorChar);
+
+    private static bool IsRootEntry(string entryFullName) => !Normalize(entryFullName).Contains('/');
+
+    private static bool PathsEqual(string left, string right) =>
+        string.Equals(Normalize(left), Normalize(right), StringComparison.OrdinalIgnoreCase);
+
+    private static string Normalize(string path) => path.Replace('\\', '/').TrimStart('/');
+}
+
+/// <summary>A file read from a package's content: its name and raw bytes.</summary>
+/// <param name="Name">The file name (without directory).</param>
+/// <param name="Content">The file bytes.</param>
+public sealed record PackageContentFile(string Name, byte[] Content);

--- a/test/Nuplane.Runtime.Tests/PackageContentTests.cs
+++ b/test/Nuplane.Runtime.Tests/PackageContentTests.cs
@@ -1,0 +1,99 @@
+using System.IO.Compression;
+using System.Text;
+using Xunit;
+
+namespace Nuplane.Runtime.Tests;
+
+public sealed class PackageContentTests : IDisposable
+{
+    private readonly string _root = Path.Combine(Path.GetTempPath(), $"nuplane-package-content-{Guid.NewGuid():N}");
+
+    public PackageContentTests() => Directory.CreateDirectory(_root);
+
+    [Fact]
+    public void TryReadFile_ReadsRootFileFromExtractedDirectory()
+    {
+        File.WriteAllText(Path.Combine(_root, "manifest.json"), "{\"ok\":true}");
+
+        var bytes = PackageContent.TryReadFile(_root, "manifest.json");
+
+        Assert.Equal("{\"ok\":true}", AsText(bytes));
+    }
+
+    [Fact]
+    public void TryReadFile_ReadsNestedFileUsingForwardOrBackSlashes()
+    {
+        Directory.CreateDirectory(Path.Combine(_root, "build"));
+        File.WriteAllText(Path.Combine(_root, "build", "manifest.json"), "nested");
+
+        Assert.Equal("nested", AsText(PackageContent.TryReadFile(_root, "build/manifest.json")));
+        Assert.Equal("nested", AsText(PackageContent.TryReadFile(_root, "build\\manifest.json")));
+    }
+
+    [Fact]
+    public void TryReadFile_ReturnsNullForMissingFileOrPath()
+    {
+        Assert.Null(PackageContent.TryReadFile(_root, "absent.json"));
+        Assert.Null(PackageContent.TryReadFile(Path.Combine(_root, "does-not-exist"), "manifest.json"));
+        Assert.Null(PackageContent.TryReadFile("", "manifest.json"));
+    }
+
+    [Fact]
+    public void TryReadFile_ReadsEntryFromNupkgArchive()
+    {
+        var nupkg = CreateNupkg(("manifest.json", "from-archive"), ("build/manifest.json", "nested-archive"));
+
+        Assert.Equal("from-archive", AsText(PackageContent.TryReadFile(nupkg, "manifest.json")));
+        Assert.Equal("nested-archive", AsText(PackageContent.TryReadFile(nupkg, "build/manifest.json")));
+        Assert.Null(PackageContent.TryReadFile(nupkg, "missing.json"));
+    }
+
+    [Fact]
+    public void TryFindByExtension_FindsRootFileInDirectory()
+    {
+        File.WriteAllText(Path.Combine(_root, "Acme.Package.nuspec"), "<package/>");
+        Directory.CreateDirectory(Path.Combine(_root, "lib"));
+        File.WriteAllText(Path.Combine(_root, "lib", "ignored.nuspec"), "should not match (not root)");
+
+        var found = PackageContent.TryFindByExtension(_root, ".nuspec");
+
+        Assert.NotNull(found);
+        Assert.Equal("Acme.Package.nuspec", found!.Name);
+        Assert.Equal("<package/>", Encoding.UTF8.GetString(found.Content));
+    }
+
+    [Fact]
+    public void TryFindByExtension_FindsRootEntryInNupkgArchive()
+    {
+        var nupkg = CreateNupkg(("Acme.Package.nuspec", "<archive-nuspec/>"), ("lib/net10.0/Acme.dll", "binary"));
+
+        var found = PackageContent.TryFindByExtension(nupkg, ".nuspec");
+
+        Assert.NotNull(found);
+        Assert.Equal("Acme.Package.nuspec", found!.Name);
+        Assert.Equal("<archive-nuspec/>", Encoding.UTF8.GetString(found.Content));
+    }
+
+    private string CreateNupkg(params (string Path, string Content)[] entries)
+    {
+        var nupkgPath = Path.Combine(_root, $"package-{Guid.NewGuid():N}.nupkg");
+        using var stream = File.Create(nupkgPath);
+        using var archive = new ZipArchive(stream, ZipArchiveMode.Create);
+        foreach (var (path, content) in entries)
+        {
+            var entry = archive.CreateEntry(path);
+            using var writer = new StreamWriter(entry.Open());
+            writer.Write(content);
+        }
+
+        return nupkgPath;
+    }
+
+    private static string? AsText(byte[]? bytes) => bytes is null ? null : Encoding.UTF8.GetString(bytes);
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_root))
+            Directory.Delete(_root, recursive: true);
+    }
+}


### PR DESCRIPTION
## Why

Hosts that inspect package-shipped files (manifests, nuspecs, etc.) currently have to re-derive Nuplane's on-disk package layout themselves — handling extracted install directories vs `.nupkg` archives, root vs nested paths, and path normalization. That layout is Nuplane's concern to own.

## What

Add a public static `Nuplane.PackageContent`:

- `TryReadFile(installPath, relativePath)` — reads a package-relative file's bytes (forward- or back-slash paths), returning `null` when absent.
- `TryFindByExtension(installPath, extension)` — finds the first root-level file with a given extension (e.g. `.nuspec`) and returns its name + bytes.

Both transparently handle **extracted install directories** and **`.nupkg` archives**, and swallow IO/format errors as `null` so a single unreadable package can't throw. Purely additive — no changes to existing types or behaviour.

## Tests

New `PackageContentTests` (6) covering root + nested reads, forward/back slashes, missing paths, `.nupkg` archive reads, and `.nuspec` discovery in both directory and archive layouts. Green locally.