### PR TITLE
Unload assembly contexts of packages removed or superseded by reconciliation

### DIFF
--- a/src/Nuplane.Loading.Abstractions/IPackageLoader.cs
+++ b/src/Nuplane.Loading.Abstractions/IPackageLoader.cs
@@ -61,4 +61,16 @@ internal interface IPackageLoader
     /// <param name="context">When successful, receives the active load context handle.</param>
     /// <returns><see langword="true"/> if the context exists; otherwise <see langword="false"/>.</returns>
     bool TryGetContext(string packageId, string version, out PackageLoadContextHandle? context);
+
+    /// <summary>
+    /// Forgets and unloads the assembly load context of every currently-loaded package whose
+    /// <c>id@version</c> identity is not present in <paramref name="activeVersionById"/> — i.e. packages
+    /// that were removed from, or superseded in, the desired set by a reconciliation. A load context shared
+    /// across a package graph is only unloaded once no still-active package references it, and
+    /// non-collectible (host-integrated) contexts are never unloaded. The unload is cooperative: the CLR
+    /// reclaims the context on a subsequent GC once every remaining managed reference to it is released.
+    /// </summary>
+    /// <param name="activeVersionById">The authoritative active version per package id after reconciliation.</param>
+    /// <returns>The <c>id@version</c> keys whose contexts were forgotten (and unloaded when unreferenced).</returns>
+    IReadOnlyList<string> UnloadContextsNotActive(IReadOnlyDictionary<string, string> activeVersionById);
 }

--- a/src/Nuplane.Loading/PackageAutoLoadingObserver.cs
+++ b/src/Nuplane.Loading/PackageAutoLoadingObserver.cs
@@ -89,6 +89,11 @@ internal sealed class PackageAutoLoadingObserver : INuplaneObserver
             return;
         }
 
+        // Unload the contexts of packages this cycle removed or superseded BEFORE loading the new set, so a
+        // hot-swapped package's old assemblies stop being rooted by the loader. Runs before the early returns
+        // below because a pure removal produces nothing to load yet still must release the old context.
+        await UnloadInactiveContextsAsync(changeSet, ct);
+
         var packagesToLoad = BuildPackagesToLoad(changeSet, appliedPackages);
         if (packagesToLoad.Count == 0)
         {
@@ -171,6 +176,40 @@ internal sealed class PackageAutoLoadingObserver : INuplaneObserver
     /// <inheritdoc />
     public Task OnPackageFailedAsync(string packageId, Exception exception, CancellationToken ct)
         => Task.CompletedTask;
+
+    /// <summary>
+    /// Releases the assembly load contexts of packages that this reconciliation removed or superseded.
+    /// The authoritative "what should stay loaded" set is the post-reconcile store state
+    /// (<c>ActiveVersionById</c>) — NOT <paramref name="changeSet"/> alone and NOT the applied delta —
+    /// so a context is only ever unloaded when it is genuinely no longer active.
+    /// </summary>
+    private async Task UnloadInactiveContextsAsync(PackageChangeSet changeSet, CancellationToken ct)
+    {
+        // Fast path: a no-op reconcile (nothing removed, nothing updated) can never orphan a context.
+        if (changeSet.Removed.Count == 0 && changeSet.Updated.Count == 0)
+        {
+            return;
+        }
+
+        // Without the store we cannot know the authoritative active set, and guessing risks unloading a
+        // still-active package. Skip rather than over-unload.
+        if (_storeRegistry is null)
+        {
+            return;
+        }
+
+        var state = await _storeRegistry.GetStateAsync(ct);
+        var unloaded = _loader.UnloadContextsNotActive(state.ActiveVersionById);
+
+        if (unloaded.Count > 0)
+        {
+            _logger.LogInformation(
+                "Unloaded {Count} package context(s) no longer active after reconciliation: {Keys}. CorrelationId={CorrelationId}",
+                unloaded.Count,
+                string.Join(", ", unloaded),
+                changeSet.CorrelationId);
+        }
+    }
 
     private List<ResolvedPackage> BuildPackagesToLoad(
         PackageChangeSet changeSet,

--- a/src/Nuplane.Loading/PackageLoader.cs
+++ b/src/Nuplane.Loading/PackageLoader.cs
@@ -474,6 +474,86 @@ internal sealed class PackageLoader : IPackageLoader
     }
 
     /// <inheritdoc />
+    public IReadOnlyList<string> UnloadContextsNotActive(IReadOnlyDictionary<string, string> activeVersionById)
+    {
+        ArgumentNullException.ThrowIfNull(activeVersionById);
+
+        var activeKeys = new HashSet<string>(
+            activeVersionById.Select(static entry => BuildKey(entry.Key, entry.Value)),
+            StringComparer.OrdinalIgnoreCase);
+
+        // Snapshot the keys before mutating: only currently-loaded contexts whose id@version is no longer
+        // the active identity are eligible. Everything still active is left completely untouched.
+        var inactiveKeys = _contexts.Keys
+            .Where(key => !activeKeys.Contains(key))
+            .ToArray();
+
+        if (inactiveKeys.Length == 0)
+        {
+            return [];
+        }
+
+        var removedContexts = new List<AssemblyLoadContext>();
+        foreach (var key in inactiveKeys)
+        {
+            _sessions.TryRemove(key, out _);
+            ClearInert(key);
+            RemoveKeyFromLoadedGraphs(key);
+
+            if (_contexts.TryRemove(key, out var context))
+            {
+                removedContexts.Add(context);
+            }
+
+            if (TrySplitKey(key, out var packageId, out var version))
+            {
+                _hostIntegratedResolutionCatalog.RemovePackage(packageId, version);
+            }
+        }
+
+        // Only actually unloads a context once no *remaining* (still-active) key references it, so a graph
+        // context shared with a package that is still active is preserved. Non-collectible contexts are skipped.
+        UnloadUnreferencedContexts(removedContexts);
+
+        foreach (var key in inactiveKeys)
+        {
+            _logger.LogInformation("Unloaded package context {ContextKey} because it is no longer active.", key);
+        }
+
+        return inactiveKeys;
+    }
+
+    // Drops any cached loaded-graph entry that included this package key, so a later reactivation of the
+    // package rebuilds its graph from scratch instead of matching a now-partial cache entry.
+    private void RemoveKeyFromLoadedGraphs(string key)
+    {
+        foreach (var graphKey in _loadedGraphs
+            .Where(entry => entry.Value.LoadablePackageKeys.Contains(key, StringComparer.OrdinalIgnoreCase))
+            .Select(static entry => entry.Key)
+            .ToArray())
+        {
+            _loadedGraphs.TryRemove(graphKey, out _);
+        }
+    }
+
+    // Context keys are BuildKey output: "{packageId}@{version}". Package ids and semver versions never
+    // contain '@', so the first '@' is an unambiguous separator.
+    private static bool TrySplitKey(string key, out string packageId, out string version)
+    {
+        var separatorIndex = key.IndexOf('@');
+        if (separatorIndex <= 0 || separatorIndex >= key.Length - 1)
+        {
+            packageId = string.Empty;
+            version = string.Empty;
+            return false;
+        }
+
+        packageId = key[..separatorIndex];
+        version = key[(separatorIndex + 1)..];
+        return true;
+    }
+
+    /// <inheritdoc />
     public bool TryRemoveContext(string packageId, string version, out PackageLoadContextHandle? context)
     {
         var key = BuildKey(packageId, version);

--- a/test/Nuplane.Integration.Tests/Reconciliation/StartupLoadingEventIntegrationTests.cs
+++ b/test/Nuplane.Integration.Tests/Reconciliation/StartupLoadingEventIntegrationTests.cs
@@ -310,6 +310,21 @@ public sealed class StartupLoadingEventIntegrationTests
             return exists;
         }
 
+        public IReadOnlyList<string> UnloadContextsNotActive(IReadOnlyDictionary<string, string> activeVersionById)
+        {
+            var activeKeys = new HashSet<string>(
+                activeVersionById.Select(static entry => BuildKey(entry.Key, entry.Value)),
+                StringComparer.OrdinalIgnoreCase);
+
+            var inactive = _sessions.Keys.Where(key => !activeKeys.Contains(key)).ToArray();
+            foreach (var key in inactive)
+            {
+                _sessions.Remove(key);
+            }
+
+            return inactive;
+        }
+
         private static string BuildKey(string packageId, string version) => $"{packageId}@{version}";
 
         private static Dictionary<string, PackageLoadSession> CreateSessions(IEnumerable<ResolvedPackage>? packages)

--- a/test/Nuplane.Loading.Tests/PackageAutoLoadingObserverTests.cs
+++ b/test/Nuplane.Loading.Tests/PackageAutoLoadingObserverTests.cs
@@ -63,6 +63,73 @@ public sealed class PackageAutoLoadingObserverTests : IDisposable
     }
 
     [Fact]
+    public async Task RemovedPackage_UnloadsItsContext()
+    {
+        var oldPackage = new ResolvedPackage("pkg-old", "1.0.0", "feed", "/path-old", Now);
+        var newPackage = new ResolvedPackage("pkg-new", "1.0.0", "feed", "/path-new", Now);
+
+        // The loader already holds the old package's context from a previous cycle.
+        var loader = new FakePackageLoader(preloadedPackages: [oldPackage]);
+        var dispatcher = new FakeLoadingEventDispatcher();
+        // Authoritative post-reconcile active set contains only the new package.
+        var store = CreateStoreRegistry("graph-new", newPackage);
+        var sut = CreateObserver(loader, dispatcher, new() { Enabled = true }, storeRegistry: store);
+
+        var changeSet = new PackageChangeSet(
+            Added: [newPackage],
+            Updated: [],
+            Removed: ["pkg-old"],
+            CorrelationId: "corr-remove",
+            Timestamp: Now);
+
+        await sut.OnPackagesReconciledAsync(changeSet, [newPackage], CancellationToken.None);
+
+        Assert.Contains("pkg-old@1.0.0", loader.UnloadedKeys);
+        Assert.False(loader.TryGetContext("pkg-old", "1.0.0", out _));
+        Assert.True(loader.TryGetContext("pkg-new", "1.0.0", out _));
+    }
+
+    [Fact]
+    public async Task UpdatedPackage_UnloadsSupersededVersionContext()
+    {
+        var oldVersion = new ResolvedPackage("pkg", "1.0.0", "feed", "/path-1", Now);
+        var newVersion = new ResolvedPackage("pkg", "2.0.0", "feed", "/path-2", Now);
+
+        var loader = new FakePackageLoader(preloadedPackages: [oldVersion]);
+        var dispatcher = new FakeLoadingEventDispatcher();
+        var store = CreateStoreRegistry("graph", newVersion); // active is pkg@2.0.0
+        var sut = CreateObserver(loader, dispatcher, new() { Enabled = true }, storeRegistry: store);
+
+        var changeSet = new PackageChangeSet([], [newVersion], [], "corr-update", Now);
+
+        await sut.OnPackagesReconciledAsync(changeSet, [newVersion], CancellationToken.None);
+
+        Assert.Contains("pkg@1.0.0", loader.UnloadedKeys);
+        Assert.False(loader.TryGetContext("pkg", "1.0.0", out _));
+        Assert.True(loader.TryGetContext("pkg", "2.0.0", out _));
+    }
+
+    [Fact]
+    public async Task PureAdd_DoesNotRunUnloadPass()
+    {
+        var existing = new ResolvedPackage("pkg-existing", "1.0.0", "feed", "/path-e", Now);
+        var added = new ResolvedPackage("pkg-added", "1.0.0", "feed", "/path-a", Now);
+
+        var loader = new FakePackageLoader(preloadedPackages: [existing]);
+        var dispatcher = new FakeLoadingEventDispatcher();
+        var store = CreateStoreRegistry("graph", existing, added);
+        var sut = CreateObserver(loader, dispatcher, new() { Enabled = true }, storeRegistry: store);
+
+        // No Removed and no Updated — a pure add (and the common no-op poll) must not touch contexts.
+        var changeSet = new PackageChangeSet([added], [], [], "corr-add", Now);
+
+        await sut.OnPackagesReconciledAsync(changeSet, [existing, added], CancellationToken.None);
+
+        Assert.Empty(loader.UnloadedKeys);
+        Assert.True(loader.TryGetContext("pkg-existing", "1.0.0", out _));
+    }
+
+    [Fact]
     public async Task LoadingDisabled_PublishLoadedNotFired()
     {
         var loader = new FakePackageLoader();
@@ -489,6 +556,24 @@ public sealed class PackageAutoLoadingObserverTests : IDisposable
             var exists = _sessions.ContainsKey(key);
             context = exists ? new PackageLoadContextHandle(key, new()) : null;
             return exists;
+        }
+
+        public List<string> UnloadedKeys { get; } = [];
+
+        public IReadOnlyList<string> UnloadContextsNotActive(IReadOnlyDictionary<string, string> activeVersionById)
+        {
+            var activeKeys = new HashSet<string>(
+                activeVersionById.Select(static entry => BuildKey(entry.Key, entry.Value)),
+                StringComparer.OrdinalIgnoreCase);
+
+            var inactive = _sessions.Keys.Where(key => !activeKeys.Contains(key)).ToArray();
+            foreach (var key in inactive)
+            {
+                _sessions.Remove(key);
+            }
+
+            UnloadedKeys.AddRange(inactive);
+            return inactive;
         }
 
         private static string BuildKey(string packageId, string version) => $"{packageId}@{version}";


### PR DESCRIPTION
## Problem
`PackageAutoLoadingObserver` only ever *loads* packages: on reconcile it calls `EnsureGraphLoadedAsync` for the newly-applied set and does nothing with `changeSet.Removed` / superseded `changeSet.Updated`. The removed package's collectible `AssemblyLoadContext` therefore stays in `PackageLoader._contexts` (the only structure holding it) for the lifetime of the process, so a hot-swapped package's old assemblies can never be unloaded — a forced GC reclaims nothing because a live reference remains.

The unload machinery already exists but had **no runtime callers**: `PackageLoader.TryRemoveContext` and the whole `PackageUnloadCoordinator`.

## Fix
- **`PackageLoader.UnloadContextsNotActive(activeVersionById)`**: forgets and unloads every loaded context whose `id@version` is not in the authoritative active set. Reuses the existing `UnloadUnreferencedContexts` guard so a context shared across a graph is only unloaded once no still-active package references it, and non-collectible (host-integrated) contexts are never unloaded. Also drops the matching `_sessions`, inert marks, host-integrated resolution entries, and any now-partial `_loadedGraphs` cache entry.
- **`PackageAutoLoadingObserver`**: before loading the new set, when the cycle removed or updated anything, prune contexts against the post-reconcile store state (`ActiveVersionById`) — the authoritative "what should stay loaded", not the applied delta. Guarded so a no-op reconcile does no work, and skipped when the store is unavailable rather than risk unloading a still-active package.

The unload is cooperative: the CLR reclaims the context on the next GC once every remaining managed reference is released (e.g. a drained CShells shell generation's disposed provider — see the companion CShells PR).

## Tests
`PackageAutoLoadingObserverTests` gains removed-package, updated-supersede, and pure-add (no-op guard) cases.

## Verification
Verified end-to-end against `Elsa.Foundation.Host` (with the companion CShells fix): after a feed hot-swap the old package's collectible load context unloads — `/_module-management/assemblies` reports `collectible=1 lingering=0` — and 6 repeated swaps stay at `collectible=1 lingering=0` (no accumulation). Before: `collectible=2 lingering=1`, GC reclaimed nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)