### PR TITLE
Correct the private field naming convention to match the code

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,7 @@ Run focused tests first for the area changed, then run the full solution when pr
 - Package versions are centrally managed in `Directory.Packages.props`; do not add `Version` attributes to individual `PackageReference` items.
 - Prefer `sealed record` for DTO/result types and sealed data-only options classes.
 - Use file-scoped namespaces that mirror folder structure.
-- Use private fields without underscore prefixes.
+- Use `_camelCase` for private instance fields and PascalCase for private static fields; the naming policy in `Nuplane.sln.DotSettings` enforces this.
 - Use `ArgumentNullException.ThrowIfNull(...)` for public API null guards.
 - Keep options validation in `IValidateOptions<T>` implementations; do not add `IsValid()` methods to options classes.
 - Use `[LoggerMessage]` source-generated logging for structured log methods.

--- a/docs/coding-conventions.md
+++ b/docs/coding-conventions.md
@@ -48,12 +48,18 @@ This document defines the coding standards and conventions for the Nuplane proje
 | Kind | Convention | Example |
 |------|-----------|---------|
 | Public property | PascalCase | `PollInterval`, `MaxRetryAttempts` |
-| Private field | camelCase (no underscore prefix) | `reconciliationOptions`, `cycleLock` |
+| Private instance field | `_camelCase` (underscore prefix) | `_reconciliationOptions`, `_cycleLock` |
+| Private static field | PascalCase | `JsonOptions`, `AssemblyNames` |
 | Parameter | camelCase | `cancellationToken`, `configureFeeds` |
 | Local variable | camelCase | `feedResolutionOptions`, `validationErrors` |
 | Constant | PascalCase | `EmptyChangeSet` |
 | Method | PascalCase, verb phrase | `TriggerManualAsync`, `EvaluateAsync` |
 | Async method | `Async` suffix | `ResolveAsync`, `GetDesiredAsync` |
+
+The private instance field rule is enforced by the naming policy in `Nuplane.sln.DotSettings`
+(`AccessRightKinds="Private"`, `Prefix="_"`, `Style="aaBb"`), so ReSharper and Rider flag deviations
+automatically. A small number of older files still use bare `camelCase`; treat `_camelCase` as correct
+when adding fields or touching those files.
 
 ### Files
 


### PR DESCRIPTION
Follow-up to #63, where an automated reviewer cited the documented private-field naming rule against a field that matched both its own file and the repo's enforced tooling policy. The rule, not the code, turned out to be wrong.

## The divergence

`AGENTS.md` and `docs/coding-conventions.md` both said to use private fields **without** underscore prefixes. Three independent lines of evidence say the opposite.

**1. The repo's own tooling enforces underscores.** `Nuplane.sln.DotSettings` is checked in and configures private instance fields as:

```
AccessRightKinds="Private"  Prefix="_"  Style="aaBb"
```

ReSharper and Rider have therefore been flagging the *documented* style as a violation.

**2. The code agrees with the tooling.**

| Scope | `_camelCase` | bare `camelCase` | % conforming to tooling |
|---|---|---|---|
| `src/` private instance fields | 144 | 20 | 87% |
| `test/` private instance fields | 73 | 21 | 77% |
| `src/` private static fields | 13 PascalCase | 0 | 100% |

Private static fields are consistently PascalCase and the table did not cover them at all.

**3. The rule's own examples give it away.** It cited `reconciliationOptions` and `cycleLock`. Both exist in `ReconciliationService.cs` — as `_reconciliationOptions` and `_cycleLock`. They are real fields with the underscore stripped off to fit a rule the code never followed.

## Changes

Documentation only. Splits the naming table row into private instance vs. private static fields, restores the original examples with their actual names, and points at the DotSettings policy as the enforcement mechanism.

No code changes. The ~20 non-conforming fields (mostly `Nuplane.Loading`) are deliberately left alone rather than churned as part of a docs fix — the note flags them as the minority case. Happy to follow up with a mechanical rename if you want full conformance.

## Verification

Documentation-only, so no build or test impact. Checked that the stale claim appears nowhere else: `.github/agents/copilot-instructions.md`, `README.md`, `docs/wiki/`, and the `specs/` tree contain no copy of it, and the two edited files were the only occurrences.

## Also noticed, not changed

`[LoggerMessage]` source-generated logging is documented as the rule for structured log methods, but `src/` has 32 `[LoggerMessage]` declarations against 71 direct `logger.Log*` calls. That reads as genuine tech debt against a goal worth keeping, rather than a wrong doc, so I left it. Worth a separate decision on whether to close the gap or soften the wording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
