### PR TITLE
Extract directory-feed packages under PackageInstallRoot instead of inside the feed directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ These patterns also inform source/package trust defaults unless you explicitly o
 A local folder treated as a feed.
 Nuplane can scan it for `.nupkg` files and optionally watch it for file changes with debounce.
 This is what powers the sample's drop-folder workflow.
+The folder itself is only read: packages resolved from it are extracted under `FeedResolution:PackageInstallRoot`,
+so a pre-populated package folder can be mounted read-only (`-v "$(pwd)/packages:/app/packages:ro"`).
 
 ### Reconciliation
 
@@ -398,6 +400,7 @@ Operational guidance:
 - for Kubernetes, a `StatefulSet` with one volume per replica is the best fit when warm restarts matter
 - if `UseInMemoryStore=true` is enabled, restart persistence is intentionally disabled
 - if `PackageInstallRoot` is not persisted, Nuplane may need to download and extract packages again after pod restart even if the store state file is preserved
+- `PackageInstallRoot` must be writable; it is the only package location Nuplane writes to, so feed directories supplying `.nupkg` files can stay read-only
 
 With both paths persisted, a restarted pod can typically reload prior active state and reuse previously extracted packages instead of rebuilding its local package store from scratch.
 

--- a/docs/wiki/Usage-Guide.md
+++ b/docs/wiki/Usage-Guide.md
@@ -97,6 +97,23 @@ versions are matched in normalized form. A `.nupkg` written by `dotnet restore` 
 file name therefore still satisfies a dependency that declares the canonical identifier, including
 on case-sensitive file systems such as those inside Linux containers.
 
+The directory is only ever read. Packages resolved from it are extracted under
+`Nuplane:FeedResolution:PackageInstallRoot` — at
+`{PackageInstallRoot}/{feedName}/{packageId}/{version}` — the same layout remote feeds use, so a
+directory feed can be baked into a container image or mounted read-only:
+
+```bash
+docker run --read-only \
+  -v "$(pwd)/packages:/app/packages:ro" \
+  -v nuplane-data:/var/lib/nuplane \
+  -e Nuplane__FeedResolution__PackageInstallRoot=/var/lib/nuplane/packages \
+  your-registry/nuplane-host:latest
+```
+
+Only `PackageInstallRoot` (and the store state file path) has to be writable. Earlier versions
+extracted into a `.installed/` subdirectory of the feed directory; hosts upgrading from those
+versions can delete that directory, and packages are re-extracted once under the install root.
+
 ## Code-driven adoption
 
 - **Applicability:** `Core`

--- a/specs/008-local-feeds-and-watchers/contracts/local-directory-feed-contract.md
+++ b/specs/008-local-feeds-and-watchers/contracts/local-directory-feed-contract.md
@@ -26,7 +26,7 @@
 - Acquisition MUST treat local directory feeds as "artifact already present":
   - no remote fetch is required
   - the resolver MUST locate the `.nupkg` file in the feed directory using the conventional filename `{packageId}.{version}.nupkg`
-  - the resolver MUST extract the `.nupkg` contents to a versioned install directory (e.g., `{feedDir}/.installed/{packageId}/{version}/`)
+  - the resolver MUST extract the `.nupkg` contents to a versioned install directory under the configured package install root (`{PackageInstallRoot}/{feedName}/{packageId}/{version}/`, superseded by issue #56)
   - `ResolvedPackage.InstallPath` MUST point to the extracted directory on disk, NOT a synthetic or placeholder path
   - the loader depends on `InstallPath` being a real directory containing assemblies (under `lib/<tfm>/` or root); a non-existent path causes a loader boundary failure
   - extraction MUST be idempotent (skip if directory already exists)

--- a/specs/008-local-feeds-and-watchers/data-model.md
+++ b/specs/008-local-feeds-and-watchers/data-model.md
@@ -48,7 +48,7 @@
 - Relevant fields:
   - `installPath` (string, required): The file-system path where the package content is installed. The package loader expects this to be a real directory containing loadable assemblies.
 - Install path rules (normative for this feature):
-  - **Local directory feeds (`file://` scheme)**: The resolver MUST extract the `.nupkg` archive to a versioned install directory within the feed directory (e.g., `{feedLocalPath}/.installed/{packageId}/{version}/`) and set `installPath` to that extracted directory. Extraction MUST be idempotent (skip if directory already exists). A synthetic or placeholder path MUST NOT be used.
+  - **Local directory feeds (`file://` scheme)**: The resolver MUST extract the `.nupkg` archive to a versioned install directory under the configured package install root (`{PackageInstallRoot}/{feedName}/{packageId}/{version}/`, superseded by issue #56 — the feed directory is read-only to the resolver) and set `installPath` to that extracted directory. Extraction MUST be idempotent (skip when the directory already carries the completion marker). A synthetic or placeholder path MUST NOT be used.
   - **Remote feeds**: The resolver produces a path that is populated by a future acquisition/download step. For the current implementation this is a synthetic path (e.g., `/packages/{id}/{version}`).
   - **Loader dependency**: The package loader (`PackageLoader.ResolveMainAssemblyPath`) requires `installPath` to be a real directory on disk containing `.dll` files (directly or under `lib/<tfm>/`). If `installPath` does not exist, the loader reports a boundary failure.
 

--- a/specs/008-local-feeds-and-watchers/quickstart.md
+++ b/specs/008-local-feeds-and-watchers/quickstart.md
@@ -54,7 +54,7 @@ dotnet test Nuplane.sln
 4. Verify:
    - a reconciliation cycle runs,
    - feed resolution selects the local directory feed,
-   - the `.nupkg` is extracted to a versioned install directory under the feed path (e.g., `{feedDir}/.installed/{packageId}/{version}/`),
+   - the `.nupkg` is extracted to a versioned install directory under the configured package install root (`{PackageInstallRoot}/{feedName}/{packageId}/{version}/`, superseded by issue #56),
    - the resolved `InstallPath` points to a real directory on disk containing assemblies,
    - no `InvalidOperationException: No available feed could resolve package ...` is thrown,
    - no `DirectoryNotFoundException: Install path '...' does not exist.` is thrown from the loader boundary,

--- a/specs/008-local-feeds-and-watchers/research.md
+++ b/specs/008-local-feeds-and-watchers/research.md
@@ -52,7 +52,7 @@
   - Have the loader extract the nupkg itself (rejected: violates separation of concerns; the loader should not know about feed types or nupkg archives).
 - Alternatives considered:
 - Rationale: The package loader (`PackageLoader.ResolveMainAssemblyPath`) requires `InstallPath` to be a real directory on disk containing assemblies. A `.nupkg` is a ZIP archive; without extraction, the loader has no directory to scan for DLLs. The original implementation produced a synthetic path (`/packages/{id}/{version}`) for all feeds, which caused `DirectoryNotFoundException` at the loader boundary.
-- Decision: When a `file://` feed resolves a package, the resolver MUST locate the `.nupkg` file by conventional name (`{id}.{version}.nupkg`) and extract it to `{feedDir}/.installed/{id}/{version}/`. The `ResolvedPackage.InstallPath` MUST point to this extracted directory. Extraction is idempotent (skip if directory already exists).
+- Decision: When a `file://` feed resolves a package, the resolver MUST locate the `.nupkg` file by conventional name (`{id}.{version}.nupkg`) and extract it to `{PackageInstallRoot}/{feedName}/{id}/{version}/` (superseded by issue #56; the feed directory is never written to). The `ResolvedPackage.InstallPath` MUST point to this extracted directory. Extraction is idempotent (skip if directory already exists).
 ## Decision 9: Local feed resolution must extract nupkg to produce a real install path
   - a regression test proving "directory-only + no remote feeds" does not throw and yields an explicit outcome,
   - unit tests for watcher coalescing and debounce behavior,

--- a/specs/008-local-feeds-and-watchers/spec.md
+++ b/specs/008-local-feeds-and-watchers/spec.md
@@ -27,7 +27,7 @@
 - **Resolution**: The decision-making step that selects an eligible feed for each desired package request.
 
 - **Acquisition**: The step that determines and records the artifact *location* for activation.
-  - For a local directory feed, this means locating the `.nupkg` file on disk and **extracting its contents** to a versioned install directory (e.g., `{feedLocalPath}/.installed/{packageId}/{version}/`) so that the loader can resolve assemblies from the extracted content. The `ResolvedPackage.InstallPath` MUST point to this extracted directory, NOT a synthetic path.
+  - For a local directory feed, this means locating the `.nupkg` file on disk and **extracting its contents** to a versioned install directory under the configured package install root (`{PackageInstallRoot}/{feedName}/{packageId}/{version}/`, superseded by issue #56) so that the loader can resolve assemblies from the extracted content. The `ResolvedPackage.InstallPath` MUST point to this extracted directory, NOT a synthetic path.
   - For a remote feed, this is typically a remote feed identifier/URI and a concrete version, followed by download and extraction.
   - This feature does not require implementing new NuGet download/extraction mechanics for remote feeds; it requires that directory-originating requests are resolvable without remote feeds, produce a real on-disk install path, and produce explicit outcomes.
 

--- a/src/Nuplane/Feeds/MultiFeedPackageResolver.cs
+++ b/src/Nuplane/Feeds/MultiFeedPackageResolver.cs
@@ -1,6 +1,5 @@
 using System.Collections.Concurrent;
 using System.Diagnostics;
-using System.IO.Compression;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Nuplane.Abstractions;
@@ -348,8 +347,11 @@ public sealed class MultiFeedPackageResolver : IPackageResolver
 
     /// <summary>
     /// Resolves the install path for a package from the specified feed.
-    /// Local directory feeds extract the <c>.nupkg</c> into a stable install directory;
-    /// remote feeds are downloaded and extracted via the configured remote package acquirer.
+    /// Local directory feeds extract the <c>.nupkg</c> into a stable install directory under the
+    /// configured package install root — never inside the feed directory, which is only read — so a
+    /// feed that just supplies <c>.nupkg</c> files can be mounted read-only.
+    /// Remote feeds are downloaded and extracted under the same root via the configured remote
+    /// package acquirer.
     /// </summary>
     /// <param name="feed">The feed the package was resolved from.</param>
     /// <param name="packageId">The requested package identifier.</param>
@@ -380,26 +382,25 @@ public sealed class MultiFeedPackageResolver : IPackageResolver
                 Path.Combine(feedDirectoryPath, nupkgFileName));
         }
 
-        var nupkgPath = packageFile.Value.FilePath;
-
         // Key the install directory off the identifier as spelled on disk so that requests for the
         // same package under different casing share one extraction.
-        var installDir = Path.Combine(feedDirectoryPath, ".installed", packageFile.Value.PackageId, version);
-        var completionMarkerPath = Path.Combine(installDir, ".nuplane-ready");
+        var installRoot = PackageInstallStore.ResolveInstallRoot(_options);
+        var installDirectory = PackageInstallStore.GetInstallDirectory(
+            installRoot,
+            feed.Name,
+            packageFile.Value.PackageId,
+            version);
 
-        if (!File.Exists(completionMarkerPath))
+        if (!PackageInstallStore.IsInstalled(installDirectory))
         {
-            if (Directory.Exists(installDir))
-            {
-                Directory.Delete(installDir, recursive: true);
-            }
-
-            Directory.CreateDirectory(installDir);
-            ZipFile.ExtractToDirectory(nupkgPath, installDir, overwriteFiles: true);
-            await File.WriteAllTextAsync(completionMarkerPath, string.Empty, cancellationToken);
+            await PackageInstallStore.InstallAsync(
+                installRoot,
+                installDirectory,
+                packageFile.Value.FilePath,
+                cancellationToken);
         }
 
-        return installDir;
+        return installDirectory;
     }
 
     private static bool IsLocalDirectoryFeed(FeedDefinition feed) =>

--- a/src/Nuplane/Feeds/NuGetRemotePackageAcquirer.cs
+++ b/src/Nuplane/Feeds/NuGetRemotePackageAcquirer.cs
@@ -1,4 +1,3 @@
-using System.IO.Compression;
 using System.Collections.Concurrent;
 using System.Net;
 using System.Text.Json;
@@ -29,30 +28,15 @@ public sealed class NuGetRemotePackageAcquirer(IOptions<FeedResolutionOptions> o
                 $"Feed '{feed.Name}' configures credentials, but remote credential resolution is not implemented yet.");
         }
 
-        var installRoot = ResolveInstallRoot();
-        var installDirectory = Path.Combine(
-            installRoot,
-            SanitizePathSegment(feed.Name),
-            SanitizePathSegment(packageId),
-            SanitizePathSegment(version));
-        var completionMarkerPath = Path.Combine(installDirectory, ".nuplane-ready");
+        var installRoot = PackageInstallStore.ResolveInstallRoot(_options);
+        var installDirectory = PackageInstallStore.GetInstallDirectory(installRoot, feed.Name, packageId, version);
 
-        if (File.Exists(completionMarkerPath))
+        if (PackageInstallStore.IsInstalled(installDirectory))
         {
             return installDirectory;
         }
 
-        if (Directory.Exists(installDirectory))
-        {
-            Directory.Delete(installDirectory, recursive: true);
-        }
-
-        var tempRoot = Path.Combine(installRoot, ".tmp");
-        Directory.CreateDirectory(tempRoot);
-        Directory.CreateDirectory(Path.GetDirectoryName(installDirectory)!);
-
-        var tempNupkgPath = Path.Combine(tempRoot, $"{Guid.NewGuid():N}.nupkg");
-        var tempExtractDirectory = Path.Combine(tempRoot, Guid.NewGuid().ToString("N"));
+        var stagedNupkgPath = PackageInstallStore.CreateStagingPath(installRoot, ".nupkg");
 
         try
         {
@@ -60,28 +44,19 @@ public sealed class NuGetRemotePackageAcquirer(IOptions<FeedResolutionOptions> o
                 feed,
                 packageId,
                 version,
-                tempNupkgPath,
+                stagedNupkgPath,
                 _options.PackageBaseAddressCacheTtl,
                 cancellationToken);
 
-            Directory.CreateDirectory(tempExtractDirectory);
-            ZipFile.ExtractToDirectory(tempNupkgPath, tempExtractDirectory, overwriteFiles: true);
-            await File.WriteAllTextAsync(Path.Combine(tempExtractDirectory, ".nuplane-ready"), string.Empty, cancellationToken);
-            Directory.Move(tempExtractDirectory, installDirectory);
-            tempExtractDirectory = string.Empty;
+            await PackageInstallStore.InstallAsync(installRoot, installDirectory, stagedNupkgPath, cancellationToken);
 
             return installDirectory;
         }
         finally
         {
-            if (File.Exists(tempNupkgPath))
+            if (File.Exists(stagedNupkgPath))
             {
-                File.Delete(tempNupkgPath);
-            }
-
-            if (!string.IsNullOrEmpty(tempExtractDirectory) && Directory.Exists(tempExtractDirectory))
-            {
-                Directory.Delete(tempExtractDirectory, recursive: true);
+                File.Delete(stagedNupkgPath);
             }
         }
     }
@@ -216,18 +191,6 @@ public sealed class NuGetRemotePackageAcquirer(IOptions<FeedResolutionOptions> o
         return value.EndsWith("/", StringComparison.Ordinal)
             ? uri
             : new Uri(value + "/", UriKind.Absolute);
-    }
-
-    private string ResolveInstallRoot() =>
-        !string.IsNullOrWhiteSpace(_options.PackageInstallRoot)
-            ? Path.GetFullPath(_options.PackageInstallRoot)
-            : Path.Combine(AppContext.BaseDirectory, ".nuplane", "packages");
-
-    private static string SanitizePathSegment(string value)
-    {
-        var invalidCharacters = Path.GetInvalidFileNameChars();
-        var buffer = value.Select(ch => invalidCharacters.Contains(ch) ? '_' : ch).ToArray();
-        return new(buffer);
     }
 
     private sealed record CachedPackageBaseAddress(Uri Uri, DateTimeOffset ExpiresAt);

--- a/src/Nuplane/Feeds/PackageInstallStore.cs
+++ b/src/Nuplane/Feeds/PackageInstallStore.cs
@@ -1,0 +1,173 @@
+using System.IO.Compression;
+using Nuplane.Feeds.Configuration;
+
+namespace Nuplane.Feeds;
+
+/// <summary>
+/// Owns the on-disk layout of extracted packages and the rules for publishing an extraction into it.
+/// Every feed kind — local directory and remote alike — extracts under the single writable root
+/// derived from <see cref="FeedResolutionOptions.PackageInstallRoot"/>, so a feed directory that only
+/// supplies <c>.nupkg</c> files never has to be writable and can be mounted read-only.
+/// An install directory only counts as usable once it carries the completion marker, so a partially
+/// extracted directory is never handed to the loader.
+/// </summary>
+internal static class PackageInstallStore
+{
+    /// <summary>
+    /// The marker file written as the last step of an extraction, inside the staging directory and
+    /// therefore already present when the directory is published under its final name.
+    /// </summary>
+    public const string CompletionMarkerFileName = ".nuplane-ready";
+
+    /// <summary>
+    /// Resolves the writable root that all package extractions land under.
+    /// </summary>
+    /// <param name="options">The feed resolution options carrying the configured root.</param>
+    public static string ResolveInstallRoot(FeedResolutionOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        return !string.IsNullOrWhiteSpace(options.PackageInstallRoot)
+            ? Path.GetFullPath(options.PackageInstallRoot)
+            : Path.Combine(AppContext.BaseDirectory, ".nuplane", "packages");
+    }
+
+    /// <summary>
+    /// Composes the install directory for a concrete package version acquired from a feed.
+    /// </summary>
+    /// <param name="installRoot">The writable install root.</param>
+    /// <param name="feedName">The name of the feed the package came from.</param>
+    /// <param name="packageId">The package identifier to key the directory off.</param>
+    /// <param name="version">The concrete package version.</param>
+    public static string GetInstallDirectory(string installRoot, string feedName, string packageId, string version) =>
+        Path.Combine(
+            installRoot,
+            SanitizePathSegment(feedName),
+            SanitizePathSegment(packageId),
+            SanitizePathSegment(version));
+
+    /// <summary>
+    /// Determines whether the install directory holds a completed extraction.
+    /// </summary>
+    /// <param name="installDirectory">The install directory to probe.</param>
+    public static bool IsInstalled(string installDirectory) =>
+        File.Exists(Path.Combine(installDirectory, CompletionMarkerFileName));
+
+    /// <summary>
+    /// Creates the staging area and returns a unique path inside it; the path itself is not created.
+    /// Staging sits under the install root so that publishing an extraction is a rename within one
+    /// volume.
+    /// </summary>
+    /// <param name="installRoot">The writable install root.</param>
+    /// <param name="extension">An optional file extension for staged files.</param>
+    public static string CreateStagingPath(string installRoot, string extension = "")
+    {
+        var stagingRoot = Path.Combine(installRoot, ".tmp");
+        Directory.CreateDirectory(stagingRoot);
+        return Path.Combine(stagingRoot, $"{Guid.NewGuid():N}{extension}");
+    }
+
+    /// <summary>
+    /// Extracts a <c>.nupkg</c> into <paramref name="installDirectory"/>, staging the extraction under
+    /// the install root and publishing it with a single rename so no half-extracted directory is ever
+    /// reachable under the final path. The source <c>.nupkg</c> is only read.
+    /// </summary>
+    /// <param name="installRoot">The writable install root.</param>
+    /// <param name="installDirectory">The final install directory, below <paramref name="installRoot"/>.</param>
+    /// <param name="nupkgPath">The package file to extract.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    public static async Task InstallAsync(
+        string installRoot,
+        string installDirectory,
+        string nupkgPath,
+        CancellationToken cancellationToken)
+    {
+        var stagingDirectory = CreateStagingPath(installRoot);
+
+        try
+        {
+            Directory.CreateDirectory(stagingDirectory);
+            ZipFile.ExtractToDirectory(nupkgPath, stagingDirectory, overwriteFiles: true);
+            await File.WriteAllTextAsync(
+                Path.Combine(stagingDirectory, CompletionMarkerFileName),
+                string.Empty,
+                cancellationToken);
+
+            Directory.CreateDirectory(Path.GetDirectoryName(installDirectory)!);
+
+            if (TryPublish(stagingDirectory, installDirectory))
+            {
+                stagingDirectory = string.Empty;
+            }
+        }
+        finally
+        {
+            if (!string.IsNullOrEmpty(stagingDirectory) && Directory.Exists(stagingDirectory))
+            {
+                Directory.Delete(stagingDirectory, recursive: true);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Renames a completed staging directory onto the final install path.
+    /// Returns <see langword="false"/> when a concurrent writer already published a complete extraction
+    /// there, in which case the staged copy is redundant and the caller discards it. A directory left
+    /// behind by an interrupted extraction is replaced instead, because it carries no marker and is
+    /// therefore not in use.
+    /// </summary>
+    private static bool TryPublish(string stagingDirectory, string installDirectory)
+    {
+        for (var attempt = 0; attempt < 2; attempt++)
+        {
+            try
+            {
+                Directory.Move(stagingDirectory, installDirectory);
+                return true;
+            }
+            catch (IOException) when (Directory.Exists(installDirectory))
+            {
+                if (IsInstalled(installDirectory))
+                {
+                    return false;
+                }
+
+                if (attempt > 0)
+                {
+                    throw;
+                }
+
+                try
+                {
+                    Directory.Delete(installDirectory, recursive: true);
+                }
+                catch (DirectoryNotFoundException)
+                {
+                    // A concurrent writer removed it first; the retried rename is what matters.
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Reduces a value to a single safe path segment. Besides characters the platform rejects, this
+    /// also neutralizes directory separators and relative segments so that a hostile package
+    /// identifier, feed name, or version cannot escape the install root.
+    /// </summary>
+    private static string SanitizePathSegment(string value)
+    {
+        var invalidCharacters = Path.GetInvalidFileNameChars();
+        var buffer = value
+            .Select(ch => invalidCharacters.Contains(ch)
+                || ch == Path.DirectorySeparatorChar
+                || ch == Path.AltDirectorySeparatorChar
+                    ? '_'
+                    : ch)
+            .ToArray();
+        var sanitized = new string(buffer);
+
+        return sanitized is "" or "." or ".." ? "_" : sanitized;
+    }
+}

--- a/test/Nuplane.Runtime.Tests/Reconciliation/LocalDirectoryFeedContractTests.cs
+++ b/test/Nuplane.Runtime.Tests/Reconciliation/LocalDirectoryFeedContractTests.cs
@@ -20,20 +20,66 @@ namespace Nuplane.Runtime.Tests.Reconciliation;
 public sealed class LocalDirectoryFeedContractTests : IDisposable
 {
     private readonly string _tempDir = Path.Combine(Path.GetTempPath(), $"nuplane-local-feed-test-{Guid.NewGuid():N}");
+    private readonly string _installRoot = Path.Combine(Path.GetTempPath(), $"nuplane-local-feed-install-{Guid.NewGuid():N}");
 
     public void Dispose()
     {
-        if (Directory.Exists(_tempDir))
+        RestoreWritable(_tempDir);
+
+        foreach (var directory in new[] { _tempDir, _installRoot })
         {
-            Directory.Delete(_tempDir, recursive: true);
+            if (Directory.Exists(directory))
+            {
+                Directory.Delete(directory, recursive: true);
+            }
         }
     }
 
     private FeedResolutionOptions CreateLocalFeedOptions()
     {
-        var options = new FeedResolutionOptions();
+        var options = new FeedResolutionOptions { PackageInstallRoot = _installRoot };
         options.Feeds.Add(new("local-drop", new("file:///" + _tempDir.Replace('\\', '/').TrimStart('/'))));
         return options;
+    }
+
+    /// <summary>
+    /// The set of entries the feed directory holds, relative to it, so a test can assert the resolver
+    /// left the feed directory byte-for-byte as it found it.
+    /// </summary>
+    private string[] FeedDirectoryEntries() =>
+        Directory
+            .EnumerateFileSystemEntries(_tempDir, "*", SearchOption.AllDirectories)
+            .Select(entry => Path.GetRelativePath(_tempDir, entry))
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+
+    /// <summary>
+    /// Probes whether the feed directory is still writable despite its permission bits, which is the
+    /// case when the test process runs as root.
+    /// </summary>
+    private bool IsFeedDirectoryStillWritable()
+    {
+        var probePath = Path.Combine(_tempDir, $"probe-{Guid.NewGuid():N}");
+        try
+        {
+            File.WriteAllText(probePath, string.Empty);
+            File.Delete(probePath);
+            return true;
+        }
+        catch (Exception exception) when (exception is UnauthorizedAccessException or IOException)
+        {
+            return false;
+        }
+    }
+
+    private static void RestoreWritable(string directoryPath)
+    {
+        if (!OperatingSystem.IsWindows() && Directory.Exists(directoryPath))
+        {
+            File.SetUnixFileMode(
+                directoryPath,
+                UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+        }
     }
 
     private static MultiFeedPackageResolver CreateResolver(
@@ -94,6 +140,7 @@ public sealed class LocalDirectoryFeedContractTests : IDisposable
                 feed.Watch = false;
             });
         });
+        services.Configure<FeedResolutionOptions>(options => options.PackageInstallRoot = _installRoot);
 
         using var provider = services.BuildServiceProvider();
         var resolver = provider.GetRequiredService<IPackageResolver>();
@@ -163,8 +210,107 @@ public sealed class LocalDirectoryFeedContractTests : IDisposable
         Assert.Equal("1.0.0", result.Version);
         Assert.True(Directory.Exists(result.InstallPath), $"Install path '{result.InstallPath}' should exist on disk.");
         Assert.Equal(
-            Path.Combine(_tempDir, ".installed", "sourcegear.sqlite3", "1.0.0"),
+            Path.Combine(_installRoot, "local-drop", "sourcegear.sqlite3", "1.0.0"),
             result.InstallPath);
+    }
+
+    [Fact]
+    public async Task Resolve_FromLocalFeed_ExtractsUnderInstallRootWithoutWritingToFeedDirectory()
+    {
+        NupkgTestBuilder.Create("MyPlugin", "1.0.0").BuildTo(_tempDir);
+        var before = FeedDirectoryEntries();
+        var resolver = CreateResolver(CreateLocalFeedOptions());
+
+        var result = await resolver.ResolveAsync(
+            new("MyPlugin", "1.0.0", "local-drop", PackageUpdatePolicy.Exact, "local-source"),
+            CancellationToken.None);
+
+        Assert.Equal(Path.Combine(_installRoot, "local-drop", "MyPlugin", "1.0.0"), result.InstallPath);
+        Assert.True(File.Exists(Path.Combine(result.InstallPath, "MyPlugin.nuspec")));
+        Assert.Equal(["MyPlugin.1.0.0.nupkg"], before);
+        Assert.Equal(before, FeedDirectoryEntries());
+    }
+
+    [Fact]
+    public async Task Resolve_RemotePinnedRequestServedByLocalCacheFeed_ExtractsUnderInstallRootForThatFeed()
+    {
+        // A request pinned to a remote feed still lets a local directory feed act as a cache; the
+        // extraction must be keyed off the feed that actually supplied the package.
+        NupkgTestBuilder.Create("MyPlugin", "1.0.0").BuildTo(_tempDir);
+        var before = FeedDirectoryEntries();
+        var options = CreateLocalFeedOptions();
+        options.Feeds.Add(new("nuget.org", new("https://api.nuget.org/v3/index.json")));
+        var resolver = CreateResolver(options);
+
+        var result = await resolver.ResolveAsync(
+            new("MyPlugin", "1.0.0", "nuget.org", PackageUpdatePolicy.Exact, "local-source"),
+            CancellationToken.None);
+
+        Assert.Equal("local-drop", result.FeedName);
+        Assert.Equal(Path.Combine(_installRoot, "local-drop", "MyPlugin", "1.0.0"), result.InstallPath);
+        Assert.True(File.Exists(Path.Combine(result.InstallPath, "MyPlugin.nuspec")));
+        Assert.Equal(before, FeedDirectoryEntries());
+    }
+
+    [Fact]
+    public async Task Resolve_FromReadOnlyLocalFeedDirectory_Succeeds()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        NupkgTestBuilder.Create("MyPlugin", "1.0.0").BuildTo(_tempDir);
+        File.SetUnixFileMode(_tempDir, UnixFileMode.UserRead | UnixFileMode.UserExecute);
+
+        // A process running as root ignores the permission bits, so the test would pass vacuously.
+        if (IsFeedDirectoryStillWritable())
+        {
+            RestoreWritable(_tempDir);
+            return;
+        }
+
+        var resolver = CreateResolver(CreateLocalFeedOptions());
+
+        var result = await resolver.ResolveAsync(
+            new("MyPlugin", "1.0.0", "local-drop", PackageUpdatePolicy.Exact, "local-source"),
+            CancellationToken.None);
+
+        Assert.True(File.Exists(Path.Combine(result.InstallPath, "MyPlugin.nuspec")));
+        Assert.StartsWith(_installRoot, result.InstallPath, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Resolve_SameLocalPackageUnderDifferentCasing_SharesOneExtraction()
+    {
+        NupkgTestBuilder.Create("sourcegear.sqlite3", "1.0.0").BuildTo(_tempDir);
+        var resolver = CreateResolver(CreateLocalFeedOptions());
+
+        var first = await resolver.ResolveAsync(
+            new("SourceGear.sqlite3", "1.0.0", "local-drop", PackageUpdatePolicy.Exact, "local-source"),
+            CancellationToken.None);
+        var second = await resolver.ResolveAsync(
+            new("sourcegear.SQLITE3", "1.0.0", "local-drop", PackageUpdatePolicy.Exact, "local-source"),
+            CancellationToken.None);
+
+        Assert.Equal(first.InstallPath, second.InstallPath);
+        Assert.Single(Directory.EnumerateDirectories(Path.Combine(_installRoot, "local-drop")));
+    }
+
+    [Fact]
+    public async Task Resolve_FromLocalFeed_ConcurrentResolvesOfSamePackageShareOneCompleteInstall()
+    {
+        NupkgTestBuilder.Create("MyPlugin", "1.0.0").BuildTo(_tempDir);
+        var resolver = CreateResolver(CreateLocalFeedOptions());
+        var request = new PackageRequest("MyPlugin", "1.0.0", "local-drop", PackageUpdatePolicy.Exact, "local-source");
+
+        var results = await Task.WhenAll(Enumerable
+            .Range(0, 8)
+            .Select(_ => Task.Run(() => resolver.ResolveAsync(request, CancellationToken.None))));
+
+        var installPath = Assert.Single(results.Select(result => result.InstallPath).Distinct(StringComparer.Ordinal));
+        Assert.True(File.Exists(Path.Combine(installPath, "MyPlugin.nuspec")));
+        Assert.Empty(Directory.EnumerateFileSystemEntries(Path.Combine(_installRoot, ".tmp")));
     }
 
     [Fact]


### PR DESCRIPTION
Fixes #56

## Root cause

`MultiFeedPackageResolver.ResolveInstallPathAsync` extracted every directory-feed `.nupkg` into
`Path.Combine(feedDirectoryPath, ".installed", packageId, version)` — a subdirectory **of the feed
directory itself**. The package *source* therefore had to be writable, which makes a pre-populated
package directory impossible to ship in a container image and breaks `--read-only` /
`readOnlyRootFilesystem: true` with `IOException: Read-only file system : '/app/baked-packages/.installed'`.
Remote feeds already extracted under `FeedResolution:PackageInstallRoot`; only the local path
disagreed.

## New extraction layout

Local directory feeds now use the same layout and the same writable root as remote feeds:

```
{PackageInstallRoot}/{feedName}/{packageId}/{version}/
{PackageInstallRoot}/.tmp/                 # staging for downloads and in-progress extractions
```

`PackageInstallRoot` falls back to `{AppContext.BaseDirectory}/.nuplane/packages` when unset, exactly
as it did for remote feeds. The feed directory is now only ever **read** — nothing is created,
renamed, or deleted inside it — so `-v "$(pwd)/packages:/app/packages:ro"` (which our own docs
recommend) works.

The layout, the `.nuplane-ready` completion marker, and the publish rules are now owned by one
internal helper, `PackageInstallStore`, used by both the resolver and `NuGetRemotePackageAcquirer`.
Beyond relocating the extraction it tightens three things for both feed kinds:

- **Atomic publish.** An extraction is staged under `{PackageInstallRoot}/.tmp/<guid>`, gets its
  `.nuplane-ready` marker written *inside the staging directory*, and is then published with a single
  `Directory.Move`. A half-extracted directory is never reachable under the final path, and the code
  never deletes a destination it is not immediately replacing (the old local path deleted first and
  extracted in place, leaving a window where a valid install could be removed under a concurrent
  resolve).
- **Concurrent resolves.** If another writer wins the rename, the loser checks the destination's
  marker and returns the shared install directory instead of failing the resolve. A marker-less
  leftover from an interrupted extraction is replaced instead.
- **Path traversal.** Feed names, package ids, and versions are reduced to a single path segment:
  besides characters the platform rejects, directory separators and `.`/`..` segments are
  neutralized, so none of them can escape the install root. (`Path.GetInvalidFileNameChars()` alone
  does not cover `..` on Unix, which the previous remote-only sanitizer relied on.)

The `#52` property is preserved: the install directory is still keyed off the package identifier **as
spelled on disk**, so differently-cased requests share one extraction. A new test asserts it.

Interaction with #53/#59 (a request pinned to a remote feed may be served by a local cache feed) is
covered by a new test: the extraction is keyed off the feed that actually supplied the package
(`local-drop`), matching `ResolvedPackage.FeedName`.

## Already-extracted packages at the old location

Nothing reads `{feedDir}/.installed/...` any more. On upgrade, each directory-fed package is
**re-extracted once** under `PackageInstallRoot`; from then on the marker check makes it a no-op.
Nuplane does not delete the old `.installed` directory, because that would mean writing to the feed
directory — the very thing this fix removes. Operators can delete it themselves; the docs say so.

One nuance worth stating explicitly: last-known-good startup recovery replays install paths recorded
in the store state and validates that the directory still exists. A host that restarts *before* its
first post-upgrade reconciliation can therefore still load from a previously recorded old path while
that directory exists. That is the pre-existing LKG contract for any recorded install path, the
content is the same package version, and the first reconciliation re-resolves and repoints the
descriptor at the new root. Nothing loads from a stale location once resolution runs.

## Was the double extraction real?

**No — not for a single package.** There is exactly one extraction site per feed kind, and only two
in the whole codebase (`MultiFeedPackageResolver` for local, `NuGetRemotePackageAcquirer` for
remote); no other component copies an install directory. A package resolved from a directory feed was
extracted once, into `<feed>/.installed/`. The `PackageInstallRoot/<feed>/<id>/<version>/` trees seen
alongside it belong to *different* packages (or the same package from a different feed) acquired from
remote feeds — dependencies not present in the baked directory, for example. Nothing to eliminate;
after this change both kinds simply share one root and one layout, so the two trees no longer look
like duplicates. Note the layout stays per-feed, so a package genuinely resolved from two different
feeds still gets one extraction per feed — that convention is unchanged.

A related duplicate *was* removed as a side effect: the install directory is now always keyed by the
normalized version, so `1.0` and `1.0.0` can no longer produce two extractions of one package.

## Tests

New/changed in `test/Nuplane.Runtime.Tests/Reconciliation/LocalDirectoryFeedContractTests.cs`:

- `Resolve_FromLocalFeed_ExtractsUnderInstallRootWithoutWritingToFeedDirectory` — the decisive one:
  after resolving, the feed directory contains **exactly** the `.nupkg` it started with (recursive
  entry snapshot compared before/after), and the install path is under `PackageInstallRoot`.
- `Resolve_FromReadOnlyLocalFeedDirectory_Succeeds` — chmods the feed directory to `r-x` and resolves;
  probes writability first and returns early when running as root (where the mode bits are ignored),
  and skips on Windows.
- `Resolve_SameLocalPackageUnderDifferentCasing_SharesOneExtraction` — guards the #52 property.
- `Resolve_FromLocalFeed_ConcurrentResolvesOfSamePackageShareOneCompleteInstall` — 8 racing resolves
  yield one install path, a complete extraction, and an empty staging area.
- `Resolve_RemotePinnedRequestServedByLocalCacheFeed_ExtractsUnderInstallRootForThatFeed` — the
  #53/#59 interaction.
- **Deliberately updated:** `Resolve_ExactVersion_WhenNupkgFileNameCasingDiffers_ResolvesFromLocalFeed`
  asserted `{feedDir}/.installed/sourcegear.sqlite3/1.0.0`; it now asserts
  `{PackageInstallRoot}/local-drop/sourcegear.sqlite3/1.0.0`. `CacheOnlyFeed_ResolvesExactPackage`
  now configures a `PackageInstallRoot` so the DI-built resolver does not extract into the test
  output directory.

All six new/updated tests were verified to fail against the pre-fix sources and pass after.

`dotnet test nuplane.sln` on the rebased branch: **776 passed, 0 failed, 0 skipped** — NuGet 25,
Store 44, Sources.Directory 15, Runtime 448, Loading 151, Integration 93. (`main` at `d4dc97d` is
771; the delta is the 5 net-new tests.) The `Nuplane.Sources.Directory.Tests` FileSystemWatcher/
debounce tests are timing-flaky under parallel load and failed intermittently — a different test each
run, including on unmodified `main`; they pass consistently when that project runs alone.

## Docs

- `docs/wiki/Usage-Guide.md` — the directory-feed section now states the directory is read-only to
  Nuplane, gives the extraction layout, shows a `--read-only` `docker run` with `:ro`, and tells
  upgraders what happens to the old `.installed` directory.
- `README.md` — directory-backed feed concept and the Kubernetes operational guidance.
- `specs/008-local-feeds-and-watchers/*` — the normative "MUST extract into the feed directory"
  statements are corrected and marked as superseded by #56.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
