### PR TITLE
Stop scheduled reconciliation cycles from failing inert graph members

### DIFF
--- a/src/Nuplane.Loading.Abstractions/IPackageLoader.cs
+++ b/src/Nuplane.Loading.Abstractions/IPackageLoader.cs
@@ -41,6 +41,16 @@ internal interface IPackageLoader
     bool TryRemoveContext(string packageId, string version, out PackageLoadContextHandle? context);
 
     /// <summary>
+    /// Determines whether a package version was already evaluated by the loader and deliberately not loaded
+    /// because it contributes no assemblies, either because it contains none (facade/native support packages)
+    /// or because the host runtime already provides them.
+    /// </summary>
+    /// <param name="packageId">The package identifier.</param>
+    /// <param name="version">The package version.</param>
+    /// <returns><see langword="true"/> if the package version is a known inert graph member; otherwise <see langword="false"/>.</returns>
+    bool IsInertPackage(string packageId, string version);
+
+    /// <summary>
     /// Attempts to get the active assembly load context for a specific package version without removing it.
     /// </summary>
     /// <param name="packageId">The package identifier.</param>

--- a/src/Nuplane.Loading.Abstractions/IPackageLoader.cs
+++ b/src/Nuplane.Loading.Abstractions/IPackageLoader.cs
@@ -47,7 +47,10 @@ internal interface IPackageLoader
     /// </summary>
     /// <param name="packageId">The package identifier.</param>
     /// <param name="version">The package version.</param>
-    /// <returns><see langword="true"/> if the package version is a known inert graph member; otherwise <see langword="false"/>.</returns>
+    /// <returns>
+    /// <see langword="true"/> if the package version is a known inert graph member; otherwise <see langword="false"/>.
+    /// Implementations must be total so that read surfaces can query unknown or malformed identities safely.
+    /// </returns>
     bool IsInertPackage(string packageId, string version);
 
     /// <summary>

--- a/src/Nuplane.Loading.Abstractions/LoadingStatus.cs
+++ b/src/Nuplane.Loading.Abstractions/LoadingStatus.cs
@@ -23,6 +23,11 @@ internal enum LoadingStatus
     /// <summary>
     /// The package failed to load for the current process.
     /// </summary>
-    Failed
+    Failed,
+
+    /// <summary>
+    /// The package was evaluated and deliberately not loaded because it contributes no assemblies.
+    /// </summary>
+    Skipped
 }
 

--- a/src/Nuplane.Loading.Abstractions/PackageLoadState.cs
+++ b/src/Nuplane.Loading.Abstractions/PackageLoadState.cs
@@ -46,6 +46,7 @@ public sealed record PackageLoadState(
                 LoadingStatus.Stale => PackageLoadStatus.Stale,
                 LoadingStatus.Loaded => PackageLoadStatus.Loaded,
                 LoadingStatus.Failed => PackageLoadStatus.Failed,
+                LoadingStatus.Skipped => PackageLoadStatus.Skipped,
                 _ => throw new ArgumentOutOfRangeException(nameof(descriptor))
             },
             descriptor.ActiveInstallPath,

--- a/src/Nuplane.Loading.Abstractions/PackageLoadStatus.cs
+++ b/src/Nuplane.Loading.Abstractions/PackageLoadStatus.cs
@@ -23,6 +23,13 @@ public enum PackageLoadStatus
     /// <summary>
     /// The package failed to load for the current process.
     /// </summary>
-    Failed
+    Failed,
+
+    /// <summary>
+    /// The package was evaluated for the current process and deliberately not loaded because it
+    /// contributes no assemblies, either because it contains none (facade/native support packages)
+    /// or because the host runtime already provides them. This is a settled state, not a failure.
+    /// </summary>
+    Skipped
 }
 

--- a/src/Nuplane.Loading/LoadingCatalog.cs
+++ b/src/Nuplane.Loading/LoadingCatalog.cs
@@ -90,6 +90,14 @@ internal sealed class LoadingCatalog(
                 continue;
             }
 
+            if (_packageLoader.IsInertPackage(package.PackageId, package.Version))
+            {
+                // Evaluated and deliberately not loaded because it contributes no assemblies. This is a
+                // settled outcome, not missing state, so it must not read as stale or degrade the surface.
+                descriptors.Add(CreateDescriptor(package, PackageLoadStatus.Skipped, null, ["loading-no-assemblies-to-load"], []));
+                continue;
+            }
+
             staleCount++;
             descriptors.Add(CreateDescriptor(package, PackageLoadStatus.Stale, null, ["loading-state-missing-for-active-package"], []));
         }
@@ -135,6 +143,7 @@ internal sealed class LoadingCatalog(
                     PackageLoadStatus.Stale => LoadingStatus.Stale,
                     PackageLoadStatus.Loaded => LoadingStatus.Loaded,
                     PackageLoadStatus.Failed => LoadingStatus.Failed,
+                    PackageLoadStatus.Skipped => LoadingStatus.Skipped,
                     _ => throw new ArgumentOutOfRangeException(nameof(package))
                 },
                 package.InstallPath,

--- a/src/Nuplane.Loading/LoadingLogger.cs
+++ b/src/Nuplane.Loading/LoadingLogger.cs
@@ -64,4 +64,13 @@ internal static partial class LoadingLogger
         string graphKey,
         PackageLoadMode loadMode,
         string scope);
+
+    [LoggerMessage(
+        EventId = 2107,
+        Level = LogLevel.Debug,
+        Message = "Skipped graph load for packages {PackageKeys} because every member was already evaluated as an inert graph member that contributes no assemblies. CorrelationId={CorrelationId}")]
+    public static partial void LogInertGraphSkipped(
+        this ILogger logger,
+        string packageKeys,
+        string correlationId);
 }

--- a/src/Nuplane.Loading/LoadingOperationalStateContributor.cs
+++ b/src/Nuplane.Loading/LoadingOperationalStateContributor.cs
@@ -51,6 +51,12 @@ internal sealed class LoadingOperationalStateContributor(
                 continue;
             }
 
+            if (_packageLoader.IsInertPackage(package.PackageId, package.Version))
+            {
+                // Evaluated and deliberately not loaded because it contributes no assemblies; not missing state.
+                continue;
+            }
+
             staleCount++;
         }
 

--- a/src/Nuplane.Loading/PackageAutoLoadingObserver.cs
+++ b/src/Nuplane.Loading/PackageAutoLoadingObserver.cs
@@ -96,12 +96,24 @@ internal sealed class PackageAutoLoadingObserver : INuplaneObserver
             return;
         }
 
+        var (packageGraphs, inertPackageCount) = SelectGraphsRequiringLoad(
+            await BuildPackageGraphsAsync(packagesToLoad, ct),
+            changeSet.CorrelationId);
+        if (packageGraphs.Count == 0)
+        {
+            Metrics?.RecordLoaderBoundaryOutcome(succeeded: 0, failed: 0, inertPackageCount);
+            RefreshTracker?.MarkRefreshed(changeSet.CorrelationId);
+            return;
+        }
+
+        var graphPackageCount = packageGraphs.Sum(static graph => graph.Count);
+
         _logger.LogDebug(
             "Loading {Count} packages after reconciliation. CorrelationId={CorrelationId}",
-            packagesToLoad.Count,
+            graphPackageCount,
             changeSet.CorrelationId);
 
-        foreach (var _ in packagesToLoad)
+        for (var i = 0; i < graphPackageCount; i++)
         {
             Metrics?.RecordLoadAttemptStarted();
         }
@@ -110,7 +122,6 @@ internal sealed class PackageAutoLoadingObserver : INuplaneObserver
             .Select(x => new SharedAssemblyPolicyEntry(x.Name, x.PublicKeyToken, x.MajorVersion))
             .ToArray();
 
-        var packageGraphs = await BuildPackageGraphsAsync(packagesToLoad, ct);
         var loadResult = await _loader.EnsureGraphLoadedAsync(packageGraphs, sharedPolicy, ct);
 
         foreach (var _ in loadResult.Loaded)
@@ -138,7 +149,7 @@ internal sealed class PackageAutoLoadingObserver : INuplaneObserver
             await _dispatcher.PublishFailedAsync(packageId, reason, ct);
         }
 
-        Metrics?.RecordLoaderBoundaryOutcome(loadResult.Loaded.Count, loadResult.FailedByPackageId.Count, skipped: 0);
+        Metrics?.RecordLoaderBoundaryOutcome(loadResult.Loaded.Count, loadResult.FailedByPackageId.Count, inertPackageCount);
         RefreshTracker?.MarkRefreshed(changeSet.CorrelationId);
 
         if (loadResult.Loaded.Count > 0)
@@ -185,6 +196,35 @@ internal sealed class PackageAutoLoadingObserver : INuplaneObserver
     }
 
     private static string BuildKey(string packageId, string version) => $"{packageId}@{version}";
+
+    /// <summary>
+    /// Drops graphs whose members were all already evaluated by the loader and deliberately not loaded because
+    /// they contribute no assemblies. Such graphs are the inert remainder of graphs that are already active:
+    /// activating them on their own would fail with "no loadable assembly in graph", even though nothing changed.
+    /// </summary>
+    private (IReadOnlyList<IReadOnlyList<ResolvedPackage>> GraphsRequiringLoad, int InertPackageCount) SelectGraphsRequiringLoad(
+        IReadOnlyList<IReadOnlyList<ResolvedPackage>> packageGraphs,
+        string correlationId)
+    {
+        var graphsRequiringLoad = new List<IReadOnlyList<ResolvedPackage>>(packageGraphs.Count);
+        var inertPackageCount = 0;
+
+        foreach (var packageGraph in packageGraphs)
+        {
+            if (packageGraph.Any(package => !_loader.IsInertPackage(package.Id, package.Version)))
+            {
+                graphsRequiringLoad.Add(packageGraph);
+                continue;
+            }
+
+            inertPackageCount += packageGraph.Count;
+            _logger.LogInertGraphSkipped(
+                string.Join(", ", packageGraph.Select(package => BuildKey(package.Id, package.Version))),
+                correlationId);
+        }
+
+        return (graphsRequiringLoad, inertPackageCount);
+    }
 
     private async Task<IReadOnlyList<IReadOnlyList<ResolvedPackage>>> BuildPackageGraphsAsync(
         IReadOnlyList<ResolvedPackage> packagesToLoad,

--- a/src/Nuplane.Loading/PackageLoader.cs
+++ b/src/Nuplane.Loading/PackageLoader.cs
@@ -25,6 +25,7 @@ internal sealed class PackageLoader : IPackageLoader
     private readonly ConcurrentDictionary<string, AssemblyLoadContext> _contexts = new(StringComparer.OrdinalIgnoreCase);
     private readonly ConcurrentDictionary<string, PackageLoadSession> _sessions = new(StringComparer.OrdinalIgnoreCase);
     private readonly ConcurrentDictionary<string, LoadedGraphCacheEntry> _loadedGraphs = new(StringComparer.OrdinalIgnoreCase);
+    private readonly ConcurrentDictionary<string, byte> _inertPackages = new(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>
     /// Initializes a new instance of <see cref="PackageLoader"/> with an optional shared assembly policy matcher.
@@ -50,6 +51,15 @@ internal sealed class PackageLoader : IPackageLoader
     /// Gets the active load sessions keyed by package-version key.
     /// </summary>
     public IReadOnlyDictionary<string, PackageLoadSession> Sessions => _sessions;
+
+    /// <inheritdoc />
+    public bool IsInertPackage(string packageId, string version)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(packageId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(version);
+
+        return _inertPackages.ContainsKey(BuildKey(packageId, version));
+    }
 
     /// <summary>
     /// Builds deterministic assembly scan candidates for the specified active package install path.
@@ -152,6 +162,7 @@ internal sealed class PackageLoader : IPackageLoader
                 var mainAssemblyPath = ResolveMainAssemblyPath(package.InstallPath, package.Id);
                 if (HostRuntimeAssemblyCatalog.Contains(mainAssemblyPath))
                 {
+                    MarkInert(key);
                     _logger.LogInformation(
                         "Skipped package {PackageId}@{Version} because assembly {AssemblyPath} is provided by the host runtime.",
                         package.Id,
@@ -165,6 +176,7 @@ internal sealed class PackageLoader : IPackageLoader
                 context.LoadFromAssemblyName(assemblyName);
 
                 _contexts[key] = context;
+                ClearInert(key);
 
                 var session = new PackageLoadSession(
                     package.Id,
@@ -183,6 +195,9 @@ internal sealed class PackageLoader : IPackageLoader
             }
             catch (Exception ex)
             {
+                // A package reported as failed must stay retryable, so it can never remain marked inert.
+                ClearInert(key);
+
                 failed[package.Id] = ex.Message;
                 _sessions[key] = new(
                     package.Id,
@@ -237,6 +252,7 @@ internal sealed class PackageLoader : IPackageLoader
             {
                 if (graphPackages.SkippedPackages.Count == 0 && graphPackages.HostRuntimePackages.Count > 0)
                 {
+                    MarkInert(graphPackages.InertPackages);
                     return new(loaded, failed);
                 }
 
@@ -284,6 +300,7 @@ internal sealed class PackageLoader : IPackageLoader
                 }
 
                 _contexts[key] = context;
+                ClearInert(key);
 
                 var session = new PackageLoadSession(
                     package.Id,
@@ -316,6 +333,7 @@ internal sealed class PackageLoader : IPackageLoader
                     .ToArray());
 
             UnloadUnreferencedContexts(replacedContexts);
+            MarkInert(graphPackages.InertPackages);
         }
         catch (Exception ex)
         {
@@ -338,6 +356,9 @@ internal sealed class PackageLoader : IPackageLoader
                 {
                     _hostIntegratedResolutionCatalog.RemovePackage(package.Id, package.Version);
                 }
+
+                // A package reported as failed must stay retryable, so it can never remain marked inert.
+                ClearInert(key);
 
                 failed[package.Id] = ex.Message;
                 _sessions[key] = new(
@@ -432,6 +453,18 @@ internal sealed class PackageLoader : IPackageLoader
         return new(loadablePackages, skippedPackages, hostRuntimePackages, failedPackages, resolutionFailure);
     }
 
+    private void MarkInert(IEnumerable<GraphPackage> packages)
+    {
+        foreach (var package in packages)
+        {
+            MarkInert(BuildKey(package.Id, package.Version));
+        }
+    }
+
+    private void MarkInert(string packageKey) => _inertPackages[packageKey] = 0;
+
+    private void ClearInert(string packageKey) => _inertPackages.TryRemove(packageKey, out _);
+
     private void UnloadUnreferencedContexts(IEnumerable<AssemblyLoadContext> contexts)
     {
         foreach (var context in contexts.Distinct())
@@ -448,6 +481,7 @@ internal sealed class PackageLoader : IPackageLoader
     {
         var key = BuildKey(packageId, version);
         _sessions.TryRemove(key, out _);
+        ClearInert(key);
 
         if (_contexts.TryRemove(key, out var removed))
         {
@@ -821,6 +855,12 @@ internal sealed class PackageLoader : IPackageLoader
         Exception? ResolutionFailure)
     {
         public IReadOnlyList<string> SkippedInstallPaths => SkippedPackages.Select(static package => package.InstallPath).ToArray();
+
+        /// <summary>
+        /// Gets the graph members that were evaluated successfully but contribute no assemblies to load,
+        /// either because they contain none or because the host runtime already provides them.
+        /// </summary>
+        public IEnumerable<GraphPackage> InertPackages => SkippedPackages.Concat(HostRuntimePackages);
     }
 
     private sealed record LoadedGraphCacheEntry(

--- a/src/Nuplane.Loading/PackageLoader.cs
+++ b/src/Nuplane.Loading/PackageLoader.cs
@@ -53,13 +53,10 @@ internal sealed class PackageLoader : IPackageLoader
     public IReadOnlyDictionary<string, PackageLoadSession> Sessions => _sessions;
 
     /// <inheritdoc />
-    public bool IsInertPackage(string packageId, string version)
-    {
-        ArgumentException.ThrowIfNullOrWhiteSpace(packageId);
-        ArgumentException.ThrowIfNullOrWhiteSpace(version);
-
-        return _inertPackages.ContainsKey(BuildKey(packageId, version));
-    }
+    public bool IsInertPackage(string packageId, string version) =>
+        !string.IsNullOrWhiteSpace(packageId)
+        && !string.IsNullOrWhiteSpace(version)
+        && _inertPackages.ContainsKey(BuildKey(packageId, version));
 
     /// <summary>
     /// Builds deterministic assembly scan candidates for the specified active package install path.

--- a/test/Nuplane.Integration.Tests/Reconciliation/StartupLoadingEventIntegrationTests.cs
+++ b/test/Nuplane.Integration.Tests/Reconciliation/StartupLoadingEventIntegrationTests.cs
@@ -292,6 +292,8 @@ public sealed class StartupLoadingEventIntegrationTests
             CancellationToken ct) =>
             EnsureLoadedAsync(packageGraphs.SelectMany(static graph => graph).ToArray(), sharedPolicies, ct);
 
+        public bool IsInertPackage(string packageId, string version) => false;
+
         public bool TryRemoveContext(string packageId, string version, out PackageLoadContextHandle? context)
         {
             var key = BuildKey(packageId, version);

--- a/test/Nuplane.Loading.Tests/InertGraphMemberLoadStateTests.cs
+++ b/test/Nuplane.Loading.Tests/InertGraphMemberLoadStateTests.cs
@@ -1,0 +1,228 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Nuplane.Abstractions;
+using Nuplane.Health;
+using Nuplane.Loading.Events;
+using Nuplane.Observability;
+using Nuplane.Operational;
+using Nuplane.Store.State;
+
+namespace Nuplane.Loading.Tests;
+
+/// <summary>
+/// Covers the load-state surfaces for graph members that the loader deliberately does not load,
+/// across a startup cycle followed by a scheduled cycle over unchanged desired state.
+/// </summary>
+public sealed class InertGraphMemberLoadStateTests : IDisposable
+{
+    private static readonly DateTimeOffset Now = DateTimeOffset.UtcNow;
+
+    private readonly string tempRoot = Path.Combine(Path.GetTempPath(), $"nuplane-inert-load-state-{Guid.NewGuid():N}");
+    private readonly PackageLoader loader = new();
+    private readonly LoadingCatalogRefreshTracker refreshTracker = new();
+    private readonly ResolvedPackage root;
+    private readonly ResolvedPackage facade;
+    private readonly ResolvedPackage nativeFacade;
+
+    public InertGraphMemberLoadStateTests()
+    {
+        root = new("Plugin.Root", "1.0.0", "feed", CreateAssemblyPackageInstall("Plugin.Root"), Now, "test-source");
+        facade = new("Microsoft.Data.Sqlite", "10.0.9", "feed", CreateNoAssemblyPackageInstall("Microsoft.Data.Sqlite"), Now, "test-source");
+        nativeFacade = new("SQLitePCLRaw.bundle_e_sqlite3", "10.0.9", "feed", CreateNoAssemblyPackageInstall("SQLitePCLRaw.bundle_e_sqlite3"), Now, "test-source");
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(tempRoot))
+        {
+            Directory.Delete(tempRoot, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task ScheduledCycle_WithInertGraphMembers_DoesNotDegradeLoadingOperationalState()
+    {
+        await RunReconciliationCyclesAsync();
+
+        var snapshot = await ProjectOperationalSnapshotAsync();
+
+        Assert.Empty(snapshot.DegradedReasons);
+        Assert.Equal(HealthState.Healthy, snapshot.Health);
+    }
+
+    [Fact]
+    public async Task ScheduledCycle_WithInertGraphMembers_ReportsThemAsSkippedRatherThanStale()
+    {
+        await RunReconciliationCyclesAsync();
+
+        var snapshot = await CreateCatalog().GetLoadStateAsync(CancellationToken.None);
+
+        Assert.Equal(PackageLoadStateAvailability.Available, snapshot.Availability);
+        Assert.Null(snapshot.Reason);
+        Assert.Equal(PackageLoadStatus.Loaded, StatusOf(snapshot, root.Id));
+        Assert.Equal(PackageLoadStatus.Skipped, StatusOf(snapshot, facade.Id));
+        Assert.Equal(PackageLoadStatus.Skipped, StatusOf(snapshot, nativeFacade.Id));
+    }
+
+    [Fact]
+    public async Task ScheduledCycle_WithFailedPackage_StillDegradesLoadingOperationalState()
+    {
+        var broken = new ResolvedPackage("Plugin.Broken", "1.0.0", "feed", Path.Combine(tempRoot, "missing"), Now, "test-source");
+        await RunReconciliationCyclesAsync(broken);
+
+        var snapshot = await ProjectOperationalSnapshotAsync(broken);
+
+        Assert.Contains(snapshot.DegradedReasons, reason => reason.StartsWith("load-state-issues:", StringComparison.Ordinal));
+    }
+
+    private async Task RunReconciliationCyclesAsync(params ResolvedPackage[] additionalPackages)
+    {
+        var applied = new[] { root, facade, nativeFacade }.Concat(additionalPackages).ToArray();
+        var observer = new PackageAutoLoadingObserver(
+            loader,
+            new StubLoadingEventDispatcher(),
+            Options.Create(new LoadingOptions { Enabled = true }),
+            NullLogger<PackageAutoLoadingObserver>.Instance,
+            loadingFailureTracker: null,
+            refreshTracker: refreshTracker,
+            storeRegistry: new StubStoreRegistry(CreateStoreState(applied)));
+
+        await observer.OnPackagesReconciledAsync(new PackageChangeSet(applied, [], [], "corr-startup", Now), applied, CancellationToken.None);
+        await observer.OnPackagesReconciledAsync(new PackageChangeSet([], [], [], "corr-scheduled", Now), applied, CancellationToken.None);
+    }
+
+    private async Task<OperationalStateSnapshot> ProjectOperationalSnapshotAsync(params ResolvedPackage[] additionalPackages)
+    {
+        var projector = new OperationalSnapshotProjector(
+            new ReconciliationHealthEvaluator(),
+            new ReconciliationLogger(),
+            new ReconciliationMetrics(new ReconciliationTelemetry()),
+            [new LoadingOperationalStateContributor(
+                CreateActivePackageCatalog(additionalPackages),
+                loader,
+                refreshTracker,
+                Options.Create(new LoadingOptions { Enabled = true }))]);
+
+        return await projector.ProjectAsync("state-1", CancellationToken.None);
+    }
+
+    private LoadingCatalog CreateCatalog() =>
+        new(
+            CreateActivePackageCatalog(),
+            loader,
+            new AssemblyScanCandidateProjector(loader),
+            refreshTracker,
+            Options.Create(new LoadingOptions { Enabled = true }),
+            new ReconciliationLogger(),
+            new ReconciliationMetrics(new ReconciliationTelemetry()));
+
+    private StubActivePackageCatalog CreateActivePackageCatalog(params ResolvedPackage[] additionalPackages) =>
+        new(new ActivePackageCatalogSnapshot(
+            Now,
+            Now,
+            new[] { root, facade, nativeFacade }
+                .Concat(additionalPackages)
+                .Select(Descriptor)
+                .ToArray(),
+            "read"));
+
+    private static PackageLoadStatus StatusOf(PackageLoadStateSnapshot snapshot, string packageId) =>
+        snapshot.Packages.Single(package => string.Equals(package.PackageId, packageId, StringComparison.OrdinalIgnoreCase)).Status;
+
+    private static StoreStateRecord CreateStoreState(IReadOnlyList<ResolvedPackage> packages) =>
+        StoreStateRecord.Empty() with
+        {
+            ActiveVersionById = packages.ToDictionary(
+                static package => package.Id,
+                static package => package.Version,
+                StringComparer.OrdinalIgnoreCase),
+            ActivePackageDescriptorsById = packages.ToDictionary(
+                static package => package.Id,
+                Descriptor,
+                StringComparer.OrdinalIgnoreCase),
+            ActiveGraphsById = new(StringComparer.OrdinalIgnoreCase)
+            {
+                ["graph-sqlite"] = new(
+                    "graph-sqlite",
+                    "generation-a",
+                    [packages[0].Id],
+                    packages.Select(static package => package.Id).ToArray(),
+                    Now,
+                    "corr-startup",
+                    GraphActivationStatus.Active)
+            }
+        };
+
+    private static ActivePackageDescriptor Descriptor(ResolvedPackage package) =>
+        ActivePackageDescriptor.FromActivePackage(new ActivePackage(
+            package.Id,
+            package.Version,
+            package.FeedName,
+            package.SourceName,
+            package.InstallPath,
+            Now,
+            "corr-active"));
+
+    private string CreateAssemblyPackageInstall(string packageId)
+    {
+        var libPath = Path.Combine(tempRoot, packageId, "1.0.0", "lib", "net10.0");
+        Directory.CreateDirectory(libPath);
+        File.Copy(
+            TestFixtureAssemblyPaths.FindProjectAssembly("Nuplane.Loading.Tests.Fixtures.Root", "Plugin.Root.dll"),
+            Path.Combine(libPath, "Plugin.Root.dll"),
+            overwrite: true);
+        return Path.Combine(tempRoot, packageId, "1.0.0");
+    }
+
+    private string CreateNoAssemblyPackageInstall(string packageId)
+    {
+        var libPath = Path.Combine(tempRoot, packageId, "10.0.9", "lib", "netstandard2.0");
+        Directory.CreateDirectory(libPath);
+        File.WriteAllText(Path.Combine(libPath, "_._"), string.Empty);
+        return Path.Combine(tempRoot, packageId, "10.0.9");
+    }
+
+    private sealed class StubActivePackageCatalog(ActivePackageCatalogSnapshot snapshot) : IActivePackageCatalog
+    {
+        public Task<ActivePackagesSnapshot> GetActivePackagesAsync(CancellationToken cancellationToken) =>
+            Task.FromResult(snapshot.ToActivePackagesSnapshot());
+
+        public Task<ActivePackageCatalogSnapshot> GetSnapshotAsync(CancellationToken cancellationToken) => Task.FromResult(snapshot);
+    }
+
+    private sealed class StubStoreRegistry(StoreStateRecord state) : IStoreRegistry
+    {
+        public Task<IReadOnlyDictionary<string, string>> GetActiveVersionsAsync(CancellationToken cancellationToken) =>
+            Task.FromResult<IReadOnlyDictionary<string, string>>(state.ActiveVersionById);
+
+        public Task<StoreStateRecord> GetStateAsync(CancellationToken cancellationToken) => Task.FromResult(state);
+
+        public Task PersistActiveVersionsAsync(
+            IReadOnlyDictionary<string, string> activeVersions,
+            IReadOnlyDictionary<string, string> successfullyApplied,
+            string correlationId,
+            CancellationToken cancellationToken) =>
+            Task.CompletedTask;
+
+        public Task PersistFailureAsync(
+            string packageId,
+            string stage,
+            string message,
+            string correlationId,
+            CancellationToken cancellationToken) =>
+            Task.CompletedTask;
+
+        public Task PersistSourceSnapshotAsync(
+            string sourceName,
+            SourceSnapshotRef snapshot,
+            CancellationToken cancellationToken) =>
+            Task.CompletedTask;
+    }
+
+    private sealed class StubLoadingEventDispatcher : ILoadingEventDispatcher
+    {
+        public Task PublishLoadedAsync(PackageLoadedEvent evt, CancellationToken cancellationToken) => Task.CompletedTask;
+
+        public Task PublishFailedAsync(string packageId, string reason, CancellationToken cancellationToken) => Task.CompletedTask;
+    }
+}

--- a/test/Nuplane.Loading.Tests/PackageAutoLoadingObserverTests.cs
+++ b/test/Nuplane.Loading.Tests/PackageAutoLoadingObserverTests.cs
@@ -7,9 +7,19 @@ using Nuplane.Store.State;
 
 namespace Nuplane.Loading.Tests;
 
-public sealed class PackageAutoLoadingObserverTests
+public sealed class PackageAutoLoadingObserverTests : IDisposable
 {
     private static readonly DateTimeOffset Now = DateTimeOffset.UtcNow;
+
+    private readonly string tempRoot = Path.Combine(Path.GetTempPath(), $"nuplane-auto-loading-{Guid.NewGuid():N}");
+
+    public void Dispose()
+    {
+        if (Directory.Exists(tempRoot))
+        {
+            Directory.Delete(tempRoot, recursive: true);
+        }
+    }
 
     [Fact]
     public async Task AddedAndUpdatedPackages_PublishLoadedFired()
@@ -242,8 +252,106 @@ public sealed class PackageAutoLoadingObserverTests
         Assert.Equal(["dependency", "root-a", "root-b"], packageGraph.Select(static package => package.Id));
     }
 
+    [Fact]
+    public async Task GraphWithOnlyInertPackages_IsNotSubmittedToLoader()
+    {
+        var facade = new ResolvedPackage("pkg-facade", "1.0.0", "feed", "/path-facade", Now);
+        var loader = new FakePackageLoader(inertPackages: [facade]);
+        var dispatcher = new FakeLoadingEventDispatcher();
+        var sut = CreateObserver(
+            loader,
+            dispatcher,
+            new() { Enabled = true },
+            storeRegistry: CreateStoreRegistry("graph-facade", facade));
+
+        await sut.OnPackagesReconciledAsync(new PackageChangeSet([], [], [], "corr-inert", Now), [facade], CancellationToken.None);
+
+        Assert.False(loader.WasCalled);
+        Assert.Empty(dispatcher.LoadedEvents);
+        Assert.Empty(dispatcher.FailedPackages);
+    }
+
+    [Fact]
+    public async Task GraphWithInertAndPendingPackages_SubmitsWholeGraphToLoader()
+    {
+        var pending = new ResolvedPackage("pkg-pending", "1.0.0", "feed", "/path-pending", Now);
+        var facade = new ResolvedPackage("pkg-facade", "1.0.0", "feed", "/path-facade", Now);
+        var loader = new FakePackageLoader(inertPackages: [facade]);
+        var dispatcher = new FakeLoadingEventDispatcher();
+        var sut = CreateObserver(
+            loader,
+            dispatcher,
+            new() { Enabled = true },
+            storeRegistry: CreateStoreRegistry("graph-mixed", pending, facade));
+
+        await sut.OnPackagesReconciledAsync(
+            new PackageChangeSet([pending], [], [], "corr-mixed", Now),
+            [pending, facade],
+            CancellationToken.None);
+
+        var packageGraph = Assert.Single(loader.PackageGraphs);
+        Assert.Equal(["pkg-facade", "pkg-pending"], packageGraph.Select(static package => package.Id));
+    }
+
+    [Fact]
+    public async Task RepeatedCycles_WithNoAssemblyGraphMembers_DoNotFailSkippedGraphMembers()
+    {
+        var loader = new PackageLoader();
+        var dispatcher = new FakeLoadingEventDispatcher();
+        var failureTracker = new LoadingFailureTracker();
+        var root = new ResolvedPackage("Plugin.Root", "1.0.0", "feed", CreateAssemblyPackageInstall("Plugin.Root"), Now, "test-source");
+        var facade = new ResolvedPackage("Microsoft.Data.Sqlite", "10.0.9", "feed", CreateNoAssemblyPackageInstall("Microsoft.Data.Sqlite"), Now, "test-source");
+        var nativeFacade = new ResolvedPackage("SQLitePCLRaw.bundle_e_sqlite3", "10.0.9", "feed", CreateNoAssemblyPackageInstall("SQLitePCLRaw.bundle_e_sqlite3"), Now, "test-source");
+        var applied = new[] { root, facade, nativeFacade };
+        var sut = CreateObserver(
+            loader,
+            dispatcher,
+            new() { Enabled = true },
+            loadingFailureTracker: failureTracker,
+            storeRegistry: CreateStoreRegistry("graph-sqlite", applied));
+
+        await sut.OnPackagesReconciledAsync(
+            new PackageChangeSet(applied, [], [], "corr-startup", Now),
+            applied,
+            CancellationToken.None);
+
+        Assert.Empty(dispatcher.FailedPackages);
+        Assert.Empty(failureTracker.TakeFailedPackageIds("corr-startup"));
+        Assert.Single(dispatcher.LoadedEvents);
+
+        await sut.OnPackagesReconciledAsync(
+            new PackageChangeSet([], [], [], "corr-scheduled", Now),
+            applied,
+            CancellationToken.None);
+
+        Assert.Empty(dispatcher.FailedPackages);
+        Assert.Empty(failureTracker.TakeFailedPackageIds("corr-scheduled"));
+        Assert.Single(dispatcher.LoadedEvents);
+    }
+
+    private string CreateAssemblyPackageInstall(string packageId)
+    {
+        var installPath = Path.Combine(tempRoot, packageId, "1.0.0");
+        var libPath = Path.Combine(installPath, "lib", "net10.0");
+        Directory.CreateDirectory(libPath);
+        File.Copy(
+            TestFixtureAssemblyPaths.FindProjectAssembly("Nuplane.Loading.Tests.Fixtures.Root", "Plugin.Root.dll"),
+            Path.Combine(libPath, "Plugin.Root.dll"),
+            overwrite: true);
+        return installPath;
+    }
+
+    private string CreateNoAssemblyPackageInstall(string packageId)
+    {
+        var installPath = Path.Combine(tempRoot, packageId, "10.0.9");
+        var libPath = Path.Combine(installPath, "lib", "netstandard2.0");
+        Directory.CreateDirectory(libPath);
+        File.WriteAllText(Path.Combine(libPath, "_._"), string.Empty);
+        return installPath;
+    }
+
     private static PackageAutoLoadingObserver CreateObserver(
-        FakePackageLoader loader,
+        IPackageLoader loader,
         FakeLoadingEventDispatcher dispatcher,
         LoadingOptions options,
         FakeFailureRecorder? failureRecorder = null,
@@ -260,6 +368,23 @@ public sealed class PackageAutoLoadingObserverTests
             loadingFailureTracker,
             null,
             storeRegistry);
+
+    private static FakeStoreRegistry CreateStoreRegistry(string graphId, params ResolvedPackage[] packages) =>
+        new(StoreStateRecord.Empty() with
+        {
+            ActiveVersionById = packages.ToDictionary(
+                static package => package.Id,
+                static package => package.Version,
+                StringComparer.OrdinalIgnoreCase),
+            ActivePackageDescriptorsById = packages.ToDictionary(
+                static package => package.Id,
+                Descriptor,
+                StringComparer.OrdinalIgnoreCase),
+            ActiveGraphsById = new(StringComparer.OrdinalIgnoreCase)
+            {
+                [graphId] = Graph(graphId, $"{graphId}-generation", packages.Select(static package => package.Id).ToArray())
+            }
+        });
 
     private static GraphActivationRecord Graph(string graphId, string generationId, IReadOnlyList<string> nodePackageIds) =>
         new(
@@ -283,11 +408,15 @@ public sealed class PackageAutoLoadingObserverTests
 
     internal sealed class FakePackageLoader(
         IEnumerable<string>? failIds = null,
-        IEnumerable<ResolvedPackage>? preloadedPackages = null) : IPackageLoader
+        IEnumerable<ResolvedPackage>? preloadedPackages = null,
+        IEnumerable<ResolvedPackage>? inertPackages = null) : IPackageLoader
     {
         private readonly HashSet<string> _failIds = failIds is not null
             ? new HashSet<string>(failIds, StringComparer.OrdinalIgnoreCase)
             : [];
+        private readonly HashSet<string> _inertPackageKeys = (inertPackages ?? [])
+            .Select(static package => BuildKey(package.Id, package.Version))
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
         private readonly Dictionary<string, PackageLoadSession> _sessions = CreateSessions(preloadedPackages);
 
         public bool WasCalled { get; private set; }
@@ -342,6 +471,9 @@ public sealed class PackageAutoLoadingObserverTests
             PackageGraphs.AddRange(packageGraphs);
             return EnsureLoadedAsync(packageGraphs.SelectMany(static graph => graph).ToArray(), sharedPolicy, cancellationToken);
         }
+
+        public bool IsInertPackage(string packageId, string version) =>
+            _inertPackageKeys.Contains(BuildKey(packageId, version));
 
         public bool TryRemoveContext(string packageId, string version, out PackageLoadContextHandle? context)
         {

--- a/test/Nuplane.Loading.Tests/PackageLoaderGraphRegressionTests.cs
+++ b/test/Nuplane.Loading.Tests/PackageLoaderGraphRegressionTests.cs
@@ -133,6 +133,8 @@ public sealed class PackageLoaderGraphRegressionTests : IDisposable
         Assert.Empty(result.FailedByPackageId);
         Assert.True(loader.TryGetContext("Plugin.Root", "1.0.0", out _));
         Assert.False(loader.TryGetContext("Microsoft.Data.Sqlite", "10.0.3", out _));
+        Assert.True(loader.IsInertPackage("Microsoft.Data.Sqlite", "10.0.3"));
+        Assert.False(loader.IsInertPackage("Plugin.Root", "1.0.0"));
     }
 
     [Fact]
@@ -254,6 +256,64 @@ public sealed class PackageLoaderGraphRegressionTests : IDisposable
         Assert.DoesNotContain("Microsoft.Data.Sqlite", loader.Sessions.Keys, StringComparer.OrdinalIgnoreCase);
         Assert.False(loader.TryGetContext("Plugin.Root", "1.0.0", out _));
         Assert.False(loader.TryGetContext("Microsoft.Data.Sqlite", "10.0.3", out _));
+        Assert.False(loader.IsInertPackage("Microsoft.Data.Sqlite", "10.0.3"));
+    }
+
+    [Fact]
+    public async Task EnsureGraphLoadedAsync_HostRuntimeAssemblyPackage_MarksSkippedDependencyInert()
+    {
+        var rootInstall = CreatePackageInstall("Plugin.Root", "Plugin.Root.dll");
+        var systemMemoryInstall = CreateHostRuntimeAssemblyPackageInstall("System.Memory");
+        var loader = new PackageLoader();
+
+        await loader.EnsureGraphLoadedAsync(
+            [[
+                new ResolvedPackage("Plugin.Root", "1.0.0", "test-feed", rootInstall, DateTimeOffset.UtcNow, "test-source"),
+                new ResolvedPackage("System.Memory", "4.5.3", "test-feed", systemMemoryInstall, DateTimeOffset.UtcNow, "dependency-of:Plugin.Root")
+            ]],
+            [],
+            CancellationToken.None);
+
+        Assert.True(loader.IsInertPackage("System.Memory", "4.5.3"));
+    }
+
+    [Fact]
+    public async Task EnsureGraphLoadedAsync_InertPackageThatLaterFails_ClearsInertMarker()
+    {
+        var rootInstall = CreatePackageInstall("Plugin.Root", "Plugin.Root.dll");
+        var facadeInstall = CreateNoAssemblyPackageInstall("Microsoft.Data.Sqlite");
+        var facade = new ResolvedPackage("Microsoft.Data.Sqlite", "10.0.3", "test-feed", facadeInstall, DateTimeOffset.UtcNow, "test-source");
+        var loader = new PackageLoader();
+
+        await loader.EnsureGraphLoadedAsync(
+            [[new ResolvedPackage("Plugin.Root", "1.0.0", "test-feed", rootInstall, DateTimeOffset.UtcNow, "test-source"), facade]],
+            [],
+            CancellationToken.None);
+        Assert.True(loader.IsInertPackage(facade.Id, facade.Version));
+
+        var result = await loader.EnsureGraphLoadedAsync([[facade]], [], CancellationToken.None);
+
+        Assert.Single(result.FailedByPackageId);
+        Assert.False(loader.IsInertPackage(facade.Id, facade.Version));
+    }
+
+    [Fact]
+    public async Task EnsureGraphLoadedAsync_GraphWithOnlyNoAssemblyPackages_DoesNotMarkFailedPackagesInert()
+    {
+        var facadeInstall = CreateNoAssemblyPackageInstall("Microsoft.Data.Sqlite");
+        var loader = new PackageLoader();
+
+        var result = await loader.EnsureGraphLoadedAsync(
+            [[
+                new ResolvedPackage("Microsoft.Data.Sqlite", "10.0.3", "test-feed", facadeInstall, DateTimeOffset.UtcNow, "test-source"),
+                new ResolvedPackage("Microsoft.Data.Sqlite.Support", "10.0.3", "test-feed", CreateNoAssemblyPackageInstall("Microsoft.Data.Sqlite.Support"), DateTimeOffset.UtcNow, "test-source")
+            ]],
+            [],
+            CancellationToken.None);
+
+        Assert.Equal(2, result.FailedByPackageId.Count);
+        Assert.False(loader.IsInertPackage("Microsoft.Data.Sqlite", "10.0.3"));
+        Assert.False(loader.IsInertPackage("Microsoft.Data.Sqlite.Support", "10.0.3"));
     }
 
     public void Dispose()


### PR DESCRIPTION
## Confirmed root cause

The asymmetry is not in the loader's "must contain a loadable assembly" check — it is in **which packages the reload path hands to the loader**.

`PackageAutoLoadingObserver.BuildPackagesToLoad` (`src/Nuplane.Loading/PackageAutoLoadingObserver.cs`) decides what still needs loading with `_loader.TryGetContext(id, version)`: "no assembly load context" means "not loaded yet". Packages that graph loading *deliberately* skips — the facade/native support packages tolerated by `019-tolerate-facade-packages`, and packages whose main assembly is provided by the host runtime — are never given a load context or a session by `PackageLoader.EnsureGraphLoaded`, by design.

So the cycle sequence is:

1. **Startup cycle** — nothing is loaded yet, so the observer submits the *whole* closure as one graph. `PackageLoader.ResolveGraphPackages` classifies `Microsoft.Data.Sqlite`, `Microsoft.EntityFrameworkCore.Sqlite`, `SourceGear.sqlite3` and `SQLitePCLRaw.bundle_e_sqlite3` as skipped members, loads the rest, and the cycle is clean (`IsDegraded=False`).
2. **Every scheduled cycle after it** — `PackageApplyExecutor` reports all packages as applied again (transactions are idempotent), but every package that actually loaded now has a context and is filtered out. The only packages left pending are the four skipped ones. `BuildPackageGraphsAsync` groups them (they share one active graph record) into a *single graph that contains no loadable member*.
3. `EnsureGraphLoaded` → `graphPackages.LoadablePackages.Count == 0` with skipped members present → `NoLoadableAssemblyException("No loadable assembly found in graph 'graph:Microsoft.Data.Sqlite@…|…'")`. `ResolveFailedGraphPackages` then reports *all four skipped packages* as failed (it returns `SkippedPackages` when there is nothing loadable and nothing failed).
4. The observer records those four in `LoadingFailureTracker`; `HealthAndMetricsMiddleware` folds `loaderFailedIds` into `hadFailures` → `IsDegraded=True, FailedCount=4`, forever, while `/health` and `/alive` stay 200.

This is FR-005 of spec 019 ("a graph where every member is non-loadable must fail") firing correctly — on an input that should never have been submitted as a graph. The initial load never hits it because the loadable packages are still in the graph.

## What changed

**Reconciliation cycle (the reported symptom)**

- `PackageLoader` now records packages it deliberately did not load during a **successful** graph evaluation (no loadable assemblies, or provided by the host runtime) and exposes them via the new `IPackageLoader.IsInertPackage(packageId, version)`. The marker is cleared whenever the package is actually loaded, whenever it is reported as failed, and on `TryRemoveContext`.
- `PackageAutoLoadingObserver` drops graphs whose members are *all* inert instead of asking the loader to activate them, logs them at Debug (`LoadingLogger.LogInertGraphSkipped`, EventId 2107), and reports them through the loader-boundary `skipped` counter, which was previously hard-coded to `0`.

Graphs that still contain something to load are submitted **unchanged**, so inert members keep contributing their install paths to the graph load context (native asset probing for packages like `SQLitePCLRaw.lib.e_sqlite3` is unaffected).

**Load-state surfaces (see the measurement below)**

- Added `PackageLoadStatus.Skipped` (public, appended so existing values keep their ordinals) and the internal `LoadingStatus.Skipped` it maps to: "evaluated for the current process and deliberately not loaded because it contributes no assemblies".
- `LoadingCatalog` reports inert active packages as `Skipped` with diagnostic `loading-no-assemblies-to-load` instead of `Stale` with `loading-state-missing-for-active-package`, and stops counting them toward `staleCount`, so the snapshot stays `Available` with no reason code.
- `LoadingOperationalStateContributor` stops counting them toward `load-state-stale`.

## Did this actually fix #55, or relocate the symptom?

Measured rather than reasoned, with `InertGraphMemberLoadStateTests.ScheduledCycle_WithInertGraphMembers_DoesNotDegradeLoadingOperationalState` (startup cycle + scheduled cycle over unchanged desired state, one loadable root and two no-assembly graph members, then project the operational snapshot):

| Code under test | `OperationalStateSnapshot.DegradedReasons` after the scheduled cycle |
| --- | --- |
| `main` | `["load-state-issues:2", "load-state-divergence:2"]` — degraded, from the failed sessions the reload path recorded |
| This PR, reconciliation fix only | `["load-state-stale:2"]` — **still degraded**, now because no session exists at all |
| This PR, final | *(empty)* — `HealthState.Healthy` |

The middle row is why the load-state surfaces are part of this PR: fixing only the reconciliation cycle would have moved the permanent degradation from `load-state-issues` to `load-state-stale` rather than removing it.

I consult the inert marker rather than recording a `PackageLoadSession` for inert packages: `PackageLoadSession.IsLoaded` is a two-state flag and every existing reader of `PackageLoader.Sessions` treats "session with `IsLoaded=false`" as a failure, so inert sessions would have changed the meaning of `Sessions` for all of them.

## Genuine load failures are still detected

- A package is only recorded as inert when the graph evaluation *succeeded* and the package was classified as skipped/host-provided by a fresh filesystem scan. Missing install paths, incompatible target frameworks, ambiguous main assemblies, invalid assemblies and load exceptions all take the failure path and are never marked inert — `EnsureGraphLoadedAsync_NoAssemblyDependencyWithRealPackageFailure_DoesNotFailSkippedDependency`, `EnsureGraphLoadedAsync_GraphWithOnlyNoAssemblyPackages_DoesNotMarkFailedPackagesInert`.
- Anything reported as failed has its inert marker cleared, so failures always stay retryable on the next cycle — `EnsureGraphLoadedAsync_InertPackageThatLaterFails_ClearsInertMarker`.
- A graph submitted for the first time whose members are all non-loadable still fails with the existing diagnostic (FR-005 preserved) — `EnsureGraphLoadedAsync_GraphWithOnlyNoAssemblyPackages_FailsGraph` and `…_ReportsScannedInstallPath`, unchanged and green.
- A package with a failed session still reads `Failed` and still degrades the loading surface, and a package with genuinely missing load state still reads `Stale` — `ScheduledCycle_WithFailedPackage_StillDegradesLoadingOperationalState`, `LoadingCatalogHealthTests.StaleLoadingState_ProducesLoadingStaleDegradedReason`.

## Tests

The primary regression test, `PackageAutoLoadingObserverTests.RepeatedCycles_WithNoAssemblyGraphMembers_DoNotFailSkippedGraphMembers`, drives two reconciliation callbacks over unchanged desired state with a real `PackageLoader`. Verified failing before the fix with the exact error from this issue:

```
Assert.Empty() Failure: Collection was not empty
Collection: [Tuple ("Microsoft.Data.Sqlite", "No loadable assembly found in graph 'graph:Microso"···),
             Tuple ("SQLitePCLRaw.bundle_e_sqlite3", "No loadable assembly found in graph 'graph:Microso"···)]
```

Also added: `GraphWithOnlyInertPackages_IsNotSubmittedToLoader`, `GraphWithInertAndPendingPackages_SubmitsWholeGraphToLoader` (guards graph composition), `EnsureGraphLoadedAsync_HostRuntimeAssemblyPackage_MarksSkippedDependencyInert`, `EnsureGraphLoadedAsync_InertPackageThatLaterFails_ClearsInertMarker`, `EnsureGraphLoadedAsync_GraphWithOnlyNoAssemblyPackages_DoesNotMarkFailedPackagesInert`, and the three `InertGraphMemberLoadStateTests` covering the load-state surfaces after a second no-change cycle.

`dotnet test nuplane.sln` — 0 failed:

| Project | Passed |
| --- | --- |
| Nuplane.Store.Tests | 44 |
| Nuplane.NuGet.Tests | 25 |
| Nuplane.Sources.Directory.Tests | 15 |
| Nuplane.Runtime.Tests | 421 |
| Nuplane.Integration.Tests | 93 |
| Nuplane.Loading.Tests | 160 |

Fixes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)
