### PR TITLE
Select compatible RID runtime assemblies

### DIFF
--- a/src/Nuplane.Loading/PackageLoader.cs
+++ b/src/Nuplane.Loading/PackageLoader.cs
@@ -702,9 +702,16 @@ internal sealed class PackageLoader : IPackageLoader
     {
         var relativePath = Path.GetRelativePath(installPath, assemblyPath);
         var segments = relativePath.Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-        if (segments.Length >= 3
-            && string.Equals(segments[0], "lib", StringComparison.OrdinalIgnoreCase)
-            && TryParseFrameworkTarget(segments[1], out var framework))
+
+        var frameworkFolder = segments.Length >= 2 && string.Equals(segments[0], "lib", StringComparison.OrdinalIgnoreCase)
+            ? segments[1]
+            : segments.Length >= 4
+                && string.Equals(segments[0], "runtimes", StringComparison.OrdinalIgnoreCase)
+                && string.Equals(segments[2], "lib", StringComparison.OrdinalIgnoreCase)
+                ? segments[3]
+                : null;
+
+        if (frameworkFolder is not null && TryParseFrameworkTarget(frameworkFolder, out var framework))
         {
             return framework.DisplayName;
         }

--- a/src/Nuplane.Loading/PackageLoader.cs
+++ b/src/Nuplane.Loading/PackageLoader.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Runtime.Loader;
 using System.Runtime.Versioning;
 using Microsoft.Extensions.Logging;
@@ -727,6 +728,11 @@ internal sealed class PackageLoader : IPackageLoader
             throw new DirectoryNotFoundException($"Install path '{installPath}' does not exist.");
         }
 
+        if (TryResolveRuntimeSpecificAssemblySelection(installPath, packageId, hostTargetFrameworkOverride, out var runtimeSpecificSelection))
+        {
+            return runtimeSpecificSelection;
+        }
+
         var libPath = Path.Combine(installPath, "lib");
         if (Directory.Exists(libPath) && TryResolveFrameworkSpecificAssemblySelection(libPath, installPath, packageId, hostTargetFrameworkOverride, out var frameworkSpecificSelection))
         {
@@ -743,6 +749,61 @@ internal sealed class PackageLoader : IPackageLoader
         return new AssemblyAssetSelection(mainAssemblyPath, searchRoot);
     }
 
+    private static bool TryResolveRuntimeSpecificAssemblySelection(
+        string installPath,
+        string packageId,
+        string? hostTargetFrameworkOverride,
+        out AssemblyAssetSelection selection)
+    {
+        var runtimesPath = Path.Combine(installPath, "runtimes");
+        if (!Directory.Exists(runtimesPath))
+        {
+            selection = null!;
+            return false;
+        }
+
+        var hostFramework = ResolveHostFramework(hostTargetFrameworkOverride);
+        if (hostFramework is null)
+        {
+            throw new InvalidOperationException(
+                $"Nuplane could not determine the current host target framework while resolving '{packageId}' from '{installPath}'.");
+        }
+
+        foreach (var runtimeIdentifier in PackageGraphLoadContext.ExpandRuntimeIdentifiers(RuntimeInformation.RuntimeIdentifier))
+        {
+            var libPath = Path.Combine(runtimesPath, runtimeIdentifier, "lib");
+            if (!Directory.Exists(libPath))
+            {
+                continue;
+            }
+
+            var frameworkDirectories = GetFrameworkDirectories(libPath);
+            var selectedDirectory = SelectBestFrameworkDirectory(hostFramework, frameworkDirectories);
+            if (selectedDirectory is null)
+            {
+                continue;
+            }
+
+            var candidatePaths = EnumerateAssemblyCandidatesExcludingNativeAssets(selectedDirectory.Path, installPath).ToArray();
+            if (candidatePaths.Length == 0)
+            {
+                continue;
+            }
+
+            var mainAssemblyPath = ResolveAssemblyFromCandidates(
+                candidatePaths,
+                installPath,
+                packageId,
+                selectedDirectory.FolderName);
+
+            selection = new AssemblyAssetSelection(mainAssemblyPath, selectedDirectory.Path);
+            return true;
+        }
+
+        selection = null!;
+        return false;
+    }
+
     private static bool TryResolveFrameworkSpecificAssemblySelection(
         string libPath,
         string installPath,
@@ -750,12 +811,7 @@ internal sealed class PackageLoader : IPackageLoader
         string? hostTargetFrameworkOverride,
         out AssemblyAssetSelection selection)
     {
-        var frameworkDirectories = Directory
-            .EnumerateDirectories(libPath)
-            .Select(FrameworkDirectory.Create)
-            .Where(candidate => candidate is not null)
-            .Cast<FrameworkDirectory>()
-            .ToArray();
+        var frameworkDirectories = GetFrameworkDirectories(libPath);
 
         if (frameworkDirectories.Length == 0)
         {
@@ -788,6 +844,13 @@ internal sealed class PackageLoader : IPackageLoader
 
         return true;
     }
+
+    private static FrameworkDirectory[] GetFrameworkDirectories(string libPath) => Directory
+        .EnumerateDirectories(libPath)
+        .Select(FrameworkDirectory.Create)
+        .Where(candidate => candidate is not null)
+        .Cast<FrameworkDirectory>()
+        .ToArray();
 
     private static string ResolveAssemblyFromCandidates(
         IEnumerable<string> candidatePaths,

--- a/test/Nuplane.Loading.Tests/PackageLoaderTests.cs
+++ b/test/Nuplane.Loading.Tests/PackageLoaderTests.cs
@@ -188,6 +188,27 @@ public sealed class PackageLoaderTests : IDisposable
         var candidates = new PackageLoader().BuildScanCandidates(packageId, installPath);
         var primary = Assert.Single(candidates);
         Assert.Equal(resolvedAssemblyPath, primary.AssemblyPath);
+        Assert.Equal("net9.0", primary.TargetFrameworkMoniker);
+    }
+
+    [Fact]
+    public void ResolveMainAssemblyPath_MultiTargetPackage_PrefersExactRidOverFallbackRid()
+    {
+        var packageId = "Nuplane.Loading.Tests.Fixtures";
+        var runtimeIdentifiers = PackageGraphLoadContext.ExpandRuntimeIdentifiers(RuntimeInformation.RuntimeIdentifier);
+        var exactRuntimeIdentifier = runtimeIdentifiers[0];
+        var fallbackRuntimeIdentifier = Assert.Single(runtimeIdentifiers.Skip(1).Take(1));
+        var installPath = CreateRuntimeMultiTargetInstallDir(
+            packageId,
+            [fallbackRuntimeIdentifier, exactRuntimeIdentifier],
+            "net9.0");
+
+        var resolvedAssemblyPath = GetResolvedAssemblyPath(installPath, packageId, "net10.0");
+
+        Assert.Contains(
+            $"{Path.DirectorySeparatorChar}runtimes{Path.DirectorySeparatorChar}{exactRuntimeIdentifier}{Path.DirectorySeparatorChar}lib{Path.DirectorySeparatorChar}net9.0{Path.DirectorySeparatorChar}",
+            resolvedAssemblyPath,
+            StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
@@ -225,6 +246,12 @@ public sealed class PackageLoaderTests : IDisposable
     }
 
     private string CreateRuntimeMultiTargetInstallDir(string packageId, string runtimeIdentifier, params string[] frameworks)
+        => CreateRuntimeMultiTargetInstallDir(packageId, [runtimeIdentifier], frameworks);
+
+    private string CreateRuntimeMultiTargetInstallDir(
+        string packageId,
+        IReadOnlyList<string> runtimeIdentifiers,
+        params string[] frameworks)
     {
         var packageDir = _tempDir.CreateSubdirectory(packageId);
         foreach (var framework in frameworks)
@@ -232,21 +259,27 @@ public sealed class PackageLoaderTests : IDisposable
             var compileDirectory = Directory.CreateDirectory(Path.Combine(packageDir.FullName, "lib", framework));
             CopyFixtureAssembly(compileDirectory.FullName, packageId);
 
-            var runtimeDirectory = Directory.CreateDirectory(Path.Combine(
+            foreach (var runtimeIdentifier in runtimeIdentifiers)
+            {
+                var runtimeDirectory = Directory.CreateDirectory(Path.Combine(
+                    packageDir.FullName,
+                    "runtimes",
+                    runtimeIdentifier,
+                    "lib",
+                    framework));
+                CopyFixtureAssembly(runtimeDirectory.FullName, packageId);
+            }
+        }
+
+        foreach (var runtimeIdentifier in runtimeIdentifiers)
+        {
+            var nativeDirectory = Directory.CreateDirectory(Path.Combine(
                 packageDir.FullName,
                 "runtimes",
                 runtimeIdentifier,
-                "lib",
-                framework));
-            CopyFixtureAssembly(runtimeDirectory.FullName, packageId);
+                "native"));
+            File.WriteAllText(Path.Combine(nativeDirectory.FullName, "native-support.dll"), "native asset");
         }
-
-        var nativeDirectory = Directory.CreateDirectory(Path.Combine(
-            packageDir.FullName,
-            "runtimes",
-            runtimeIdentifier,
-            "native"));
-        File.WriteAllText(Path.Combine(nativeDirectory.FullName, "native-support.dll"), "native asset");
 
         return packageDir.FullName;
     }

--- a/test/Nuplane.Loading.Tests/PackageLoaderTests.cs
+++ b/test/Nuplane.Loading.Tests/PackageLoaderTests.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using Nuplane.Abstractions;
 using Nuplane.Loading.Tests.Fixtures;
@@ -167,6 +168,29 @@ public sealed class PackageLoaderTests : IDisposable
     }
 
     [Fact]
+    public void ResolveMainAssemblyPath_MultiTargetPackage_PrefersNearestCompatibleRuntimeRidAssembly()
+    {
+        var packageId = "Nuplane.Loading.Tests.Fixtures";
+        var installPath = CreateRuntimeMultiTargetInstallDir(packageId, "unix", "net8.0", "net9.0");
+
+        Assert.Contains(
+            "unix",
+            PackageGraphLoadContext.ExpandRuntimeIdentifiers(RuntimeInformation.RuntimeIdentifier),
+            StringComparer.OrdinalIgnoreCase);
+
+        var resolvedAssemblyPath = GetResolvedAssemblyPath(installPath, packageId, "net10.0");
+
+        Assert.Contains(
+            $"{Path.DirectorySeparatorChar}runtimes{Path.DirectorySeparatorChar}unix{Path.DirectorySeparatorChar}lib{Path.DirectorySeparatorChar}net9.0{Path.DirectorySeparatorChar}",
+            resolvedAssemblyPath,
+            StringComparison.OrdinalIgnoreCase);
+
+        var candidates = new PackageLoader().BuildScanCandidates(packageId, installPath);
+        var primary = Assert.Single(candidates);
+        Assert.Equal(resolvedAssemblyPath, primary.AssemblyPath);
+    }
+
+    [Fact]
     public async Task EnsureLoadedAsync_MultiTargetPackage_WithOnlyHigherFrameworks_FailsClearly()
     {
         var installPath = CreateMultiTargetInstallDir("Nuplane.Loading.Tests.Fixtures", "net11.0");
@@ -196,6 +220,33 @@ public sealed class PackageLoaderTests : IDisposable
             var frameworkDir = Directory.CreateDirectory(Path.Combine(packageDir.FullName, "lib", framework));
             CopyFixtureAssembly(frameworkDir.FullName, packageId);
         }
+
+        return packageDir.FullName;
+    }
+
+    private string CreateRuntimeMultiTargetInstallDir(string packageId, string runtimeIdentifier, params string[] frameworks)
+    {
+        var packageDir = _tempDir.CreateSubdirectory(packageId);
+        foreach (var framework in frameworks)
+        {
+            var compileDirectory = Directory.CreateDirectory(Path.Combine(packageDir.FullName, "lib", framework));
+            CopyFixtureAssembly(compileDirectory.FullName, packageId);
+
+            var runtimeDirectory = Directory.CreateDirectory(Path.Combine(
+                packageDir.FullName,
+                "runtimes",
+                runtimeIdentifier,
+                "lib",
+                framework));
+            CopyFixtureAssembly(runtimeDirectory.FullName, packageId);
+        }
+
+        var nativeDirectory = Directory.CreateDirectory(Path.Combine(
+            packageDir.FullName,
+            "runtimes",
+            runtimeIdentifier,
+            "native"));
+        File.WriteAllText(Path.Combine(nativeDirectory.FullName, "native-support.dll"), "native asset");
 
         return packageDir.FullName;
     }


### PR DESCRIPTION
## Summary

- prefer `runtimes/<rid>/lib/<tfm>` managed assets using the host RID fallback graph
- choose the nearest compatible TFM, including net9 assets for a net10 host
- preserve native-only support-package exclusion and report selected runtime TFM metadata
- cover generic Unix fallback and exact-RID precedence

## Validation

- focused loader tests: 13 passed
- full `Nuplane.Loading.Tests`: 166 passed
- full solution: 806 passed
- multi-target build: clean

Issue #70 remains open until the merged preview package is consumed by `valence-works/elsa-production-image#26` and both linux/arm64 and linux/amd64 SQL profiles advance through `SqlConnection` construction.
