### PR TITLE
Resolve local directory feeds from directory contents

### DIFF
--- a/docs/wiki/Usage-Guide.md
+++ b/docs/wiki/Usage-Guide.md
@@ -80,6 +80,17 @@ This avoids positional array merging when `appsettings.json`, environment variab
 configuration files are layered. Feed object order is not semantic; configure feed priorities
 separately when resolution order matters.
 
+### Directory feeds as an offline package source
+
+A directory feed declared with `DirectoryPath` both contributes desired roots and resolves packages,
+so pre-populating it with the full dependency closure removes the boot-time network dependency —
+useful when baking packages into a container image.
+
+Resolution reads the directory itself: package identifiers are matched case-insensitively and
+versions are matched in normalized form. A `.nupkg` written by `dotnet restore` under a lower-cased
+file name therefore still satisfies a dependency that declares the canonical identifier, including
+on case-sensitive file systems such as those inside Linux containers.
+
 ## Code-driven adoption
 
 - **Applicability:** `Core`

--- a/src/Nuplane/Feeds/LocalDirectoryFeedIndex.cs
+++ b/src/Nuplane/Feeds/LocalDirectoryFeedIndex.cs
@@ -1,0 +1,102 @@
+using NuGet.Versioning;
+
+namespace Nuplane.Feeds;
+
+/// <summary>
+/// A <c>.nupkg</c> file discovered inside a local directory feed.
+/// </summary>
+/// <param name="FilePath">The full path of the package file.</param>
+/// <param name="PackageId">The package identifier exactly as it is spelled in the file name.</param>
+/// <param name="Version">The parsed package version.</param>
+internal readonly record struct LocalDirectoryPackageFile(string FilePath, string PackageId, NuGetVersion Version);
+
+/// <summary>
+/// Locates <c>.nupkg</c> files inside a local directory feed.
+/// Package identifiers are matched case-insensitively and versions by their normalized form, because
+/// NuGet writes restored package files in lower case while nuspec dependencies declare canonical ids.
+/// Composing a file name from the requested identifier would therefore miss packages the directory
+/// demonstrably contains whenever the host runs on a case-sensitive file system, such as inside a
+/// Linux container.
+/// </summary>
+internal static class LocalDirectoryFeedIndex
+{
+    private static readonly EnumerationOptions NupkgEnumerationOptions = new()
+    {
+        MatchCasing = MatchCasing.CaseInsensitive,
+        RecurseSubdirectories = false,
+        IgnoreInaccessible = true,
+    };
+
+    /// <summary>
+    /// Returns every package file in the directory that carries the requested package identifier,
+    /// ordered by version and then by path so selection is deterministic.
+    /// </summary>
+    /// <param name="directoryPath">The local directory feed path.</param>
+    /// <param name="packageId">The requested package identifier, in any casing.</param>
+    public static IReadOnlyList<LocalDirectoryPackageFile> FindPackageFiles(string directoryPath, string packageId)
+    {
+        if (string.IsNullOrWhiteSpace(directoryPath)
+            || string.IsNullOrWhiteSpace(packageId)
+            || !Directory.Exists(directoryPath))
+        {
+            return [];
+        }
+
+        var prefix = packageId + ".";
+        var matches = new List<LocalDirectoryPackageFile>();
+
+        foreach (var filePath in Directory.EnumerateFiles(directoryPath, "*.nupkg", NupkgEnumerationOptions))
+        {
+            var fileName = Path.GetFileNameWithoutExtension(filePath);
+            if (fileName.Length <= prefix.Length
+                || !fileName.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)
+                || !NuGetVersion.TryParse(fileName[prefix.Length..], out var version))
+            {
+                continue;
+            }
+
+            matches.Add(new(filePath, fileName[..packageId.Length], version));
+        }
+
+        return matches
+            .OrderBy(static match => match.Version)
+            .ThenBy(static match => match.FilePath, StringComparer.Ordinal)
+            .ToArray();
+    }
+
+    /// <summary>
+    /// Returns the package file carrying the requested version, or <see langword="null"/> when the
+    /// directory does not contain it.
+    /// </summary>
+    /// <param name="directoryPath">The local directory feed path.</param>
+    /// <param name="packageId">The requested package identifier, in any casing.</param>
+    /// <param name="version">The requested version, in any equivalent form.</param>
+    public static LocalDirectoryPackageFile? FindPackageFile(string directoryPath, string packageId, string version) =>
+        SelectVersion(FindPackageFiles(directoryPath, packageId), version);
+
+    /// <summary>
+    /// Returns the candidate carrying the requested version, comparing versions by their normalized form
+    /// so that equivalent spellings such as <c>1.0</c> and <c>1.0.0</c> match.
+    /// </summary>
+    /// <param name="candidates">The package files to select from.</param>
+    /// <param name="version">The requested version.</param>
+    public static LocalDirectoryPackageFile? SelectVersion(
+        IReadOnlyList<LocalDirectoryPackageFile> candidates,
+        string version)
+    {
+        if (!NuGetVersion.TryParse(version, out var requestedVersion))
+        {
+            return null;
+        }
+
+        foreach (var candidate in candidates)
+        {
+            if (candidate.Version.Equals(requestedVersion))
+            {
+                return candidate;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Nuplane/Feeds/MultiFeedPackageResolver.cs
+++ b/src/Nuplane/Feeds/MultiFeedPackageResolver.cs
@@ -74,13 +74,8 @@ public sealed class MultiFeedPackageResolver : IPackageResolver
         {
             if (IsRemoteFeedDisabled(candidate, request, candidateNames, out var disabledDecision))
             {
-                if (lastFailure is not null)
-                {
-                    disabledDecision = CombineFailureDiagnostics(lastFailure, disabledDecision);
-                }
-
-                lastFailure = disabledDecision;
-                _decisions[request.Id] = disabledDecision;
+                lastFailure = Accumulate(lastFailure, disabledDecision);
+                _decisions[request.Id] = lastFailure;
                 continue;
             }
 
@@ -107,7 +102,7 @@ public sealed class MultiFeedPackageResolver : IPackageResolver
             var selectedVersion = await ResolveVersionAsync(candidate, request, cancellationToken);
             if (!selectedVersion.Success)
             {
-                lastFailure = FeedResolutionDecision.Failed(
+                lastFailure = Accumulate(lastFailure, FeedResolutionDecision.Failed(
                     request,
                     candidateNames,
                     correlationId: string.Empty,
@@ -116,7 +111,7 @@ public sealed class MultiFeedPackageResolver : IPackageResolver
                     failureReason: selectedVersion.FailureReason ?? $"No version matched '{request.VersionRange}'.",
                     selectedFeed: candidate.Name,
                     enumeratedVersionCount: selectedVersion.EnumeratedCount,
-                    cacheHit: selectedVersion.CacheHit);
+                    cacheHit: selectedVersion.CacheHit));
                 _decisions[request.Id] = lastFailure;
                 continue;
             }
@@ -128,7 +123,7 @@ public sealed class MultiFeedPackageResolver : IPackageResolver
             }
             catch (Exception ex) when (ex is not OperationCanceledException)
             {
-                lastFailure = FeedResolutionDecision.Failed(
+                lastFailure = Accumulate(lastFailure, FeedResolutionDecision.Failed(
                     request,
                     candidateNames,
                     correlationId: string.Empty,
@@ -137,7 +132,7 @@ public sealed class MultiFeedPackageResolver : IPackageResolver
                     failureReason: ex.Message,
                     selectedFeed: candidate.Name,
                     enumeratedVersionCount: selectedVersion.EnumeratedCount,
-                    cacheHit: selectedVersion.CacheHit);
+                    cacheHit: selectedVersion.CacheHit));
                 _decisions[request.Id] = lastFailure;
 
                 var shouldStop = _options.PolicyMode == FeedResolutionPolicyMode.Strict
@@ -199,7 +194,8 @@ public sealed class MultiFeedPackageResolver : IPackageResolver
     {
         var versionRequest = NuGetVersionRequestClassifier.Classify(request.VersionRange);
 
-        // Local directory feeds have exact versions already specified in the package request.
+        // Local directory feeds are backed by nupkg files already on disk, so candidate versions
+        // come from the directory itself rather than from a remote version enumeration.
         if (IsLocalDirectoryFeed(feed))
         {
             if (string.IsNullOrWhiteSpace(request.VersionRange))
@@ -209,21 +205,47 @@ public sealed class MultiFeedPackageResolver : IPackageResolver
                     $"Local directory feed '{feed.Name}' requires an explicit version for package '{request.Id}'; empty or whitespace version ranges are not supported.");
             }
 
+            var feedDirectoryPath = feed.ServiceIndex.LocalPath;
+            var packageFiles = LocalDirectoryFeedIndex.FindPackageFiles(feedDirectoryPath, request.Id);
+
             if (versionRequest.IsExact)
             {
-                var nupkgPath = GetLocalNupkgPath(feed, request.Id, versionRequest.ExactVersion!);
-                if (!File.Exists(nupkgPath))
+                var exactMatch = LocalDirectoryFeedIndex.SelectVersion(packageFiles, versionRequest.ExactVersion!);
+                if (exactMatch is null)
                 {
                     return VersionSelection.Failed(
                         "exact-local-cache-miss",
-                        $"Exact package '{request.Id}' version '{versionRequest.ExactVersion}' was not found in local directory feed '{feed.Name}'.");
+                        $"Exact package '{request.Id}' version '{versionRequest.ExactVersion}' was not found in local directory feed '{feed.Name}' at '{feedDirectoryPath}'.",
+                        packageFiles.Count,
+                        cacheHit: true);
                 }
 
-                return VersionSelection.Succeeded(versionRequest.ExactVersion!, 0, cacheHit: true, "exact-local-cache-hit");
+                return VersionSelection.Succeeded(
+                    exactMatch.Value.Version.ToNormalizedString(),
+                    packageFiles.Count,
+                    cacheHit: true,
+                    "exact-local-cache-hit");
             }
 
-            var localVersion = NuGetVersionRangeParser.SelectVersion(request.VersionRange);
-            return VersionSelection.Succeeded(localVersion, 0, cacheHit: false);
+            var localVersions = packageFiles.Select(static file => file.Version.ToNormalizedString()).ToArray();
+            var localResult = IsDependencyRequest(request)
+                ? SelectLowestDependencyMatch(request.VersionRange, localVersions)
+                : _versionRangeEvaluator.SelectBestMatch(request.VersionRange, localVersions);
+
+            if (!localResult.Success)
+            {
+                return VersionSelection.Failed(
+                    "local-directory-version-no-match",
+                    $"No version of package '{request.Id}' matching '{request.VersionRange}' was found in local directory feed '{feed.Name}' at '{feedDirectoryPath}': {localResult.FailureReason}",
+                    localResult.CandidateCount,
+                    cacheHit: true);
+            }
+
+            return VersionSelection.Succeeded(
+                localResult.SelectedVersion!,
+                localResult.CandidateCount,
+                cacheHit: true,
+                "local-directory-version-match");
         }
 
         if (versionRequest.IsExact)
@@ -325,17 +347,21 @@ public sealed class MultiFeedPackageResolver : IPackageResolver
         }
 
         var feedDirectoryPath = feed.ServiceIndex.LocalPath;
-        var nupkgPath = GetLocalNupkgPath(feed, packageId, version);
+        var packageFile = LocalDirectoryFeedIndex.FindPackageFile(feedDirectoryPath, packageId, version);
 
-        if (!File.Exists(nupkgPath))
+        if (packageFile is null)
         {
-            var nupkgFileName = Path.GetFileName(nupkgPath);
+            var nupkgFileName = $"{packageId}.{version}.nupkg";
             throw new FileNotFoundException(
                 $"Expected nupkg '{nupkgFileName}' was not found in local directory feed '{feed.Name}' at '{feedDirectoryPath}'.",
-                nupkgPath);
+                Path.Combine(feedDirectoryPath, nupkgFileName));
         }
 
-        var installDir = Path.Combine(feedDirectoryPath, ".installed", packageId, version);
+        var nupkgPath = packageFile.Value.FilePath;
+
+        // Key the install directory off the identifier as spelled on disk so that requests for the
+        // same package under different casing share one extraction.
+        var installDir = Path.Combine(feedDirectoryPath, ".installed", packageFile.Value.PackageId, version);
         var completionMarkerPath = Path.Combine(installDir, ".nuplane-ready");
 
         if (!File.Exists(completionMarkerPath))
@@ -355,9 +381,6 @@ public sealed class MultiFeedPackageResolver : IPackageResolver
 
     private static bool IsLocalDirectoryFeed(FeedDefinition feed) =>
         feed.ServiceIndex.Scheme.Equals("file", StringComparison.OrdinalIgnoreCase);
-
-    private static string GetLocalNupkgPath(FeedDefinition feed, string packageId, string version) =>
-        Path.Combine(feed.ServiceIndex.LocalPath, $"{packageId}.{version}.nupkg");
 
     private bool IsRemoteFeedDisabled(
         FeedDefinition feed,
@@ -395,6 +418,13 @@ public sealed class MultiFeedPackageResolver : IPackageResolver
 
         return true;
     }
+
+    /// <summary>
+    /// Folds a candidate failure into the running failure so the final diagnostic names every feed
+    /// that was tried, instead of only the one that happened to be tried last.
+    /// </summary>
+    private static FeedResolutionDecision Accumulate(FeedResolutionDecision? previous, FeedResolutionDecision current) =>
+        previous is null ? current : CombineFailureDiagnostics(previous, current);
 
     private static FeedResolutionDecision CombineFailureDiagnostics(
         FeedResolutionDecision previous,

--- a/src/Nuplane/Feeds/MultiFeedPackageResolver.cs
+++ b/src/Nuplane/Feeds/MultiFeedPackageResolver.cs
@@ -69,12 +69,13 @@ public sealed class MultiFeedPackageResolver : IPackageResolver
         var candidates = _policy.OrderCandidates(request);
         var candidateNames = candidates.Select(x => x.Name).ToArray();
         FeedResolutionDecision? lastFailure = null;
+        var seenFailureKeys = new HashSet<string>(StringComparer.Ordinal);
 
         foreach (var candidate in candidates)
         {
             if (IsRemoteFeedDisabled(candidate, request, candidateNames, out var disabledDecision))
             {
-                lastFailure = Accumulate(lastFailure, disabledDecision);
+                lastFailure = Accumulate(lastFailure, disabledDecision, seenFailureKeys);
                 _decisions[request.Id] = lastFailure;
                 continue;
             }
@@ -111,7 +112,7 @@ public sealed class MultiFeedPackageResolver : IPackageResolver
                     failureReason: selectedVersion.FailureReason ?? $"No version matched '{request.VersionRange}'.",
                     selectedFeed: candidate.Name,
                     enumeratedVersionCount: selectedVersion.EnumeratedCount,
-                    cacheHit: selectedVersion.CacheHit));
+                    cacheHit: selectedVersion.CacheHit), seenFailureKeys);
                 _decisions[request.Id] = lastFailure;
                 continue;
             }
@@ -132,7 +133,7 @@ public sealed class MultiFeedPackageResolver : IPackageResolver
                     failureReason: ex.Message,
                     selectedFeed: candidate.Name,
                     enumeratedVersionCount: selectedVersion.EnumeratedCount,
-                    cacheHit: selectedVersion.CacheHit));
+                    cacheHit: selectedVersion.CacheHit), seenFailureKeys);
                 _decisions[request.Id] = lastFailure;
 
                 var shouldStop = _options.PolicyMode == FeedResolutionPolicyMode.Strict
@@ -422,19 +423,28 @@ public sealed class MultiFeedPackageResolver : IPackageResolver
     /// <summary>
     /// Folds a candidate failure into the running failure so the final diagnostic names every feed
     /// that was tried, instead of only the one that happened to be tried last.
+    /// Deduplication is keyed by <c>(DecisionPath, FailureReason)</c> so that identical policy-wide
+    /// diagnostics (e.g. offline-mode applied to every remote feed) are collapsed into one entry
+    /// while feed-specific failures that share a decision path but differ in reason are all preserved.
     /// </summary>
-    private static FeedResolutionDecision Accumulate(FeedResolutionDecision? previous, FeedResolutionDecision current) =>
-        previous is null ? current : CombineFailureDiagnostics(previous, current);
+    private static FeedResolutionDecision Accumulate(
+        FeedResolutionDecision? previous,
+        FeedResolutionDecision current,
+        HashSet<string> seenKeys)
+    {
+        var key = $"{current.DecisionPath}\x1f{current.FailureReason}";
+        if (!seenKeys.Add(key))
+        {
+            return previous!;
+        }
+
+        return previous is null ? current : CombineFailureDiagnostics(previous, current);
+    }
 
     private static FeedResolutionDecision CombineFailureDiagnostics(
         FeedResolutionDecision previous,
         FeedResolutionDecision current)
     {
-        if (previous.DecisionPath.Split('+').Contains(current.DecisionPath, StringComparer.Ordinal))
-        {
-            return previous;
-        }
-
         return current with
         {
             DecisionPath = $"{previous.DecisionPath}+{current.DecisionPath}",

--- a/src/Nuplane/Feeds/MultiFeedPackageResolver.cs
+++ b/src/Nuplane/Feeds/MultiFeedPackageResolver.cs
@@ -114,13 +114,24 @@ public sealed class MultiFeedPackageResolver : IPackageResolver
                     enumeratedVersionCount: selectedVersion.EnumeratedCount,
                     cacheHit: selectedVersion.CacheHit), seenFailureKeys);
                 _decisions[request.Id] = lastFailure;
+
+                if (ShouldStopAfterCandidateFailure(request))
+                {
+                    break;
+                }
+
                 continue;
             }
 
             string installPath;
             try
             {
-                installPath = await ResolveInstallPathAsync(candidate, request.Id, selectedVersion.Version!, cancellationToken);
+                installPath = await ResolveInstallPathAsync(
+                    candidate,
+                    request.Id,
+                    selectedVersion.Version!,
+                    selectedVersion.LocalPackageFile,
+                    cancellationToken);
             }
             catch (Exception ex) when (ex is not OperationCanceledException)
             {
@@ -136,10 +147,7 @@ public sealed class MultiFeedPackageResolver : IPackageResolver
                     cacheHit: selectedVersion.CacheHit), seenFailureKeys);
                 _decisions[request.Id] = lastFailure;
 
-                var shouldStop = _options.PolicyMode == FeedResolutionPolicyMode.Strict
-                    || _options.StopOnFirstSuccessfulFeed
-                    || !string.IsNullOrWhiteSpace(request.FeedName);
-                if (shouldStop)
+                if (ShouldStopAfterCandidateFailure(request))
                 {
                     throw;
                 }
@@ -185,7 +193,8 @@ public sealed class MultiFeedPackageResolver : IPackageResolver
 
     /// <summary>
     /// Resolves the concrete version for a package from the specified feed.
-    /// For local directory feeds, the version is extracted from the request's range directly.
+    /// For local directory feeds, candidate versions are read from the nupkg files present in the
+    /// directory and the match is carried forward so acquisition does not have to locate it again.
     /// For remote feeds, version enumeration and range evaluation are used.
     /// </summary>
     private async Task<VersionSelection> ResolveVersionAsync(
@@ -217,15 +226,15 @@ public sealed class MultiFeedPackageResolver : IPackageResolver
                     return VersionSelection.Failed(
                         "exact-local-cache-miss",
                         $"Exact package '{request.Id}' version '{versionRequest.ExactVersion}' was not found in local directory feed '{feed.Name}' at '{feedDirectoryPath}'.",
-                        packageFiles.Count,
-                        cacheHit: true);
+                        packageFiles.Count);
                 }
 
                 return VersionSelection.Succeeded(
                     exactMatch.Value.Version.ToNormalizedString(),
                     packageFiles.Count,
                     cacheHit: true,
-                    "exact-local-cache-hit");
+                    "exact-local-cache-hit",
+                    exactMatch);
             }
 
             var localVersions = packageFiles.Select(static file => file.Version.ToNormalizedString()).ToArray();
@@ -238,15 +247,15 @@ public sealed class MultiFeedPackageResolver : IPackageResolver
                 return VersionSelection.Failed(
                     "local-directory-version-no-match",
                     $"No version of package '{request.Id}' matching '{request.VersionRange}' was found in local directory feed '{feed.Name}' at '{feedDirectoryPath}': {localResult.FailureReason}",
-                    localResult.CandidateCount,
-                    cacheHit: true);
+                    localResult.CandidateCount);
             }
 
             return VersionSelection.Succeeded(
                 localResult.SelectedVersion!,
                 localResult.CandidateCount,
                 cacheHit: true,
-                "local-directory-version-match");
+                "local-directory-version-match",
+                LocalDirectoryFeedIndex.SelectVersion(packageFiles, localResult.SelectedVersion!));
         }
 
         if (versionRequest.IsExact)
@@ -322,14 +331,16 @@ public sealed class MultiFeedPackageResolver : IPackageResolver
         int EnumeratedCount,
         bool CacheHit,
         string? FailureReason,
-        string DecisionPath)
+        string DecisionPath,
+        LocalDirectoryPackageFile? LocalPackageFile = null)
     {
         public static VersionSelection Succeeded(
             string version,
             int enumeratedCount,
             bool cacheHit,
-            string decisionPath = "ordered-candidate-success") =>
-            new(true, version, enumeratedCount, cacheHit, null, decisionPath);
+            string decisionPath = "ordered-candidate-success",
+            LocalDirectoryPackageFile? localPackageFile = null) =>
+            new(true, version, enumeratedCount, cacheHit, null, decisionPath, localPackageFile);
 
         public static VersionSelection Failed(string decisionPath, string? failureReason, int enumeratedCount = 0, bool cacheHit = false) =>
             new(false, null, enumeratedCount, cacheHit, failureReason, decisionPath);
@@ -340,7 +351,17 @@ public sealed class MultiFeedPackageResolver : IPackageResolver
     /// Local directory feeds extract the <c>.nupkg</c> into a stable install directory;
     /// remote feeds are downloaded and extracted via the configured remote package acquirer.
     /// </summary>
-    private async Task<string> ResolveInstallPathAsync(FeedDefinition feed, string packageId, string version, CancellationToken cancellationToken)
+    /// <param name="feed">The feed the package was resolved from.</param>
+    /// <param name="packageId">The requested package identifier.</param>
+    /// <param name="version">The resolved concrete version.</param>
+    /// <param name="localPackageFile">The package file already located during version selection, when the feed is a local directory.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    private async Task<string> ResolveInstallPathAsync(
+        FeedDefinition feed,
+        string packageId,
+        string version,
+        LocalDirectoryPackageFile? localPackageFile,
+        CancellationToken cancellationToken)
     {
         if (!IsLocalDirectoryFeed(feed))
         {
@@ -348,7 +369,8 @@ public sealed class MultiFeedPackageResolver : IPackageResolver
         }
 
         var feedDirectoryPath = feed.ServiceIndex.LocalPath;
-        var packageFile = LocalDirectoryFeedIndex.FindPackageFile(feedDirectoryPath, packageId, version);
+        var packageFile = localPackageFile
+            ?? LocalDirectoryFeedIndex.FindPackageFile(feedDirectoryPath, packageId, version);
 
         if (packageFile is null)
         {
@@ -419,6 +441,16 @@ public sealed class MultiFeedPackageResolver : IPackageResolver
 
         return true;
     }
+
+    /// <summary>
+    /// Determines whether a failed candidate ends resolution instead of falling through to the next
+    /// feed. Strict mode and <see cref="FeedResolutionOptions.StopOnFirstSuccessfulFeed"/> both forbid
+    /// fallback, and an explicitly requested feed has no other candidate to fall back to.
+    /// </summary>
+    private bool ShouldStopAfterCandidateFailure(PackageRequest request) =>
+        _options.PolicyMode == FeedResolutionPolicyMode.Strict
+        || _options.StopOnFirstSuccessfulFeed
+        || !string.IsNullOrWhiteSpace(request.FeedName);
 
     /// <summary>
     /// Folds a candidate failure into the running failure so the final diagnostic names every feed

--- a/test/Nuplane.Runtime.Tests/Feeds/MultiFeedPackageResolverTests.cs
+++ b/test/Nuplane.Runtime.Tests/Feeds/MultiFeedPackageResolverTests.cs
@@ -307,6 +307,36 @@ public sealed class MultiFeedPackageResolverTests
     }
 
     [Fact]
+    public async Task ResolveAsync_TwoLocalFeedsMissSameDecisionPath_BothFeedsNamedInFailureReason()
+    {
+        using var localPackages1 = new TempDirectory();
+        using var localPackages2 = new TempDirectory();
+        var options = new FeedResolutionOptions();
+        options.Feeds.Add(new("local-a", new Uri(localPackages1.Path + Path.DirectorySeparatorChar)));
+        options.Feeds.Add(new("local-b", new Uri(localPackages2.Path + Path.DirectorySeparatorChar)));
+        var wrappedOptions = new OptionsWrapper<FeedResolutionOptions>(options);
+        var policy = new FeedResolutionPolicy(wrappedOptions);
+
+        var resolver = new MultiFeedPackageResolver(
+            wrappedOptions,
+            policy,
+            Substitute.For<IRemotePackageAcquirer>(),
+            Substitute.For<IFeedVersionEnumerator>(),
+            Substitute.For<IVersionRangeEvaluator>(),
+            NullLogger<MultiFeedPackageResolver>.Instance);
+
+        var request = new PackageRequest("MyPlugin", "[2.0.0]", null, PackageUpdatePolicy.Exact, "source");
+
+        await Assert.ThrowsAsync<NoEligibleFeedException>(
+            () => resolver.ResolveAsync(request, CancellationToken.None));
+
+        Assert.True(resolver.TryGetDecision("MyPlugin", out var decision));
+        Assert.Equal("exact-local-cache-miss+exact-local-cache-miss", decision.DecisionPath);
+        Assert.Contains("local-a", decision.FailureReason);
+        Assert.Contains("local-b", decision.FailureReason);
+    }
+
+    [Fact]
     public async Task ResolveAsync_Range_RemoteStillEnumeratesVersions()
     {
         var options = new FeedResolutionOptions();

--- a/test/Nuplane.Runtime.Tests/Reconciliation/LocalDirectoryFeedContractTests.cs
+++ b/test/Nuplane.Runtime.Tests/Reconciliation/LocalDirectoryFeedContractTests.cs
@@ -29,22 +29,32 @@ public sealed class LocalDirectoryFeedContractTests : IDisposable
         }
     }
 
+    private FeedResolutionOptions CreateLocalFeedOptions()
+    {
+        var options = new FeedResolutionOptions();
+        options.Feeds.Add(new("local-drop", new("file:///" + _tempDir.Replace('\\', '/').TrimStart('/'))));
+        return options;
+    }
+
+    private static MultiFeedPackageResolver CreateResolver(
+        FeedResolutionOptions options,
+        IFeedVersionEnumerator? versionEnumerator = null)
+    {
+        var wrappedOptions = new OptionsWrapper<FeedResolutionOptions>(options);
+        return new(
+            wrappedOptions,
+            new FeedResolutionPolicy(wrappedOptions),
+            Substitute.For<IRemotePackageAcquirer>(),
+            versionEnumerator ?? Substitute.For<IFeedVersionEnumerator>(),
+            Substitute.For<IVersionRangeEvaluator>(),
+            NullLogger<MultiFeedPackageResolver>.Instance);
+    }
+
     [Fact]
     public async Task Resolve_WithOnlyLocalFeed_Succeeds()
     {
         NupkgTestBuilder.Create("MyPlugin", "1.0.0").BuildTo(_tempDir);
-
-        var feedUri = new Uri("file:///" + _tempDir.Replace('\\', '/').TrimStart('/'));
-        var localFeed = new FeedDefinition("local-drop", feedUri);
-        var opts = new FeedResolutionOptions();
-        opts.Feeds.Add(localFeed);
-        var policy = new FeedResolutionPolicy(new OptionsWrapper<FeedResolutionOptions>(opts));
-        var resolver = new MultiFeedPackageResolver(
-            new OptionsWrapper<FeedResolutionOptions>(opts), policy,
-            Substitute.For<IRemotePackageAcquirer>(),
-            Substitute.For<IFeedVersionEnumerator>(),
-            Substitute.For<IVersionRangeEvaluator>(),
-            NullLogger<MultiFeedPackageResolver>.Instance);
+        var resolver = CreateResolver(CreateLocalFeedOptions());
 
         var request = new PackageRequest("MyPlugin", "1.0.0", "local-drop", PackageUpdatePolicy.Exact, "local-source");
         var result = await resolver.ResolveAsync(request, CancellationToken.None);
@@ -58,18 +68,7 @@ public sealed class LocalDirectoryFeedContractTests : IDisposable
     public async Task Resolve_WithLocalFeedOnly_NoExplicitFeedNameOnRequest_StillResolvesViaPriority()
     {
         NupkgTestBuilder.Create("MyPlugin", "1.0.0").BuildTo(_tempDir);
-
-        var feedUri = new Uri("file:///" + _tempDir.Replace('\\', '/').TrimStart('/'));
-        var localFeed = new FeedDefinition("local-drop", feedUri);
-        var opts = new FeedResolutionOptions();
-        opts.Feeds.Add(localFeed);
-        var policy = new FeedResolutionPolicy(new OptionsWrapper<FeedResolutionOptions>(opts));
-        var resolver = new MultiFeedPackageResolver(
-            new OptionsWrapper<FeedResolutionOptions>(opts), policy,
-            Substitute.For<IRemotePackageAcquirer>(),
-            Substitute.For<IFeedVersionEnumerator>(),
-            Substitute.For<IVersionRangeEvaluator>(),
-            NullLogger<MultiFeedPackageResolver>.Instance);
+        var resolver = CreateResolver(CreateLocalFeedOptions());
 
         // No explicit feed name; resolution should still find the local feed via priority ordering
         var request = new PackageRequest("MyPlugin", "1.0.0", FeedName: null, PackageUpdatePolicy.Exact, "local-source");
@@ -109,16 +108,88 @@ public sealed class LocalDirectoryFeedContractTests : IDisposable
 
 
     [Fact]
+    public async Task Resolve_ExactVersion_WhenNupkgFileNameCasingDiffers_ResolvesFromLocalFeed()
+    {
+        // Restore writes lower-cased file names; nuspec dependencies declare canonical ids.
+        NupkgTestBuilder.Create("sourcegear.sqlite3", "1.0.0").BuildTo(_tempDir);
+        var resolver = CreateResolver(CreateLocalFeedOptions());
+
+        var request = new PackageRequest("SourceGear.sqlite3", "1.0.0", FeedName: null, PackageUpdatePolicy.Exact, "local-source");
+        var result = await resolver.ResolveAsync(request, CancellationToken.None);
+
+        Assert.Equal("local-drop", result.FeedName);
+        Assert.Equal("1.0.0", result.Version);
+        Assert.True(Directory.Exists(result.InstallPath), $"Install path '{result.InstallPath}' should exist on disk.");
+        Assert.Equal(
+            Path.Combine(_tempDir, ".installed", "sourcegear.sqlite3", "1.0.0"),
+            result.InstallPath);
+    }
+
+    [Fact]
+    public async Task Resolve_DependencyRange_SelectsVersionPresentInDirectory()
+    {
+        // The directory holds 1.2.0 while the dependency asks for "1.0.0 or newer"; the lower bound
+        // of the range is not on disk, so the version must come from the directory contents.
+        NupkgTestBuilder.Create("MyPlugin", "1.2.0").BuildTo(_tempDir);
+        var resolver = CreateResolver(CreateLocalFeedOptions());
+
+        var request = new PackageRequest("MyPlugin", "[1.0.0, )", FeedName: null, PackageUpdatePolicy.Exact, "dependency-of:MyRoot");
+        var result = await resolver.ResolveAsync(request, CancellationToken.None);
+
+        Assert.Equal("local-drop", result.FeedName);
+        Assert.Equal("1.2.0", result.Version);
+        Assert.True(Directory.Exists(result.InstallPath), $"Install path '{result.InstallPath}' should exist on disk.");
+    }
+
+    [Fact]
+    public async Task Resolve_DependencyRange_WithUnreachableRemoteFeed_ResolvesFromLocalFeed()
+    {
+        NupkgTestBuilder.Create("sourcegear.sqlite3", "1.0.0").BuildTo(_tempDir);
+
+        var options = CreateLocalFeedOptions();
+        options.Feeds.Add(new("nuget.org", new("https://api.nuget.org/v3/index.json")));
+        var enumerator = Substitute.For<IFeedVersionEnumerator>();
+        enumerator.EnumerateVersionsAsync(Arg.Any<FeedDefinition>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns<Task<PackageVersionList>>(_ => throw new InvalidOperationException(
+                "Unable to load the service index for source https://api.nuget.org/v3/index.json."));
+        var resolver = CreateResolver(options, enumerator);
+
+        var request = new PackageRequest("SourceGear.sqlite3", "[1.0.0, )", FeedName: null, PackageUpdatePolicy.Exact, "dependency-of:MyRoot");
+        var result = await resolver.ResolveAsync(request, CancellationToken.None);
+
+        Assert.Equal("local-drop", result.FeedName);
+        Assert.Equal("1.0.0", result.Version);
+        await enumerator.DidNotReceiveWithAnyArgs().EnumerateVersionsAsync(default!, default!, default);
+    }
+
+    [Fact]
+    public async Task Resolve_WhenLocalFeedMissesAndRemoteFeedFails_FailureNamesBothFeeds()
+    {
+        NupkgTestBuilder.Create("OtherPlugin", "1.0.0").BuildTo(_tempDir);
+
+        var options = CreateLocalFeedOptions();
+        options.Feeds.Add(new("nuget.org", new("https://api.nuget.org/v3/index.json")));
+        var enumerator = Substitute.For<IFeedVersionEnumerator>();
+        enumerator.EnumerateVersionsAsync(Arg.Any<FeedDefinition>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns<Task<PackageVersionList>>(_ => throw new InvalidOperationException("Unable to load the service index."));
+        var resolver = CreateResolver(options, enumerator);
+
+        var request = new PackageRequest("MyPlugin", "[1.0.0, )", FeedName: null, PackageUpdatePolicy.Exact, "dependency-of:MyRoot");
+
+        var exception = await Assert.ThrowsAsync<NoEligibleFeedException>(
+            () => resolver.ResolveAsync(request, CancellationToken.None));
+
+        Assert.Contains("local-drop", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("nuget.org", exception.Message, StringComparison.Ordinal);
+        Assert.True(resolver.TryGetDecision("MyPlugin", out var decision));
+        Assert.Contains("local-directory-version-no-match", decision.DecisionPath, StringComparison.Ordinal);
+        Assert.Contains("version-enumeration-error", decision.DecisionPath, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public async Task Resolve_WithNoFeeds_ThrowsForNoEligibleFeed()
     {
-        var opts = new FeedResolutionOptions();
-        var policy = new FeedResolutionPolicy(new OptionsWrapper<FeedResolutionOptions>(opts));
-        var resolver = new MultiFeedPackageResolver(
-            new OptionsWrapper<FeedResolutionOptions>(opts), policy,
-            Substitute.For<IRemotePackageAcquirer>(),
-            Substitute.For<IFeedVersionEnumerator>(),
-            Substitute.For<IVersionRangeEvaluator>(),
-            NullLogger<MultiFeedPackageResolver>.Instance);
+        var resolver = CreateResolver(new FeedResolutionOptions());
 
         var request = new PackageRequest("MyPlugin", "1.0.0", FeedName: null, PackageUpdatePolicy.Exact, "local-source");
 


### PR DESCRIPTION
Fixes #52.

## Root cause

The issue title's hypothesis does not hold: the directory feed **is** registered for resolution inside the container (`DirectoryFeedRole` defaults to `DesiredAndCache`, and `DirectorySourceRegistrationServices.RegisterFeed` adds it to `FeedResolutionOptions.Feeds`). It is consulted — and it misses.

`MultiFeedPackageResolver` located a local feed's package by *composing* a file name from the requested id: `Path.Combine(feedDir, $"{packageId}.{version}.nupkg")`, then `File.Exists`. Two things break that inside a container:

1. **Casing.** `dotnet restore` writes lower-cased file names (`sourcegear.sqlite3.…nupkg`), while dependency requests carry the canonical id from the parent's `.nuspec` (`SourceGear.sqlite3` — note the capitals in the reported error, which is how a dependency request is distinguishable from a directory-derived root). On macOS/Windows the composed path still matches; on the container's case-sensitive filesystem it does not. That is exactly the works-outside/fails-inside split, and it survives a cold NuGet cache and absolute paths, as the reporter observed.
2. **Versions.** Dependency ranges are normalized to `[10.0.9,)`, which is not "exact", so the old code took the range's *lower bound* as the version without ever consulting the directory. A directory holding `10.0.10` could not satisfy `[10.0.9,)` regardless of casing.

Both misses fall through to `nuget.org`, which is unreachable, so every root fails.

The two supporting observations in the issue are symptoms, not causes:

- `grep -c "Directory watcher enabled"` is 0 because `NuplaneStartupHostedService` is registered in `RegisterRuntime()` — before the builder callback adds the watcher services. Startup reconciliation throws, host startup aborts, and the watcher never starts.
- Only `nuget.org` was ever named because `lastFailure` was overwritten per candidate, so the final exception reported only the feed tried last. The local feed's `exact-local-cache-miss` was discarded.

## Changes

- **New `LocalDirectoryFeedIndex`** — reads the feed directory and matches package ids case-insensitively and versions in normalized form, returning the file that is actually on disk.
- **`MultiFeedPackageResolver`** — local feeds now take their candidate versions from the directory contents. Exact requests match through the index; range requests go through the same lowest-for-dependency / best-match selection used for remote feeds. Acquisition uses the real file path, and `.installed/` is keyed off the on-disk id so differently-cased requests share one extraction.
- **Failure diagnostics** — candidate failures are accumulated, so `NoEligibleFeedException` names every feed tried with its own reason instead of just the last one.
- **Docs** — short subsection in `docs/wiki/Usage-Guide.md` on using a directory feed as an offline package source.

## Verification

Four regression tests in `LocalDirectoryFeedContractTests`, including a dependency-range resolve against a local feed with an unreachable remote feed. Three of them fail against the unpatched resolver on macOS; the fourth only fails on a case-sensitive filesystem (APFS masks the casing bug) and is kept as a Linux/CI guard.

Full solution: **748 passed, 0 failed**. Solution builds clean across `net8.0;net9.0;net10.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)