### PR TITLE
Harden PackageContent.TryReadFile against path traversal

### DIFF
--- a/src/Nuplane/PackageContent.cs
+++ b/src/Nuplane/PackageContent.cs
@@ -14,18 +14,32 @@ public static class PackageContent
     /// installed at <paramref name="installPath"/>.
     /// </summary>
     /// <param name="installPath">The package install path — either an extracted directory or a <c>.nupkg</c> file.</param>
-    /// <param name="relativePath">The forward-slash or backslash separated path of the file within the package.</param>
-    /// <returns>The file bytes, or <see langword="null"/> when the file does not exist or the content cannot be read.</returns>
+    /// <param name="relativePath">
+    /// The forward-slash or backslash separated path of the file within the package. Absolute paths and
+    /// <c>..</c> traversal are rejected — only content inside the package can be read.
+    /// </param>
+    /// <returns>The file bytes, or <see langword="null"/> when the file does not exist, escapes the package root, or cannot be read.</returns>
     public static byte[]? TryReadFile(string installPath, string relativePath)
     {
         if (string.IsNullOrWhiteSpace(installPath) || string.IsNullOrWhiteSpace(relativePath))
+            return null;
+
+        // Defense in depth: never let a relative path escape the package root (absolute paths, drive roots,
+        // or ".." traversal). Reading a file "from a package" is only ever a read of content inside it.
+        if (EscapesRoot(relativePath))
             return null;
 
         try
         {
             if (Directory.Exists(installPath))
             {
-                var path = Path.Combine(installPath, ToOsRelativePath(relativePath));
+                var root = Path.GetFullPath(installPath);
+                var path = Path.GetFullPath(Path.Combine(root, ToOsRelativePath(relativePath)));
+
+                // Reject anything that resolves outside the package root even after normalization.
+                if (!path.StartsWith(root + Path.DirectorySeparatorChar, StringComparison.Ordinal))
+                    return null;
+
                 return File.Exists(path) ? File.ReadAllBytes(path) : null;
             }
 
@@ -96,6 +110,13 @@ public static class PackageContent
         using var memory = new MemoryStream();
         entryStream.CopyTo(memory);
         return memory.ToArray();
+    }
+
+    private static bool EscapesRoot(string relativePath)
+    {
+        var normalized = relativePath.Replace('\\', '/');
+        return Path.IsPathRooted(normalized)
+            || normalized.Split('/').Any(segment => segment == "..");
     }
 
     private static bool IsNupkg(string path) =>

--- a/test/Nuplane.Runtime.Tests/PackageContentTests.cs
+++ b/test/Nuplane.Runtime.Tests/PackageContentTests.cs
@@ -49,6 +49,22 @@ public sealed class PackageContentTests : IDisposable
     }
 
     [Fact]
+    public void TryReadFile_RejectsPathTraversalAndAbsolutePaths()
+    {
+        // A secret living next to (outside) the package root must never be reachable via traversal.
+        var secret = Path.Combine(_root, "outside-secret.txt");
+        File.WriteAllText(secret, "top-secret");
+        var packageDir = Path.Combine(_root, "package");
+        Directory.CreateDirectory(packageDir);
+        File.WriteAllText(Path.Combine(packageDir, "manifest.json"), "ok");
+
+        Assert.Equal("ok", AsText(PackageContent.TryReadFile(packageDir, "manifest.json")));
+        Assert.Null(PackageContent.TryReadFile(packageDir, "../outside-secret.txt"));
+        Assert.Null(PackageContent.TryReadFile(packageDir, "..\\outside-secret.txt"));
+        Assert.Null(PackageContent.TryReadFile(packageDir, secret));
+    }
+
+    [Fact]
     public void TryFindByExtension_FindsRootFileInDirectory()
     {
         File.WriteAllText(Path.Combine(_root, "Acme.Package.nuspec"), "<package/>");


### PR DESCRIPTION
Follow-up hardening for `PackageContent` (#50).

`TryReadFile` is public API. A future caller threading an untrusted `relativePath` could read files outside the package via `..` traversal or an absolute path. Every current caller passes a constant, so this is **defense in depth**, not a live vulnerability.

- Reject rooted / `..`-containing relative paths up front.
- For the extracted-directory case, verify the resolved full path stays under the package root after normalization (belt-and-suspenders).
- Returns `null` (deny), consistent with the method's existing contract.

New test covers `..`, `..\`, and absolute-path denial while a sibling file outside the root stays unreachable. Suite green (7 PackageContent tests).