### PR TITLE
Handle native-only NuGet support packages

### DIFF
--- a/src/Nuplane.Loading/PackageLoader.cs
+++ b/src/Nuplane.Loading/PackageLoader.cs
@@ -67,8 +67,7 @@ internal sealed class PackageLoader : IPackageLoader
         ArgumentException.ThrowIfNullOrWhiteSpace(installPath);
 
         var selection = ResolveAssemblySelection(installPath, packageId, hostTargetFrameworkOverride: null);
-        var assemblyPaths = Directory
-            .EnumerateFiles(selection.CandidateSearchRoot, "*.dll", SearchOption.AllDirectories)
+        var assemblyPaths = EnumerateAssemblyCandidatesExcludingNativeAssets(selection.CandidateSearchRoot, installPath)
             .OrderBy(path => path, StringComparer.OrdinalIgnoreCase)
             .ToArray();
 
@@ -736,7 +735,7 @@ internal sealed class PackageLoader : IPackageLoader
 
         var searchRoot = Directory.Exists(libPath) ? libPath : installPath;
         var mainAssemblyPath = ResolveAssemblyFromCandidates(
-            Directory.EnumerateFiles(searchRoot, "*.dll", SearchOption.AllDirectories),
+            EnumerateAssemblyCandidatesExcludingNativeAssets(searchRoot, installPath),
             installPath,
             packageId,
             selectedFramework: null);
@@ -780,7 +779,7 @@ internal sealed class PackageLoader : IPackageLoader
         }
 
         var mainAssemblyPath = ResolveAssemblyFromCandidates(
-            Directory.EnumerateFiles(selectedDirectory.Path, "*.dll", SearchOption.AllDirectories),
+            EnumerateAssemblyCandidatesExcludingNativeAssets(selectedDirectory.Path, installPath),
             installPath,
             packageId,
             selectedDirectory.FolderName);
@@ -823,6 +822,21 @@ internal sealed class PackageLoader : IPackageLoader
         throw new InvalidOperationException(
             $"Multiple assemblies were found under '{installPath}'{frameworkSuffix}, and a main assembly could not be determined for package '{packageId}'. " +
             "Ensure the package contains a single loadable assembly for the selected target framework or that one assembly name matches the package ID.");
+    }
+
+    private static IEnumerable<string> EnumerateAssemblyCandidatesExcludingNativeAssets(string searchRoot, string installPath) =>
+        Directory
+            .EnumerateFiles(searchRoot, "*.dll", SearchOption.AllDirectories)
+            .Where(path => !IsNativeRuntimeAsset(path, installPath));
+
+    private static bool IsNativeRuntimeAsset(string assemblyPath, string installPath)
+    {
+        var relativePath = Path.GetRelativePath(installPath, assemblyPath);
+        var segments = relativePath.Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+
+        return segments.Length >= 3
+            && string.Equals(segments[0], "runtimes", StringComparison.OrdinalIgnoreCase)
+            && string.Equals(segments[2], "native", StringComparison.OrdinalIgnoreCase);
     }
 
     private static FrameworkDirectory? SelectBestFrameworkDirectory(

--- a/test/Nuplane.Loading.Tests/PackageLoaderGraphRegressionTests.cs
+++ b/test/Nuplane.Loading.Tests/PackageLoaderGraphRegressionTests.cs
@@ -79,6 +79,28 @@ public sealed class PackageLoaderGraphRegressionTests : IDisposable
     }
 
     [Fact]
+    public async Task EnsureGraphLoadedAsync_NativeOnlyRidPackage_SkipsPackageWithoutFailure()
+    {
+        var rootInstall = CreatePackageInstall("Plugin.Root", "Plugin.Root.dll");
+        var nativeInstall = CreateNativeOnlyPackageInstall("Microsoft.Data.SqlClient.SNI.runtime");
+        var loader = new PackageLoader();
+
+        var result = await loader.EnsureGraphLoadedAsync(
+            [[
+                new ResolvedPackage("Plugin.Root", "1.0.0", "test-feed", rootInstall, DateTimeOffset.UtcNow, "test-source"),
+                new ResolvedPackage("Microsoft.Data.SqlClient.SNI.runtime", "6.0.2", "test-feed", nativeInstall, DateTimeOffset.UtcNow, "test-source")
+            ]],
+            [],
+            CancellationToken.None);
+
+        var loaded = Assert.Single(result.Loaded);
+        Assert.Equal("Plugin.Root", loaded.PackageId);
+        Assert.Empty(result.FailedByPackageId);
+        Assert.False(loader.TryGetContext("Microsoft.Data.SqlClient.SNI.runtime", "6.0.2", out _));
+        Assert.True(loader.IsInertPackage("Microsoft.Data.SqlClient.SNI.runtime", "6.0.2"));
+    }
+
+    [Fact]
     public void ResolveNativeLibraryPath_WithRuntimeNativeAsset_ResolvesPlatformSpecificName()
     {
         var nativePackageInstall = Path.Combine(_tempRoot, "SQLitePCLRaw.lib.e_sqlite3", "2.1.11");
@@ -372,6 +394,19 @@ public sealed class PackageLoaderGraphRegressionTests : IDisposable
         var libPath = Path.Combine(installPath, "lib", "netstandard2.0");
         Directory.CreateDirectory(libPath);
         File.WriteAllText(Path.Combine(libPath, "_._"), string.Empty);
+        return installPath;
+    }
+
+    private string CreateNativeOnlyPackageInstall(string packageId)
+    {
+        var installPath = Path.Combine(_tempRoot, packageId, "6.0.2");
+        foreach (var runtimeIdentifier in new[] { "win-arm64", "win-x64", "win-x86" })
+        {
+            var nativePath = Path.Combine(installPath, "runtimes", runtimeIdentifier, "native");
+            Directory.CreateDirectory(nativePath);
+            File.WriteAllText(Path.Combine(nativePath, "Microsoft.Data.SqlClient.SNI.dll"), "native asset");
+        }
+
         return installPath;
     }
 

--- a/test/Nuplane.Runtime.Tests/Feeds/PackageDependencyGraphResolverTests.cs
+++ b/test/Nuplane.Runtime.Tests/Feeds/PackageDependencyGraphResolverTests.cs
@@ -395,6 +395,44 @@ public sealed class PackageDependencyGraphResolverTests : IDisposable
     }
 
     [Fact]
+    public async Task ResolveAsync_NativeOnlyRidDependency_RemainsResolvedWithRuntimeAsset()
+    {
+        var root = CreateInstalledPackage(
+            "Plugin.Root",
+            "1.0.0",
+            dependencyId: "Microsoft.Data.SqlClient.SNI.runtime",
+            dependencyVersionRange: "[6.0.2]");
+        var nativeDependency = CreateInstalledPackage("Microsoft.Data.SqlClient.SNI.runtime", "6.0.2");
+        var nativeAssetPath = Path.Combine(
+            nativeDependency.InstallPath,
+            "runtimes",
+            "win-x64",
+            "native",
+            "Microsoft.Data.SqlClient.SNI.dll");
+        Directory.CreateDirectory(Path.GetDirectoryName(nativeAssetPath)!);
+        File.WriteAllText(nativeAssetPath, "native asset");
+
+        var resolver = new StubPackageResolver(
+            new Dictionary<string, ResolvedPackage>(StringComparer.OrdinalIgnoreCase)
+            {
+                [nativeDependency.Id] = nativeDependency
+            });
+        var sut = new PackageDependencyGraphResolver(resolver, new PassthroughRetryPolicy());
+
+        var result = await sut.ResolveAsync(
+            [new PackageRequest("Plugin.Root", "[1.0.0]", "test-feed", PackageUpdatePolicy.Exact, "test-source")],
+            (_, _) => Task.FromResult(root),
+            CancellationToken.None);
+
+        Assert.Contains(result.ResolvedPackages, package => package.Id == nativeDependency.Id);
+        var graph = Assert.Single(result.ResolvedGraphs);
+        var node = Assert.Single(graph.Nodes, package => package.PackageId == nativeDependency.Id);
+        Assert.Equal([Path.Combine("runtimes", "win-x64", "native", "Microsoft.Data.SqlClient.SNI.dll")], node.RuntimeAssets);
+        Assert.Equal(node.RuntimeAssets, node.SupportAssets);
+        Assert.Empty(node.DiscoverableAssets);
+    }
+
+    [Fact]
     public async Task ResolveAsync_WithDependencyCycle_ThrowsCycleDiagnostic()
     {
         var root = CreateInstalledPackage("Plugin.Root", "1.0.0", dependencyId: "Plugin.Dependency", dependencyVersionRange: "[1.0.0]");


### PR DESCRIPTION
## Outcome

Native-only NuGet support packages remain in the resolved dependency graph and asset catalog without being treated as managed Nuplane modules.

## Changes

- Exclude conventional `runtimes/<RID>/native` files from managed main-assembly discovery and scan candidates.
- Preserve deterministic ambiguity failures for actual managed package candidates.
- Cover SQL Client SNI-style Windows RID assets and prove they remain available as runtime/support assets.

## Validation

- Loading tests: 164 passed.
- Runtime tests: 463 passed.
- Full solution tests: 804 passed.
- Release build: zero warnings and errors.
- Independent focused regression tests passed after review.

Closes #68.

This unblocks the SQL Server durability validation in valence-works/elsa-production-image#26; that downstream issue still requires a Nuplane release and real image/database restart proof.
