### PR TITLE
Make directory observation tests deterministic under load

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -15,6 +15,7 @@
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.3" />
     <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.3" />
     <PackageVersion Include="Microsoft.Extensions.Resilience" Version="10.1.0" />
+    <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.1.0" />
     <PackageVersion Include="Microsoft.NETCore.Platforms" Version="7.0.4" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />

--- a/src/Nuplane.Sources.Directory/Hosting/DebouncedDirtySignal.cs
+++ b/src/Nuplane.Sources.Directory/Hosting/DebouncedDirtySignal.cs
@@ -8,12 +8,18 @@ namespace Nuplane.Sources.Directory.Hosting;
 internal sealed class DebouncedDirtySignal
 {
     private readonly TimeSpan _debounceWindow;
+    private readonly TimeProvider _timeProvider;
     private readonly Channel<bool> _signals = Channel.CreateBounded<bool>(new BoundedChannelOptions(1)
     {
         FullMode = BoundedChannelFullMode.DropOldest
     });
 
-    public DebouncedDirtySignal(TimeSpan debounceWindow)
+    /// <param name="debounceWindow">The quiet period that must elapse before a settled notification is produced.</param>
+    /// <param name="timeProvider">
+    /// The clock used to measure the debounce window. Defaults to <see cref="TimeProvider.System" />; tests supply a
+    /// fake clock so debounce behavior can be verified without depending on the wall clock.
+    /// </param>
+    public DebouncedDirtySignal(TimeSpan debounceWindow, TimeProvider? timeProvider = null)
     {
         if (debounceWindow < TimeSpan.Zero)
         {
@@ -21,6 +27,7 @@ internal sealed class DebouncedDirtySignal
         }
 
         _debounceWindow = debounceWindow;
+        _timeProvider = timeProvider ?? TimeProvider.System;
     }
 
     public void Signal()
@@ -35,7 +42,7 @@ internal sealed class DebouncedDirtySignal
 
         while (true)
         {
-            await Task.Delay(_debounceWindow, cancellationToken);
+            await Task.Delay(_debounceWindow, _timeProvider, cancellationToken);
 
             if (!_signals.Reader.TryRead(out _))
             {

--- a/test/Nuplane.Sources.Directory.Tests/Hosting/DebouncedDirtySignalTests.cs
+++ b/test/Nuplane.Sources.Directory.Tests/Hosting/DebouncedDirtySignalTests.cs
@@ -29,10 +29,14 @@ public sealed class DebouncedDirtySignalTests
         // Arrange
         var wakeup = signal.WaitForNextSettledSignalAsync(CancellationToken.None);
 
-        // Act: a burst of signals inside a single quiet window.
+        // Act: a burst spread across a single quiet window. Spacing the signals in virtual time keeps the
+        // capacity-one channel from collapsing them on its own, so the debounce is what has to hold the
+        // wakeup back; the burst spans half a window, which a correct implementation never settles inside.
         for (var i = 0; i < 10; i++)
         {
             signal.Signal();
+            await FakeClockDriver.AdvanceAsync(time, DebounceWindow / 20);
+            Assert.False(wakeup.IsCompleted, $"Wakeup settled mid-burst, after signal {i + 1}.");
         }
 
         await FakeClockDriver.AdvanceUntilCompletedAsync(time, wakeup, DebounceWindow);

--- a/test/Nuplane.Sources.Directory.Tests/Hosting/DebouncedDirtySignalTests.cs
+++ b/test/Nuplane.Sources.Directory.Tests/Hosting/DebouncedDirtySignalTests.cs
@@ -1,80 +1,103 @@
-using System.Diagnostics;
+using Microsoft.Extensions.Time.Testing;
 using Nuplane.Sources.Directory.Hosting;
+using Nuplane.Sources.Directory.Tests.TestSupport;
 
 namespace Nuplane.Sources.Directory.Tests.Hosting;
 
 /// <summary>
 /// Contract tests for the debounced dirty-signal primitive used by directory observation.
 /// </summary>
+/// <remarks>
+/// The debounce window is measured against a <see cref="FakeTimeProvider" />, so every timing assertion here is
+/// about virtual time the test controls rather than about how quickly the machine happens to be running.
+/// </remarks>
 public sealed class DebouncedDirtySignalTests
 {
+    private static readonly TimeSpan DebounceWindow = TimeSpan.FromMilliseconds(150);
+
+    private readonly FakeTimeProvider time = new();
+    private readonly DebouncedDirtySignal signal;
+
+    public DebouncedDirtySignalTests()
+    {
+        signal = new DebouncedDirtySignal(DebounceWindow, time);
+    }
+
     [Fact]
     public async Task BurstSignals_AreCoalesced_IntoASingleSettledWakeup()
     {
-        var signal = new DebouncedDirtySignal(TimeSpan.FromMilliseconds(100));
+        // Arrange
+        var wakeup = signal.WaitForNextSettledSignalAsync(CancellationToken.None);
 
-        using var waitCts = new CancellationTokenSource(TimeSpan.FromSeconds(3));
-        var wakeup = signal.WaitForNextSettledSignalAsync(waitCts.Token);
-
+        // Act: a burst of signals inside a single quiet window.
         for (var i = 0; i < 10; i++)
         {
             signal.Signal();
-            await Task.Delay(10);
         }
 
-        await wakeup;
+        await FakeClockDriver.AdvanceUntilCompletedAsync(time, wakeup, DebounceWindow);
 
-        using var probeCts = new CancellationTokenSource(TimeSpan.FromMilliseconds(75));
-        await Assert.ThrowsAnyAsync<OperationCanceledException>(
-            async () => await signal.WaitForNextSettledSignalAsync(probeCts.Token));
+        // Assert: the burst produced exactly one wakeup, so a second wait never settles.
+        using var cts = new CancellationTokenSource();
+        var leftover = signal.WaitForNextSettledSignalAsync(cts.Token);
+
+        await FakeClockDriver.AdvanceAsync(time, DebounceWindow * 10);
+        Assert.False(leftover.IsCompleted);
+
+        await cts.CancelAsync();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => leftover);
     }
 
     [Fact]
     public async Task SignalDuringDebounce_ExtendsTheQuietWindow()
     {
-        var signal = new DebouncedDirtySignal(TimeSpan.FromMilliseconds(150));
-        var stopwatch = Stopwatch.StartNew();
-
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(3));
-        var wakeup = signal.WaitForNextSettledSignalAsync(cts.Token);
-
-        signal.Signal();
-        await Task.Delay(100, CancellationToken.None);
+        // Arrange
+        var wakeup = signal.WaitForNextSettledSignalAsync(CancellationToken.None);
         signal.Signal();
 
-        await wakeup;
-        stopwatch.Stop();
+        // Act: signal again halfway through the quiet window.
+        await FakeClockDriver.AdvanceAsync(time, DebounceWindow / 2);
+        Assert.False(wakeup.IsCompleted);
+        signal.Signal();
 
-        Assert.True(
-            stopwatch.Elapsed >= TimeSpan.FromMilliseconds(220),
-            $"Expected trailing-edge debounce to defer wakeup until after the second signal. Actual: {stopwatch.Elapsed.TotalMilliseconds}ms.");
+        // Assert: the original deadline passes without settling, because the late signal restarted the window.
+        await FakeClockDriver.AdvanceAsync(time, DebounceWindow / 2);
+        Assert.False(wakeup.IsCompleted);
+
+        await FakeClockDriver.AdvanceAsync(time, DebounceWindow / 2);
+        Assert.False(wakeup.IsCompleted);
+
+        await FakeClockDriver.AdvanceUntilCompletedAsync(time, wakeup, DebounceWindow);
     }
 
     [Fact]
     public async Task SignalsInSeparateQuietWindows_ProduceSeparateWakeups()
     {
-        var signal = new DebouncedDirtySignal(TimeSpan.FromMilliseconds(80));
+        // Arrange
+        var firstWakeup = signal.WaitForNextSettledSignalAsync(CancellationToken.None);
 
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(3));
-
-        var firstWakeup = signal.WaitForNextSettledSignalAsync(cts.Token);
+        // Act
         signal.Signal();
-        await firstWakeup;
+        await FakeClockDriver.AdvanceUntilCompletedAsync(time, firstWakeup, DebounceWindow);
 
-        await Task.Delay(120, CancellationToken.None);
-
-        var secondWakeup = signal.WaitForNextSettledSignalAsync(cts.Token);
+        var secondWakeup = signal.WaitForNextSettledSignalAsync(CancellationToken.None);
         signal.Signal();
-        await secondWakeup;
+
+        // Assert: a signal in a later quiet window settles on its own rather than being swallowed by the first.
+        await FakeClockDriver.AdvanceUntilCompletedAsync(time, secondWakeup, DebounceWindow);
     }
 
     [Fact]
     public async Task WaitForNextSettledSignalAsync_WhenCancelledBeforeSignal_Throws()
     {
-        var signal = new DebouncedDirtySignal(TimeSpan.FromMilliseconds(100));
-        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(50));
+        // Arrange
+        using var cts = new CancellationTokenSource();
+        var wakeup = signal.WaitForNextSettledSignalAsync(cts.Token);
 
-        await Assert.ThrowsAnyAsync<OperationCanceledException>(
-            async () => await signal.WaitForNextSettledSignalAsync(cts.Token));
+        // Act
+        await cts.CancelAsync();
+
+        // Assert
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => wakeup);
     }
 }

--- a/test/Nuplane.Sources.Directory.Tests/Hosting/DirectoryObservationContractTests.cs
+++ b/test/Nuplane.Sources.Directory.Tests/Hosting/DirectoryObservationContractTests.cs
@@ -10,144 +10,194 @@ namespace Nuplane.Sources.Directory.Tests.Hosting;
 /// <summary>
 /// Contract tests for directory observation coalescing/debounce invariants.
 /// </summary>
-public sealed class DirectoryObservationContractTests
+/// <remarks>
+/// These tests drive a real <see cref="FileSystemWatcher" />, so they cannot use a fake clock. The tests that
+/// wait for a trigger stay load-tolerant instead: readiness is awaited via <see cref="DirectoryWatcherProbe" />
+/// rather than assumed after a fixed sleep, and every wait ceiling is generous relative to the debounce window.
+/// </remarks>
+public sealed class DirectoryObservationContractTests : IAsyncDisposable
 {
+    private static readonly byte[] NupkgContent = [0x50, 0x4B];
+    private static readonly TimeSpan DebounceWindow = TimeSpan.FromMilliseconds(500);
+
+    /// <summary>
+    /// Kept short so that a trigger which should never arrive would still have time to show up within the
+    /// fixed observation window used by the negative test below.
+    /// </summary>
+    private static readonly TimeSpan NonNupkgDebounceWindow = TimeSpan.FromMilliseconds(100);
+
+    /// <summary>
+    /// A ceiling, not an expectation: the happy path returns as soon as the trigger lands, so being generous
+    /// costs nothing and stops a loaded machine from being mistaken for a broken watcher.
+    /// </summary>
+    private static readonly TimeSpan WatcherTimeout = TimeSpan.FromSeconds(30);
+
+    private readonly TempDirectory tempDir = new();
+    private readonly SpyTriggerSink spy = new();
+    private DirectorySourceReconciliationTriggerHostedService? service;
+
     [Fact]
     public async Task BurstyEvents_AreCoalesced_ToAtMostOneTriggerPerDebounceWindow()
     {
-        using var tempDir = new TempDirectory();
-        var spy = new SpyTriggerSink();
-        var options = new DirectorySourceOptions
-        {
-            FeedName = "test-feed",
-            DirectoryPath = tempDir.Path,
-            DebounceWindow = TimeSpan.FromMilliseconds(200),
-            TriggerReconciliationOnChange = true
-        };
+        // Arrange
+        await StartObservingAsync("test-feed");
 
-        var service = new DirectorySourceReconciliationTriggerHostedService(
-            options, spy, NullLogger<DirectorySourceReconciliationTriggerHostedService>.Instance, new ObservationDegradationTracker());
-
-        using var cts = new CancellationTokenSource();
-        var serviceTask = service.StartAsync(cts.Token);
-
-        await Task.Delay(150);
-
+        // Act
         for (var i = 0; i < 10; i++)
         {
-            File.WriteAllBytes(Path.Combine(tempDir.Path, $"burst-{i}.nupkg"), [0x50, 0x4B]);
-            await Task.Delay(10);
+            await WriteNupkgAsync($"burst-{i}.nupkg");
         }
 
+        // Assert
         await DebounceAssert.WaitForCountAsync(
             () => spy.TriggerCount,
             1,
-            TimeSpan.FromSeconds(5),
+            WatcherTimeout,
             "Expected at least 1 queued trigger after burst events");
 
         await DebounceAssert.AssertCoalescedAsync(
             () => spy.TriggerCount,
             2,
-            TimeSpan.FromMilliseconds(500),
+            DebounceWindow * 4,
             "Bursty events should be coalesced to at most 2 queued triggers");
-
-        cts.Cancel();
-        try { await serviceTask; } catch (OperationCanceledException) { }
     }
 
     [Fact]
     public async Task ObservedChangeTrigger_IncludesStructuredFeedOrigin()
     {
-        using var tempDir = new TempDirectory();
-        var spy = new SpyTriggerSink();
-        var options = new DirectorySourceOptions
-        {
-            FeedName = "my-local-feed",
-            DirectoryPath = tempDir.Path,
-            DebounceWindow = TimeSpan.FromMilliseconds(100),
-            TriggerReconciliationOnChange = true
-        };
+        // Arrange
+        await StartObservingAsync("my-local-feed");
 
-        var service = new DirectorySourceReconciliationTriggerHostedService(options, spy, NullLogger<DirectorySourceReconciliationTriggerHostedService>.Instance, new());
-
-        using var cts = new CancellationTokenSource();
-        var serviceTask = service.StartAsync(cts.Token);
-
-        await Task.Delay(150);
-
-        File.WriteAllBytes(Path.Combine(tempDir.Path, "test.nupkg"), [0x50, 0x4B]);
+        // Act
+        await WriteNupkgAsync("test.nupkg");
 
         await DebounceAssert.WaitForCountAsync(
             () => spy.TriggerCount,
             1,
-            TimeSpan.FromSeconds(5),
+            WatcherTimeout,
             "Expected trigger after file creation");
 
-        Assert.NotEmpty(spy.Triggers);
-        var trigger = spy.Triggers[0];
+        // Assert
+        var trigger = Assert.Single(spy.Triggers);
         Assert.Equal(TriggerType.ObservedChange, trigger.Type);
         Assert.NotNull(trigger.ObservedOrigin);
         Assert.Equal("my-local-feed", trigger.ObservedOrigin.FeedName);
         Assert.Equal(FeedObservationKind.DirectoryWatcher, trigger.ObservedOrigin.Kind);
-
-        cts.Cancel();
-        try { await serviceTask; } catch (OperationCanceledException) { }
     }
 
     [Fact]
     public async Task NonNupkgFiles_DoNotTriggerReconciliation()
     {
-        using var tempDir = new TempDirectory();
-        var spy = new SpyTriggerSink();
+        // Arrange
+        await StartAsync("filter-feed", NonNupkgDebounceWindow);
+        await Task.Delay(150, CancellationToken.None);
+
+        // Act
+        await File.WriteAllTextAsync(Path.Combine(tempDir.Path, "readme.txt"), "hello", CancellationToken.None);
+        await File.WriteAllTextAsync(Path.Combine(tempDir.Path, "data.json"), "{}", CancellationToken.None);
+
+        await Task.Delay(TimeSpan.FromMilliseconds(400), CancellationToken.None);
+
+        // Assert
+        Assert.Equal(0, spy.TriggerCount);
+    }
+
+    /// <summary>
+    /// Starts the observation loop, waits until the watcher is demonstrably delivering events, and clears the
+    /// probe triggers so the caller starts from a known-empty spy.
+    /// </summary>
+    private async Task StartObservingAsync(string feedName)
+    {
+        await StartAsync(feedName, DebounceWindow);
+
+        await DirectoryWatcherProbe.WaitUntilObservingAsync(
+            tempDir.Path,
+            () => spy.TriggerCount,
+            DebounceWindow,
+            WatcherTimeout);
+
+        spy.Reset();
+    }
+
+    private async Task StartAsync(string feedName, TimeSpan debounceWindow)
+    {
         var options = new DirectorySourceOptions
         {
-            FeedName = "filter-feed",
+            FeedName = feedName,
             DirectoryPath = tempDir.Path,
-            DebounceWindow = TimeSpan.FromMilliseconds(100),
+            DebounceWindow = debounceWindow,
             TriggerReconciliationOnChange = true
         };
 
-        var service = new DirectorySourceReconciliationTriggerHostedService(options, spy, NullLogger<DirectorySourceReconciliationTriggerHostedService>.Instance, new());
-        using var cts = new CancellationTokenSource();
-        var serviceTask = service.StartAsync(cts.Token);
+        service = new DirectorySourceReconciliationTriggerHostedService(
+            options,
+            spy,
+            NullLogger<DirectorySourceReconciliationTriggerHostedService>.Instance,
+            new ObservationDegradationTracker());
 
-        await Task.Delay(150, cts.Token);
+        await service.StartAsync(CancellationToken.None);
+    }
 
-        await File.WriteAllTextAsync(Path.Combine(tempDir.Path, "readme.txt"), "hello", cts.Token);
-        await File.WriteAllTextAsync(Path.Combine(tempDir.Path, "data.json"), "{}", cts.Token);
+    private Task WriteNupkgAsync(string fileName) =>
+        File.WriteAllBytesAsync(Path.Combine(tempDir.Path, fileName), NupkgContent, CancellationToken.None);
 
-        await Task.Delay(TimeSpan.FromMilliseconds(400), cts.Token);
+    public async ValueTask DisposeAsync()
+    {
+        if (service is not null)
+        {
+            try
+            {
+                await service.StopAsync(CancellationToken.None);
+            }
+            catch (OperationCanceledException)
+            {
+            }
 
-        Assert.Equal(0, spy.TriggerCount);
+            service.Dispose();
+        }
 
-        await cts.CancelAsync();
-        try { await serviceTask; } catch (OperationCanceledException) { }
+        tempDir.Dispose();
     }
 
     private sealed class SpyTriggerSink : IReconciliationTriggerIngress
     {
-        private int _triggerCount;
-        private readonly List<ReconciliationTrigger> _triggers = [];
+        private readonly List<ReconciliationTrigger> triggers = [];
 
-        public int TriggerCount => _triggerCount;
+        public int TriggerCount
+        {
+            get
+            {
+                lock (triggers)
+                {
+                    return triggers.Count;
+                }
+            }
+        }
 
         public IReadOnlyList<ReconciliationTrigger> Triggers
         {
             get
             {
-                lock (_triggers)
+                lock (triggers)
                 {
-                    return _triggers.ToArray();
+                    return triggers.ToArray();
                 }
+            }
+        }
+
+        public void Reset()
+        {
+            lock (triggers)
+            {
+                triggers.Clear();
             }
         }
 
         public void Enqueue(ReconciliationTrigger trigger)
         {
-            Interlocked.Increment(ref _triggerCount);
-            lock (_triggers)
+            lock (triggers)
             {
-                _triggers.Add(trigger);
+                triggers.Add(trigger);
             }
         }
 

--- a/test/Nuplane.Sources.Directory.Tests/Nuplane.Sources.Directory.Tests.csproj
+++ b/test/Nuplane.Sources.Directory.Tests/Nuplane.Sources.Directory.Tests.csproj
@@ -3,6 +3,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Logging" />
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
     <ProjectReference Include="..\..\src\Nuplane.Sources.Directory\Nuplane.Sources.Directory.csproj" />
     <ProjectReference Include="..\..\src\Nuplane.Abstractions\Nuplane.Abstractions.csproj" />
   </ItemGroup>

--- a/test/Nuplane.Sources.Directory.Tests/TestSupport/DirectoryWatcherProbe.cs
+++ b/test/Nuplane.Sources.Directory.Tests/TestSupport/DirectoryWatcherProbe.cs
@@ -1,0 +1,49 @@
+using System.Diagnostics;
+
+namespace Nuplane.Sources.Directory.Tests.TestSupport;
+
+/// <summary>
+/// Synchronizes tests with a live <see cref="FileSystemWatcher" />-backed observation loop.
+/// </summary>
+public static class DirectoryWatcherProbe
+{
+    private static readonly byte[] ProbeContent = [0x50, 0x4B];
+
+    /// <summary>
+    /// Creates probe packages until the observation loop reports a trigger, then waits for the resulting
+    /// signals to drain so they cannot be counted against the scenario under test.
+    /// </summary>
+    /// <remarks>
+    /// Enabling a <see cref="FileSystemWatcher" /> does not guarantee the platform has started delivering
+    /// events, and that gap widens under load, so no fixed startup sleep can make the first write observable.
+    /// Repeating the stimulus turns watcher readiness into something a test waits for rather than assumes.
+    /// </remarks>
+    /// <exception cref="TimeoutException">The watcher delivered no events within <paramref name="timeout" />.</exception>
+    public static async Task WaitUntilObservingAsync(
+        string directoryPath,
+        Func<int> triggerCount,
+        TimeSpan debounceWindow,
+        TimeSpan timeout)
+    {
+        ArgumentNullException.ThrowIfNull(triggerCount);
+
+        var elapsed = Stopwatch.StartNew();
+        for (var probe = 0; triggerCount() == 0; probe++)
+        {
+            if (elapsed.Elapsed > timeout)
+            {
+                throw new TimeoutException(
+                    $"Directory watcher for '{directoryPath}' delivered no events within {timeout.TotalSeconds:0.#}s.");
+            }
+
+            await File.WriteAllBytesAsync(
+                Path.Combine(directoryPath, $"probe-{probe}.nupkg"),
+                ProbeContent,
+                CancellationToken.None);
+
+            await Task.Delay(debounceWindow * 2, CancellationToken.None);
+        }
+
+        await Task.Delay(debounceWindow * 4, CancellationToken.None);
+    }
+}

--- a/test/Nuplane.Sources.Directory.Tests/TestSupport/FakeClockDriver.cs
+++ b/test/Nuplane.Sources.Directory.Tests/TestSupport/FakeClockDriver.cs
@@ -1,0 +1,57 @@
+using Microsoft.Extensions.Time.Testing;
+
+namespace Nuplane.Sources.Directory.Tests.TestSupport;
+
+/// <summary>
+/// Drives a <see cref="FakeTimeProvider" /> forward so timer-based production code can be exercised without
+/// depending on the wall clock.
+/// </summary>
+/// <remarks>
+/// Virtual time only moves when a test moves it, so a loaded machine can never make an assertion fire early.
+/// The small real delays below are scheduling nudges rather than deadlines: if a continuation misses one, the
+/// only consequence is another advance, never a failure.
+/// </remarks>
+public static class FakeClockDriver
+{
+    private static readonly TimeSpan ContinuationNudge = TimeSpan.FromMilliseconds(20);
+
+    /// <summary>
+    /// Advances virtual time by <paramref name="amount" /> and gives parked continuations a chance to run.
+    /// </summary>
+    public static async Task AdvanceAsync(FakeTimeProvider time, TimeSpan amount)
+    {
+        ArgumentNullException.ThrowIfNull(time);
+
+        time.Advance(amount);
+        await Task.Delay(ContinuationNudge, CancellationToken.None);
+    }
+
+    /// <summary>
+    /// Advances virtual time in <paramref name="step" /> increments until <paramref name="task" /> completes,
+    /// giving up after <paramref name="maxSteps" /> increments.
+    /// </summary>
+    /// <exception cref="TimeoutException">The task did not complete within the virtual-time budget.</exception>
+    public static async Task AdvanceUntilCompletedAsync(
+        FakeTimeProvider time,
+        Task task,
+        TimeSpan step,
+        int maxSteps = 20)
+    {
+        ArgumentNullException.ThrowIfNull(time);
+        ArgumentNullException.ThrowIfNull(task);
+
+        for (var taken = 0; !task.IsCompleted; taken++)
+        {
+            if (taken == maxSteps)
+            {
+                throw new TimeoutException(
+                    $"Task did not complete within {maxSteps} virtual steps of {step.TotalMilliseconds}ms.");
+            }
+
+            time.Advance(step);
+            await Task.WhenAny(task, Task.Delay(ContinuationNudge, CancellationToken.None));
+        }
+
+        await task;
+    }
+}


### PR DESCRIPTION
`DirectoryObservationContractTests` and `DebouncedDirtySignalTests` failed intermittently when the full solution ran with test assemblies in parallel, with a varying set of failures per run. Reproduced under CPU saturation: **2 of 3 baseline runs failed.**

## Root cause

Two distinct problems, only one of which was actually about timeouts.

**`DirectoryObservationContractTests` was not timing out because it was slow.** It waited 5s for a trigger with a 100ms debounce window — a 50x overshoot means the event was never delivered at all. `ExecuteAsync` sets `EnableRaisingEvents` synchronously, so the fixed `Task.Delay(150)` startup sleep looked sufficient, but on macOS the FSEvents stream needs time to *begin delivering* after the watcher is enabled, and under load that gap exceeds 150ms. The file write lands in the blind spot and no event ever fires. Raising the timeouts alone would not have fixed this.

**`DebouncedDirtySignalTests` had a genuine wall-clock dependency.**

## Changes

`DebouncedDirtySignal` accepts an optional `TimeProvider`, defaulting to `TimeProvider.System` so the hosted service and production behavior are unchanged. `DebouncedDirtySignalTests` drives a `FakeTimeProvider` — the wall clock is out of the picture entirely, and those tests now run in ~30ms.

For the two flaky contract tests, watcher readiness is now *awaited rather than assumed*: `DirectoryWatcherProbe` writes probe packages until the watcher demonstrably delivers a trigger, then drains before the spy is reset. Wait ceilings scale off the debounce window with a generous 30s cap — a ceiling, not an expectation, since the happy path returns as soon as the trigger lands.

Both helpers follow the same rule: **virtual time only moves when a test moves it, and real delays are scheduling nudges rather than deadlines** — a missed nudge causes another advance, never a failure. That is what makes the assertions load-proof.

`NonNupkgFiles_DoNotTriggerReconciliation` was not among the flaky tests and is deliberately left alone: it keeps its original debounce window, timings, and assertion. It shares the new fixture and teardown but does not use the readiness probe.

Also folds repeated arrange blocks into instance fields plus start helpers with `IAsyncDisposable` teardown; the hosted services were previously never stopped or disposed.

## Verification

**11 consecutive green runs under CPU saturation** (load average ~320): 8 Directory-assembly and 3 full-solution. Assembly duration held steady at 12-13s across every run regardless of load.

Mutation-tested to confirm the rewritten assertions still bite: removing the debounce delay from `DebouncedDirtySignal` fails both timing tests in ~35ms. The mutation was reverted and the solution rebuilt clean.

## Reviewer notes

- Adds `Microsoft.Extensions.TimeProvider.Testing` to `Directory.Packages.props`, pinned at **10.1.0** to match the existing `Microsoft.Extensions.Resilience` line rather than the latest 10.8.0.
- No `docs/` or `specs/` updates: `DebouncedDirtySignal` is internal and the new parameter is optional with an unchanged default, so there is no public API or behavior change to document.

🤖 Generated with [Claude Code](https://claude.com/claude-code)