### PR TITLE
Let the StoreRegistry section win over the Setup shorthand

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,10 +307,14 @@ Nuplane has two configuration layers:
   - `PackageLoadModes`
   - `SharedAssemblies`
 
-When both layers express the same reconciliation setting, the more specific `Nuplane:Reconciliation` section wins over the `Nuplane:Setup` shorthand:
+When both layers express the same setting, the more specific runtime option section wins over the `Nuplane:Setup` shorthand:
 
 - `Reconciliation:EnableAutomaticReconciliation` overrides `Setup:AutomaticReconciliation` in both directions when the key is present; an explicit `false` disables automatic reconciliation even when the shorthand enables it.
 - `Reconciliation:PollInterval` overrides `Setup:PollInterval`; when neither is set, automatic reconciliation polls every 60 seconds.
+- `StoreRegistry:StateFilePath` overrides `Setup:StateFilePath`, and `StoreRegistry:UseInMemoryStore` overrides `Setup:UseInMemoryStore` in both directions; an explicit `false` there keeps state persisted even when the shorthand asks for an in-memory store.
+- The two store persistence settings are mutually exclusive, so an explicit choice in `StoreRegistry` also suppresses the opposing `Setup` shorthand: `StoreRegistry:UseInMemoryStore: true` ignores `Setup:StateFilePath`, and `StoreRegistry:StateFilePath` ignores `Setup:UseInMemoryStore`.
+
+Builder calls run after configuration binds, so `WithStateFile(...)` and `UseInMemoryStore()` in the `AddNuplane` callback still override both layers.
 
 For unrestricted feeds, prefer one of these explicit forms:
 

--- a/docs/wiki/Usage-Guide.md
+++ b/docs/wiki/Usage-Guide.md
@@ -80,11 +80,19 @@ This avoids positional array merging when `appsettings.json`, environment variab
 configuration files are layered. Feed object order is not semantic; configure feed priorities
 separately when resolution order matters.
 
-When the same reconciliation setting is expressed in both layers, the more specific
-`Nuplane:Reconciliation` section wins over the `Nuplane:Setup` shorthand. An explicitly present
+When the same setting is expressed in both layers, the more specific runtime option section wins
+over the `Nuplane:Setup` shorthand. An explicitly present
 `Reconciliation:EnableAutomaticReconciliation` decides automatic reconciliation in both directions,
 so `false` there disables polling even when `Setup:AutomaticReconciliation` is `true`; the same
 applies to `Reconciliation:PollInterval` over `Setup:PollInterval`.
+
+Store persistence follows the same rule: `StoreRegistry:StateFilePath` and
+`StoreRegistry:UseInMemoryStore` decide over `Setup:StateFilePath` and `Setup:UseInMemoryStore`, so
+`StoreRegistry:UseInMemoryStore: false` keeps state persisted even when the shorthand asks for an
+in-memory store. Because the two persistence settings are mutually exclusive, an explicit choice in
+`StoreRegistry` also suppresses the opposing shorthand instead of combining into a rejected
+configuration. Builder calls run last, so `WithStateFile(...)` and `UseInMemoryStore()` in the
+`AddNuplane` callback still override both configuration layers.
 
 ### Directory feeds as an offline package source
 

--- a/specs/012-default-state-path/contracts/store-persistence-configuration.md
+++ b/specs/012-default-state-path/contracts/store-persistence-configuration.md
@@ -49,7 +49,9 @@ Defines the external configuration and builder contract for selecting store pers
 ## Precedence Rules
 
 - `Nuplane:Setup` remains the high-level translation surface.
-- Programmatic builder configuration and `Nuplane:Setup` translation continue to override directly bound `Nuplane:StoreRegistry` values, matching existing `StateFilePath` behavior.
+- Programmatic builder configuration overrides both configuration layers, because builder calls run after configuration binds.
+- The more specific `Nuplane:StoreRegistry` section overrides the `Nuplane:Setup` translation in both directions when the key is explicitly present; the shorthand only applies when the matching `StoreRegistry` key is absent. Superseded the original rule, under which the `Setup` translation always won.
+- Because the two persistence settings are mutually exclusive, an explicit `StoreRegistry` persistence choice also suppresses the opposing `Setup` shorthand rather than combining into a configuration the validator rejects.
 - The final resolved `StoreRegistryOptions` object is the single source of truth for runtime behavior.
 
 ## Trust & Security Boundary

--- a/src/Nuplane/NuplaneServiceCollectionExtensions.cs
+++ b/src/Nuplane/NuplaneServiceCollectionExtensions.cs
@@ -18,10 +18,12 @@ public static class NuplaneServiceCollectionExtensions
     /// translated from the <c>Setup</c> section.
     /// </summary>
     /// <remarks>
-    /// Where both layers express the same reconciliation setting, the more specific
-    /// <c>Reconciliation</c> section wins: an explicitly present
-    /// <c>Reconciliation:EnableAutomaticReconciliation</c> or <c>Reconciliation:PollInterval</c>
-    /// overrides the <c>Setup:AutomaticReconciliation</c> / <c>Setup:PollInterval</c> shorthand.
+    /// Where both layers express the same setting, the more specific runtime option section wins:
+    /// an explicitly present <c>Reconciliation:EnableAutomaticReconciliation</c> or
+    /// <c>Reconciliation:PollInterval</c> overrides the <c>Setup:AutomaticReconciliation</c> /
+    /// <c>Setup:PollInterval</c> shorthand, and an explicitly present
+    /// <c>StoreRegistry:StateFilePath</c> or <c>StoreRegistry:UseInMemoryStore</c> overrides the
+    /// <c>Setup:StateFilePath</c> / <c>Setup:UseInMemoryStore</c> shorthand.
     /// </remarks>
     public static IServiceCollection AddNuplane(
         this IServiceCollection services,
@@ -42,11 +44,16 @@ public static class NuplaneServiceCollectionExtensions
 
         var setupSection = NuplaneSetupConfigurationServices.GetSetupSectionOrSelf(configuration);
         var reconciliationSection = NuplaneSetupConfigurationServices.GetReconciliationSectionOrSelf(configuration);
+        var storeRegistrySection = NuplaneSetupConfigurationServices.GetStoreRegistrySectionOrSelf(configuration);
 
         return services.AddNuplane(builder =>
         {
             NuplaneOptionsRegistrationServices.BindConfiguredOptions(builder.Services, configuration);
-            NuplaneSetupConfigurationServices.ApplySetupConfiguration(builder, setupSection, reconciliationSection);
+            NuplaneSetupConfigurationServices.ApplySetupConfiguration(
+                builder,
+                setupSection,
+                reconciliationSection,
+                storeRegistrySection);
             configure?.Invoke(builder);
         });
     }

--- a/src/Nuplane/Registration/NuplaneOptionsRegistrationServices.cs
+++ b/src/Nuplane/Registration/NuplaneOptionsRegistrationServices.cs
@@ -22,7 +22,7 @@ internal static class NuplaneOptionsRegistrationServices
     private const string LockFileSectionName = "LockFile";
     private const string CleanupPolicySectionName = "CleanupPolicy";
     private const string ConvergenceSectionName = "Convergence";
-    private const string StoreRegistrySectionName = "StoreRegistry";
+    internal const string StoreRegistrySectionName = "StoreRegistry";
 
     private static readonly Action<IServiceCollection, IConfiguration>[] ConfiguredOptionBinders =
     [

--- a/src/Nuplane/Registration/NuplaneSetupConfigurationServices.cs
+++ b/src/Nuplane/Registration/NuplaneSetupConfigurationServices.cs
@@ -3,6 +3,7 @@ using Nuplane.Builder;
 using Nuplane.Feeds.Setup;
 using Nuplane.Reconciliation.Configuration;
 using Nuplane.Setup;
+using Nuplane.Store.State;
 
 namespace Nuplane.Registration;
 
@@ -20,23 +21,19 @@ internal static class NuplaneSetupConfigurationServices
             configuration,
             NuplaneOptionsRegistrationServices.ReconciliationSectionName);
 
+    internal static IConfigurationSection GetStoreRegistrySectionOrSelf(IConfiguration configuration) =>
+        NuplaneOptionsRegistrationServices.GetNamedSectionOrSelf(
+            configuration,
+            NuplaneOptionsRegistrationServices.StoreRegistrySectionName);
+
     internal static void ApplySetupConfiguration(
         NuplaneBuilder builder,
         IConfiguration setupConfiguration,
-        IConfiguration reconciliationConfiguration)
+        IConfiguration reconciliationConfiguration,
+        IConfiguration storeRegistryConfiguration)
     {
         ApplyAutomaticReconciliation(builder, setupConfiguration, reconciliationConfiguration);
-
-        var stateFilePath = setupConfiguration[nameof(NuplaneSetupOptions.StateFilePath)];
-        if (!string.IsNullOrWhiteSpace(stateFilePath))
-        {
-            builder.WithStateFile(stateFilePath);
-        }
-
-        if (setupConfiguration.GetValue<bool?>(nameof(NuplaneSetupOptions.UseInMemoryStore)) is true)
-        {
-            builder.UseInMemoryStore();
-        }
+        ApplyStorePersistence(builder, setupConfiguration, storeRegistryConfiguration);
 
         NuplaneFeedSetupConfiguration.ApplyConfiguredFeeds(builder, setupConfiguration);
     }
@@ -64,5 +61,33 @@ internal static class NuplaneSetupConfigurationServices
             ?? DefaultPollInterval;
 
         builder.PollEvery(pollInterval);
+    }
+
+    // The dedicated StoreRegistry section is more specific than the Setup shorthand, so an explicitly
+    // present key there wins in both directions: section binding already applied it, and the matching
+    // Setup shorthand is skipped. An explicit persistence choice in that section also suppresses the
+    // opposing shorthand, so the two layers can never combine into a state the validator rejects.
+    private static void ApplyStorePersistence(
+        NuplaneBuilder builder,
+        IConfiguration setupConfiguration,
+        IConfiguration storeRegistryConfiguration)
+    {
+        var storeStateFilePath = storeRegistryConfiguration.GetValue<string>(nameof(StoreRegistryOptions.StateFilePath));
+        var storeUseInMemoryStore = storeRegistryConfiguration.GetValue<bool?>(nameof(StoreRegistryOptions.UseInMemoryStore));
+        var storeSelectsPath = !string.IsNullOrWhiteSpace(storeStateFilePath);
+        var storeSelectsInMemory = storeUseInMemoryStore is true;
+
+        var stateFilePath = setupConfiguration[nameof(NuplaneSetupOptions.StateFilePath)];
+        if (storeStateFilePath is null && !storeSelectsInMemory && !string.IsNullOrWhiteSpace(stateFilePath))
+        {
+            builder.WithStateFile(stateFilePath);
+        }
+
+        if (storeUseInMemoryStore is null
+            && !storeSelectsPath
+            && setupConfiguration.GetValue<bool?>(nameof(NuplaneSetupOptions.UseInMemoryStore)) is true)
+        {
+            builder.UseInMemoryStore();
+        }
     }
 }

--- a/test/Nuplane.Runtime.Tests/Configuration/ConfigurationDrivenRegistrationTests.cs
+++ b/test/Nuplane.Runtime.Tests/Configuration/ConfigurationDrivenRegistrationTests.cs
@@ -167,8 +167,7 @@ public sealed class ConfigurationDrivenRegistrationTests
                     ["Nuplane:Setup:Feeds:0:IncludePatterns:0"] = "*",
                     ["Nuplane:Setup:Feeds:0:Directory:Watch"] = "false",
                     ["Nuplane:Setup:Feeds:0:Directory:DebounceWindow"] = "00:00:02",
-                    ["Nuplane:Reconciliation:MaxRetryAttempts"] = "5",
-                    ["Nuplane:StoreRegistry:StateFilePath"] = Path.Combine(root, "ignored-by-setup.json")
+                    ["Nuplane:Reconciliation:MaxRetryAttempts"] = "5"
                 })
                 .Build();
 
@@ -571,7 +570,7 @@ public sealed class ConfigurationDrivenRegistrationTests
     }
 
     [Fact]
-    public void AddNuplane_SetupStateFilePathOverridesStoreRegistrySection()
+    public void AddNuplane_StoreRegistryStateFilePathOverridesSetupSection()
     {
         var root = Path.Combine(Path.GetTempPath(), "nuplane-precedence", Guid.NewGuid().ToString("N"));
         var packagesPath = Path.Combine(root, "packages");
@@ -600,7 +599,7 @@ public sealed class ConfigurationDrivenRegistrationTests
             var effectiveSettings = provider.GetRequiredService<EffectiveStorePersistenceSettings>();
 
             Assert.Equal(StorePersistenceMode.ConfiguredPath, effectiveSettings.Mode);
-            Assert.Equal(Path.GetFullPath(setupPath), effectiveSettings.ResolvedStateFilePath);
+            Assert.Equal(Path.GetFullPath(storeRegistryPath), effectiveSettings.ResolvedStateFilePath);
         }
         finally
         {

--- a/test/Nuplane.Runtime.Tests/Configuration/NuplaneSetupConfigurationServicesTests.cs
+++ b/test/Nuplane.Runtime.Tests/Configuration/NuplaneSetupConfigurationServicesTests.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 using Nuplane.Hosting;
 using Nuplane.Reconciliation.Configuration;
+using Nuplane.Store.State;
 
 namespace Nuplane.Runtime.Tests.Configuration;
 
@@ -215,6 +216,144 @@ public sealed class NuplaneSetupConfigurationServicesTests
         Assert.Equal(TimeSpan.FromSeconds(10), options.PollInterval);
     }
 
+    // The store persistence layer follows the same precedence rule as the Reconciliation section:
+    // an explicitly present StoreRegistry key decides in both directions, and the Setup shorthand
+    // only applies when the matching StoreRegistry key is absent.
+    [Theory]
+    [InlineData("./setup-state.json", null, "./setup-state.json")]
+    [InlineData(null, "./store-state.json", "./store-state.json")]
+    [InlineData("./setup-state.json", "./store-state.json", "./store-state.json")]
+    public void ApplySetupConfiguration_SetupAndStoreRegistryStateFilePathCombination_PrefersStoreRegistrySection(
+        string? setupValue,
+        string? storeRegistryValue,
+        string expectedPath)
+    {
+        // Arrange
+        var settings = BuildStoreSettings(("Setup:StateFilePath", setupValue), ("StoreRegistry:StateFilePath", storeRegistryValue));
+
+        // Act
+        var settingsResult = ResolveStorePersistenceSettings(settings);
+
+        // Assert
+        Assert.Equal(StorePersistenceMode.ConfiguredPath, settingsResult.Mode);
+        Assert.Equal(Path.GetFullPath(expectedPath), settingsResult.ResolvedStateFilePath);
+    }
+
+    [Theory]
+    [InlineData("true", null, StorePersistenceMode.InMemory)]
+    [InlineData("true", "false", StorePersistenceMode.DefaultPath)]
+    [InlineData("false", "true", StorePersistenceMode.InMemory)]
+    [InlineData(null, "true", StorePersistenceMode.InMemory)]
+    [InlineData("false", null, StorePersistenceMode.DefaultPath)]
+    [InlineData(null, null, StorePersistenceMode.DefaultPath)]
+    public void ApplySetupConfiguration_SetupAndStoreRegistryUseInMemoryStoreCombination_PrefersStoreRegistrySection(
+        string? setupValue,
+        string? storeRegistryValue,
+        StorePersistenceMode expectedMode)
+    {
+        // Arrange
+        var settings = BuildStoreSettings(("Setup:UseInMemoryStore", setupValue), ("StoreRegistry:UseInMemoryStore", storeRegistryValue));
+
+        // Act
+        var settingsResult = ResolveStorePersistenceSettings(settings);
+
+        // Assert
+        Assert.Equal(expectedMode, settingsResult.Mode);
+    }
+
+    [Fact]
+    public void ApplySetupConfiguration_StoreRegistryStateFilePathWithSetupInMemoryShorthand_UsesStoreRegistryPath()
+    {
+        // Arrange
+        var settings = BuildStoreSettings(("Setup:UseInMemoryStore", "true"), ("StoreRegistry:StateFilePath", "./store-state.json"));
+
+        // Act
+        var settingsResult = ResolveStorePersistenceSettings(settings);
+
+        // Assert
+        Assert.Equal(StorePersistenceMode.ConfiguredPath, settingsResult.Mode);
+        Assert.Equal(Path.GetFullPath("./store-state.json"), settingsResult.ResolvedStateFilePath);
+    }
+
+    [Fact]
+    public void ApplySetupConfiguration_StoreRegistryInMemoryStoreWithSetupStateFilePathShorthand_UsesInMemoryStore()
+    {
+        // Arrange
+        var settings = BuildStoreSettings(("Setup:StateFilePath", "./setup-state.json"), ("StoreRegistry:UseInMemoryStore", "true"));
+
+        // Act
+        var settingsResult = ResolveStorePersistenceSettings(settings);
+
+        // Assert
+        Assert.Equal(StorePersistenceMode.InMemory, settingsResult.Mode);
+        Assert.Null(settingsResult.ResolvedStateFilePath);
+    }
+
+    [Fact]
+    public void ApplySetupConfiguration_StoreRegistryInMemoryStoreDisabledWithSetupStateFilePathShorthand_UsesSetupPath()
+    {
+        // Arrange
+        var settings = BuildStoreSettings(("Setup:StateFilePath", "./setup-state.json"), ("StoreRegistry:UseInMemoryStore", "false"));
+
+        // Act
+        var settingsResult = ResolveStorePersistenceSettings(settings);
+
+        // Assert
+        Assert.Equal(StorePersistenceMode.ConfiguredPath, settingsResult.Mode);
+        Assert.Equal(Path.GetFullPath("./setup-state.json"), settingsResult.ResolvedStateFilePath);
+    }
+
+    [Fact]
+    public void ApplySetupConfiguration_BuilderWithStateFileAfterStoreRegistrySection_UsesBuilderPath()
+    {
+        // Arrange
+        var configuration = BuildConfiguration(BuildStoreSettings(
+            ("Setup:StateFilePath", "./setup-state.json"),
+            ("StoreRegistry:StateFilePath", "./store-state.json")));
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        // Act
+        services.AddNuplane(
+            configuration.GetSection("Nuplane"),
+            nuplane => nuplane.WithStateFile("./builder-state.json"));
+
+        // Assert
+        using var provider = services.BuildServiceProvider();
+        var settingsResult = provider.GetRequiredService<EffectiveStorePersistenceSettings>();
+        Assert.Equal(StorePersistenceMode.ConfiguredPath, settingsResult.Mode);
+        Assert.Equal(Path.GetFullPath("./builder-state.json"), settingsResult.ResolvedStateFilePath);
+    }
+
+    [Fact]
+    public void ApplySetupConfiguration_SetupSectionPassedDirectly_UsesSetupStateFilePath()
+    {
+        // Arrange
+        var configuration = BuildConfiguration(BuildStoreSettings(("Setup:StateFilePath", "./setup-state.json")));
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        // Act
+        services.AddNuplane(configuration.GetSection("Nuplane:Setup"));
+
+        // Assert
+        using var provider = services.BuildServiceProvider();
+        var settingsResult = provider.GetRequiredService<EffectiveStorePersistenceSettings>();
+        Assert.Equal(StorePersistenceMode.ConfiguredPath, settingsResult.Mode);
+        Assert.Equal(Path.GetFullPath("./setup-state.json"), settingsResult.ResolvedStateFilePath);
+    }
+
+    private static Dictionary<string, string?> BuildStoreSettings(params (string Key, string? Value)[] entries)
+    {
+        var settings = new Dictionary<string, string?>();
+        foreach (var (key, value) in entries.Where(static entry => entry.Value is not null))
+        {
+            settings[$"Nuplane:{key}"] = value;
+        }
+
+        return settings;
+    }
+
     private static IConfigurationRoot BuildConfiguration(Dictionary<string, string?> settings) =>
         new ConfigurationBuilder().AddInMemoryCollection(settings).Build();
 
@@ -232,5 +371,12 @@ public sealed class NuplaneSetupConfigurationServicesTests
         var services = AddNuplaneFromConfiguration(settings);
         using var provider = services.BuildServiceProvider();
         return provider.GetRequiredService<IOptions<ReconciliationOptions>>().Value;
+    }
+
+    private static EffectiveStorePersistenceSettings ResolveStorePersistenceSettings(Dictionary<string, string?> settings)
+    {
+        var services = AddNuplaneFromConfiguration(settings);
+        using var provider = services.BuildServiceProvider();
+        return provider.GetRequiredService<EffectiveStorePersistenceSettings>();
     }
 }


### PR DESCRIPTION
## Problem

`src/Nuplane/Registration/NuplaneSetupConfigurationServices.cs` translated `Nuplane:Setup:StateFilePath` and `Nuplane:Setup:UseInMemoryStore` into `StoreRegistryOptions` through `builder.WithStateFile(...)` / `builder.UseInMemoryStore()`. Because `BindConfiguredOptions` binds the `StoreRegistry` section first and those builder calls register a later `Configure<StoreRegistryOptions>` delegate, the shorthand always won:

- an explicit `Nuplane:StoreRegistry:StateFilePath` was silently discarded;
- `Nuplane:StoreRegistry:UseInMemoryStore: false` could not undo `Setup:UseInMemoryStore: true`.

This is the same class of bug as #54 (fixed for the `Reconciliation` section in #60).

## Fix

Align the store layer with the precedence rule established in #60 rather than documenting shorthand-wins as intentional. `ApplyStorePersistence` mirrors `ApplyAutomaticReconciliation`: the more specific `StoreRegistry` section wins in both directions when the key is explicitly present, read via `GetValue<string>` / `GetValue<bool?>` so an explicit value is distinguishable from an absent key. The Setup shorthand only applies when the matching `StoreRegistry` key is absent.

One decision beyond a straight key-by-key port: the two store settings are mutually exclusive (both validators reject the combination), so an explicit `StoreRegistry` persistence choice also suppresses the **opposing** shorthand. Without that, `Setup:StateFilePath` + `StoreRegistry:UseInMemoryStore: true` would resolve to both being set and fail startup validation instead of honoring the override. An explicit `UseInMemoryStore: false` still only suppresses the in-memory shorthand — it does not discard an unrelated `Setup:StateFilePath`.

Builder calls are unaffected: `configure` runs after `ApplySetupConfiguration`, so `WithStateFile(...)` / `UseInMemoryStore()` in code still override both configuration layers. A test pins that.

## Tests

`AddNuplane_SetupStateFilePathOverridesStoreRegistrySection` asserted the old behavior (via the `ignored-by-setup.json` key); it is renamed to `AddNuplane_StoreRegistryStateFilePathOverridesSetupSection` and now asserts the opposite path. Ten cases added to `NuplaneSetupConfigurationServicesTests` cover both truth tables, the cross-key suppression, the setup-section-passed-directly path, and builder-wins.

The coverage was verified to bite: reverting `ApplyStorePersistence` to the old unconditional form fails 5 of the new tests.

## Docs

README, `docs/wiki/Usage-Guide.md`, the `AddNuplane` XML remarks, and the Precedence Rules in `specs/012-default-state-path/contracts/store-persistence-configuration.md`, which stated the superseded rule normatively.

## Validation

`dotnet test nuplane.sln` passes in full — Runtime 461, Integration 93, Loading 160, Store 44, Sources.Directory 15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)