### PR TITLE
Let the Reconciliation section win over the Setup shorthand

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,11 @@ Nuplane has two configuration layers:
   - `PackageLoadModes`
   - `SharedAssemblies`
 
+When both layers express the same reconciliation setting, the more specific `Nuplane:Reconciliation` section wins over the `Nuplane:Setup` shorthand:
+
+- `Reconciliation:EnableAutomaticReconciliation` overrides `Setup:AutomaticReconciliation` in both directions when the key is present; an explicit `false` disables automatic reconciliation even when the shorthand enables it.
+- `Reconciliation:PollInterval` overrides `Setup:PollInterval`; when neither is set, automatic reconciliation polls every 60 seconds.
+
 For unrestricted feeds, prefer one of these explicit forms:
 
 - configuration: `"IncludePatterns": ["*"]`

--- a/docs/wiki/Usage-Guide.md
+++ b/docs/wiki/Usage-Guide.md
@@ -80,6 +80,12 @@ This avoids positional array merging when `appsettings.json`, environment variab
 configuration files are layered. Feed object order is not semantic; configure feed priorities
 separately when resolution order matters.
 
+When the same reconciliation setting is expressed in both layers, the more specific
+`Nuplane:Reconciliation` section wins over the `Nuplane:Setup` shorthand. An explicitly present
+`Reconciliation:EnableAutomaticReconciliation` decides automatic reconciliation in both directions,
+so `false` there disables polling even when `Setup:AutomaticReconciliation` is `true`; the same
+applies to `Reconciliation:PollInterval` over `Setup:PollInterval`.
+
 ### Directory feeds as an offline package source
 
 A directory feed declared with `DirectoryPath` both contributes desired roots and resolves packages,

--- a/src/Nuplane/NuplaneServiceCollectionExtensions.cs
+++ b/src/Nuplane/NuplaneServiceCollectionExtensions.cs
@@ -17,6 +17,12 @@ public static class NuplaneServiceCollectionExtensions
     /// <c>StoreRegistry</c> are bound directly when present, while builder-only concepts are
     /// translated from the <c>Setup</c> section.
     /// </summary>
+    /// <remarks>
+    /// Where both layers express the same reconciliation setting, the more specific
+    /// <c>Reconciliation</c> section wins: an explicitly present
+    /// <c>Reconciliation:EnableAutomaticReconciliation</c> or <c>Reconciliation:PollInterval</c>
+    /// overrides the <c>Setup:AutomaticReconciliation</c> / <c>Setup:PollInterval</c> shorthand.
+    /// </remarks>
     public static IServiceCollection AddNuplane(
         this IServiceCollection services,
         IConfiguration configuration) =>
@@ -35,11 +41,12 @@ public static class NuplaneServiceCollectionExtensions
         ArgumentNullException.ThrowIfNull(configuration);
 
         var setupSection = NuplaneSetupConfigurationServices.GetSetupSectionOrSelf(configuration);
+        var reconciliationSection = NuplaneSetupConfigurationServices.GetReconciliationSectionOrSelf(configuration);
 
         return services.AddNuplane(builder =>
         {
             NuplaneOptionsRegistrationServices.BindConfiguredOptions(builder.Services, configuration);
-            NuplaneSetupConfigurationServices.ApplySetupConfiguration(builder, setupSection);
+            NuplaneSetupConfigurationServices.ApplySetupConfiguration(builder, setupSection, reconciliationSection);
             configure?.Invoke(builder);
         });
     }

--- a/src/Nuplane/Registration/NuplaneOptionsRegistrationServices.cs
+++ b/src/Nuplane/Registration/NuplaneOptionsRegistrationServices.cs
@@ -17,7 +17,7 @@ namespace Nuplane.Registration;
 internal static class NuplaneOptionsRegistrationServices
 {
     internal const string SetupSectionName = "Setup";
-    private const string ReconciliationSectionName = "Reconciliation";
+    internal const string ReconciliationSectionName = "Reconciliation";
     private const string FeedResolutionSectionName = "FeedResolution";
     private const string LockFileSectionName = "LockFile";
     private const string CleanupPolicySectionName = "CleanupPolicy";

--- a/src/Nuplane/Registration/NuplaneSetupConfigurationServices.cs
+++ b/src/Nuplane/Registration/NuplaneSetupConfigurationServices.cs
@@ -1,38 +1,68 @@
 using Microsoft.Extensions.Configuration;
 using Nuplane.Builder;
 using Nuplane.Feeds.Setup;
+using Nuplane.Reconciliation.Configuration;
 using Nuplane.Setup;
 
 namespace Nuplane.Registration;
 
 internal static class NuplaneSetupConfigurationServices
 {
+    private static readonly TimeSpan DefaultPollInterval = TimeSpan.FromSeconds(60);
+
     internal static IConfigurationSection GetSetupSectionOrSelf(IConfiguration configuration) =>
         NuplaneOptionsRegistrationServices.GetNamedSectionOrSelf(
             configuration,
             NuplaneOptionsRegistrationServices.SetupSectionName);
 
-    internal static void ApplySetupConfiguration(NuplaneBuilder builder, IConfiguration configuration)
-    {
-        if (configuration.GetValue<bool?>(nameof(NuplaneSetupOptions.AutomaticReconciliation)) is true)
-        {
-            builder.PollEvery(
-                configuration.GetValue<TimeSpan?>(nameof(NuplaneSetupOptions.PollInterval))
-                ?? TimeSpan.FromSeconds(60));
-        }
+    internal static IConfigurationSection GetReconciliationSectionOrSelf(IConfiguration configuration) =>
+        NuplaneOptionsRegistrationServices.GetNamedSectionOrSelf(
+            configuration,
+            NuplaneOptionsRegistrationServices.ReconciliationSectionName);
 
-        var stateFilePath = configuration[nameof(NuplaneSetupOptions.StateFilePath)];
+    internal static void ApplySetupConfiguration(
+        NuplaneBuilder builder,
+        IConfiguration setupConfiguration,
+        IConfiguration reconciliationConfiguration)
+    {
+        ApplyAutomaticReconciliation(builder, setupConfiguration, reconciliationConfiguration);
+
+        var stateFilePath = setupConfiguration[nameof(NuplaneSetupOptions.StateFilePath)];
         if (!string.IsNullOrWhiteSpace(stateFilePath))
         {
             builder.WithStateFile(stateFilePath);
         }
 
-        if (configuration.GetValue<bool?>(nameof(NuplaneSetupOptions.UseInMemoryStore)) is true)
+        if (setupConfiguration.GetValue<bool?>(nameof(NuplaneSetupOptions.UseInMemoryStore)) is true)
         {
             builder.UseInMemoryStore();
         }
 
-        NuplaneFeedSetupConfiguration.ApplyConfiguredFeeds(builder, configuration);
+        NuplaneFeedSetupConfiguration.ApplyConfiguredFeeds(builder, setupConfiguration);
+    }
+
+    // The dedicated Reconciliation section is more specific than the Setup shorthand, so an explicitly
+    // present key there wins in both directions. Values are read as nullable so that an explicit false is
+    // distinguishable from an absent key, which a bound option default cannot express.
+    private static void ApplyAutomaticReconciliation(
+        NuplaneBuilder builder,
+        IConfiguration setupConfiguration,
+        IConfiguration reconciliationConfiguration)
+    {
+        var enabled =
+            reconciliationConfiguration.GetValue<bool?>(nameof(ReconciliationOptions.EnableAutomaticReconciliation))
+            ?? setupConfiguration.GetValue<bool?>(nameof(NuplaneSetupOptions.AutomaticReconciliation));
+
+        if (enabled is not true)
+        {
+            return;
+        }
+
+        var pollInterval =
+            reconciliationConfiguration.GetValue<TimeSpan?>(nameof(ReconciliationOptions.PollInterval))
+            ?? setupConfiguration.GetValue<TimeSpan?>(nameof(NuplaneSetupOptions.PollInterval))
+            ?? DefaultPollInterval;
+
+        builder.PollEvery(pollInterval);
     }
 }
-

--- a/test/Nuplane.Runtime.Tests/Configuration/NuplaneSetupConfigurationServicesTests.cs
+++ b/test/Nuplane.Runtime.Tests/Configuration/NuplaneSetupConfigurationServicesTests.cs
@@ -1,0 +1,236 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+using Nuplane.Hosting;
+using Nuplane.Reconciliation.Configuration;
+
+namespace Nuplane.Runtime.Tests.Configuration;
+
+public sealed class NuplaneSetupConfigurationServicesTests
+{
+    // Truth table from issue #54: the explicitly present Reconciliation key decides in both directions,
+    // and the Setup shorthand only applies when the Reconciliation key is absent.
+    [Theory]
+    [InlineData("true", null, true)]
+    [InlineData("true", "false", false)]
+    [InlineData("false", "true", true)]
+    [InlineData("false", null, false)]
+    [InlineData(null, null, false)]
+    public void ApplySetupConfiguration_SetupAndReconciliationEnableCombination_PrefersReconciliationSection(
+        string? setupValue,
+        string? reconciliationValue,
+        bool expected)
+    {
+        // Arrange
+        var settings = new Dictionary<string, string?>();
+        if (setupValue is not null)
+        {
+            settings["Nuplane:Setup:AutomaticReconciliation"] = setupValue;
+        }
+
+        if (reconciliationValue is not null)
+        {
+            settings["Nuplane:Reconciliation:EnableAutomaticReconciliation"] = reconciliationValue;
+        }
+
+        // Act
+        var options = ResolveReconciliationOptions(settings);
+
+        // Assert
+        Assert.Equal(expected, options.EnableAutomaticReconciliation);
+    }
+
+    [Fact]
+    public void ApplySetupConfiguration_UnrelatedReconciliationKeysOnly_LeavesAutomaticReconciliationDisabled()
+    {
+        // Arrange
+        var settings = new Dictionary<string, string?>
+        {
+            ["Nuplane:Reconciliation:MaxRetryAttempts"] = "5"
+        };
+
+        // Act
+        var options = ResolveReconciliationOptions(settings);
+
+        // Assert
+        Assert.False(options.EnableAutomaticReconciliation);
+        Assert.Equal(5, options.MaxRetryAttempts);
+    }
+
+    [Fact]
+    public void ApplySetupConfiguration_SetupEnabledAndReconciliationExplicitlyDisabled_DoesNotRegisterSchedulerHostedService()
+    {
+        // Arrange
+        var settings = new Dictionary<string, string?>
+        {
+            ["Nuplane:Setup:AutomaticReconciliation"] = "true",
+            ["Nuplane:Reconciliation:EnableAutomaticReconciliation"] = "false"
+        };
+
+        // Act
+        var services = AddNuplaneFromConfiguration(settings);
+
+        // Assert
+        Assert.DoesNotContain(
+            services,
+            descriptor => descriptor.ServiceType == typeof(IHostedService)
+                && descriptor.ImplementationType == typeof(ReconciliationHostedService));
+    }
+
+    [Fact]
+    public void ApplySetupConfiguration_ReconciliationExplicitlyEnabledWithoutSetupShorthand_RegistersSchedulerHostedService()
+    {
+        // Arrange
+        var settings = new Dictionary<string, string?>
+        {
+            ["Nuplane:Reconciliation:EnableAutomaticReconciliation"] = "true"
+        };
+
+        // Act
+        var services = AddNuplaneFromConfiguration(settings);
+
+        // Assert
+        Assert.Contains(
+            services,
+            descriptor => descriptor.ServiceType == typeof(IHostedService)
+                && descriptor.ImplementationType == typeof(ReconciliationHostedService));
+    }
+
+    [Fact]
+    public void ApplySetupConfiguration_SetupPollIntervalWithoutReconciliationPollInterval_UsesSetupPollInterval()
+    {
+        // Arrange
+        var settings = new Dictionary<string, string?>
+        {
+            ["Nuplane:Setup:AutomaticReconciliation"] = "true",
+            ["Nuplane:Setup:PollInterval"] = "00:00:45"
+        };
+
+        // Act
+        var options = ResolveReconciliationOptions(settings);
+
+        // Assert
+        Assert.True(options.EnableAutomaticReconciliation);
+        Assert.Equal(TimeSpan.FromSeconds(45), options.PollInterval);
+    }
+
+    [Fact]
+    public void ApplySetupConfiguration_ReconciliationPollIntervalWithSetupShorthand_UsesReconciliationPollInterval()
+    {
+        // Arrange
+        var settings = new Dictionary<string, string?>
+        {
+            ["Nuplane:Setup:AutomaticReconciliation"] = "true",
+            ["Nuplane:Setup:PollInterval"] = "00:00:45",
+            ["Nuplane:Reconciliation:PollInterval"] = "00:05:00"
+        };
+
+        // Act
+        var options = ResolveReconciliationOptions(settings);
+
+        // Assert
+        Assert.True(options.EnableAutomaticReconciliation);
+        Assert.Equal(TimeSpan.FromMinutes(5), options.PollInterval);
+    }
+
+    [Fact]
+    public void ApplySetupConfiguration_SetupEnabledWithoutAnyPollInterval_UsesDefaultPollInterval()
+    {
+        // Arrange
+        var settings = new Dictionary<string, string?>
+        {
+            ["Nuplane:Setup:AutomaticReconciliation"] = "true"
+        };
+
+        // Act
+        var options = ResolveReconciliationOptions(settings);
+
+        // Assert
+        Assert.Equal(TimeSpan.FromSeconds(60), options.PollInterval);
+    }
+
+    [Fact]
+    public void ApplySetupConfiguration_SetupEnabledWithReconciliationStartupFailurePolicy_PreservesStartupFailurePolicy()
+    {
+        // Arrange
+        var settings = new Dictionary<string, string?>
+        {
+            ["Nuplane:Setup:AutomaticReconciliation"] = "true",
+            ["Nuplane:Reconciliation:StartupFailurePolicy"] = nameof(StartupFailurePolicy.UseLastKnownGood)
+        };
+
+        // Act
+        var options = ResolveReconciliationOptions(settings);
+
+        // Assert
+        Assert.True(options.EnableAutomaticReconciliation);
+        Assert.Equal(StartupFailurePolicy.UseLastKnownGood, options.StartupFailurePolicy);
+    }
+
+    [Fact]
+    public void ApplySetupConfiguration_SetupSectionPassedDirectly_EnablesAutomaticReconciliation()
+    {
+        // Arrange
+        var configuration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            ["Nuplane:Setup:AutomaticReconciliation"] = "true",
+            ["Nuplane:Setup:PollInterval"] = "00:00:30"
+        });
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        // Act
+        services.AddNuplane(configuration.GetSection("Nuplane:Setup"));
+
+        // Assert
+        using var provider = services.BuildServiceProvider();
+        var options = provider.GetRequiredService<IOptions<ReconciliationOptions>>().Value;
+        Assert.True(options.EnableAutomaticReconciliation);
+        Assert.Equal(TimeSpan.FromSeconds(30), options.PollInterval);
+    }
+
+    [Fact]
+    public void ApplySetupConfiguration_BuilderPollEveryAfterExplicitDisable_EnablesAutomaticReconciliation()
+    {
+        // Arrange
+        var settings = new Dictionary<string, string?>
+        {
+            ["Nuplane:Setup:AutomaticReconciliation"] = "true",
+            ["Nuplane:Reconciliation:EnableAutomaticReconciliation"] = "false"
+        };
+        var configuration = BuildConfiguration(settings);
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        // Act
+        services.AddNuplane(
+            configuration.GetSection("Nuplane"),
+            nuplane => nuplane.PollEvery(TimeSpan.FromSeconds(10)));
+
+        // Assert
+        using var provider = services.BuildServiceProvider();
+        var options = provider.GetRequiredService<IOptions<ReconciliationOptions>>().Value;
+        Assert.True(options.EnableAutomaticReconciliation);
+        Assert.Equal(TimeSpan.FromSeconds(10), options.PollInterval);
+    }
+
+    private static IConfigurationRoot BuildConfiguration(Dictionary<string, string?> settings) =>
+        new ConfigurationBuilder().AddInMemoryCollection(settings).Build();
+
+    private static IServiceCollection AddNuplaneFromConfiguration(Dictionary<string, string?> settings)
+    {
+        var configuration = BuildConfiguration(settings);
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddNuplane(configuration.GetSection("Nuplane"));
+        return services;
+    }
+
+    private static ReconciliationOptions ResolveReconciliationOptions(Dictionary<string, string?> settings)
+    {
+        var services = AddNuplaneFromConfiguration(settings);
+        using var provider = services.BuildServiceProvider();
+        return provider.GetRequiredService<IOptions<ReconciliationOptions>>().Value;
+    }
+}


### PR DESCRIPTION
## Root cause

`AddNuplane(IConfiguration)` binds the runtime option sections first (`services.Configure<ReconciliationOptions>(o => section.Bind(o))`) and then translates the `Setup` shorthand through the builder. `ApplySetupConfiguration` called `builder.PollEvery(...)` whenever `Setup:AutomaticReconciliation` was `true`, and `PollEvery` registers a *later* `Configure<ReconciliationOptions>` delegate that unconditionally sets `EnableAutomaticReconciliation = true` (and overwrites `PollInterval`). Since `IConfigureOptions<T>` delegates run in registration order, the Setup translation always won over the explicitly bound `Reconciliation` value — a logical OR of the two keys that failed in the dangerous direction: the operator reads `false` in configuration and background reconciliation is on.

The same mechanism silently discarded `Reconciliation:PollInterval`: `PollEvery` overwrote it with `Setup:PollInterval` or, when that was absent, the hard-coded 60-second default.

## Chosen resolution: more specific wins

Of the two resolutions the issue accepts (precedence, or a startup validation error), this PR implements **precedence — the more specific `Reconciliation` section wins over the `Setup` shorthand, in both directions**:

- It matches the layering already documented in the README (`Setup` is a builder-only shorthand; `Nuplane:*` sections are advanced operator configuration), and it is what layered configuration providers (appsettings → environment → mounted files) make natural: an operator overrides one specific key without having to know which shorthand produced it.
- A validation error would break existing valid deployments that set both keys consistently (e.g. `Setup:AutomaticReconciliation: true` plus a `Reconciliation` section that repeats `EnableAutomaticReconciliation: true`), and it turns a resolvable overlap into a hard startup failure.
- `Reconciliation:StartupFailurePolicy` already composed this way, so precedence keeps the section's behaviour uniform rather than making one key of it special.

The key subtlety is telling "explicitly `false`" from "absent". The translation now reads the `Reconciliation` section with `GetValue<bool?>` / `GetValue<TimeSpan?>` rather than relying on a bound option default, and only falls back to the `Setup` shorthand when the key is absent.

## Resulting truth table

| `Setup:AutomaticReconciliation` | `Reconciliation:EnableAutomaticReconciliation` | Result | Before |
|---|---|---|---|
| `true` | *(absent)* | `True` | `True` |
| `true` | `false` | **`False`** | `True` (bug) |
| `false` | `true` | `True` | `True` |
| `false` | *(absent)* | `False` | `False` |
| *(absent)* | *(absent)* | `False` | `False` |

Poll interval composition, same precedence: `Reconciliation:PollInterval` → `Setup:PollInterval` → 60s default. `Setup:PollInterval` alone still applies (unchanged), and `Reconciliation:StartupFailurePolicy` still composes alongside the shorthand (regression test added).

Two related behaviours follow from routing the effective value through one place:

- `Reconciliation:EnableAutomaticReconciliation: false` now also prevents `ReconciliationHostedService` from being registered, instead of registering a scheduler for a disabled feature.
- `Reconciliation:EnableAutomaticReconciliation: true` **without** the `Setup` shorthand now registers `ReconciliationHostedService`. Previously the option read `true` while nothing ever polled — the flag is documented as "a hosted service polls at `PollInterval` intervals", so this makes the section self-sufficient.

Explicit `nuplane.PollEvery(...)` in the builder callback still overrides configuration, as documented (covered by a test).

## Changes

- `src/Nuplane/Registration/NuplaneSetupConfigurationServices.cs` — `ApplySetupConfiguration` takes the `Reconciliation` section and resolves the effective enable flag and poll interval with section-wins precedence.
- `src/Nuplane/NuplaneServiceCollectionExtensions.cs` — resolves and passes the `Reconciliation` section; documents the precedence rule.
- `src/Nuplane/Registration/NuplaneOptionsRegistrationServices.cs` — `ReconciliationSectionName` made `internal` so both binder and translation use one constant.
- `test/Nuplane.Runtime.Tests/Configuration/NuplaneSetupConfigurationServicesTests.cs` — new: full truth table as a `[Theory]`, poll-interval precedence, hosted-service registration in both directions, `StartupFailurePolicy` composition, `Setup`-section-passed-directly, builder-callback override.
- `README.md`, `docs/wiki/Usage-Guide.md` — document the precedence rule.

## Test results

- New tests verified failing before the fix: 4 of 14 failed (truth-table row `true`/`false`, poll-interval precedence, and both hosted-service registration cases); all 14 pass after.
- `dotnet build nuplane.sln`: succeeded, 0 warnings, 0 errors (warnings-as-errors).
- `dotnet test nuplane.sln`: **763 passed, 0 failed, 0 skipped** — Store 44, Sources.Directory 15, Runtime 435, NuGet 25, Loading 151, Integration 93.
- `Nuplane.Sources.Directory.Tests.DirectoryObservationContractTests` failed once mid-work; reproduced the same failure on unmodified `main` (1 of 5 runs) and it passes in isolation, so it is the known FileSystemWatcher/debounce timing flakiness, not a regression from this change.

## Not changed (noted for follow-up)

`Setup:StateFilePath` and `Setup:UseInMemoryStore` override the `StoreRegistry` section with the same shorthand-wins mechanism (an existing test even names the case `ignored-by-setup.json`, so it is asserted behaviour today). That is outside the reported issue and is left as-is rather than changed silently here.

Fixes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)
